### PR TITLE
Removed Packable as a parent of StoreEntry

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -344,7 +344,7 @@ HttpRequest::swapOut(StoreEntry * e)
 {
     assert(e);
     e->buffer();
-    pack(e);
+    pack(e->packer());
     e->flush();
 }
 

--- a/src/SBufStatsAction.cc
+++ b/src/SBufStatsAction.cc
@@ -53,7 +53,7 @@ statHistSBufDumper(StoreEntry * sentry, int, double val, double size, int count)
 void
 SBufStatsAction::dump(StoreEntry* entry)
 {
-    PackableStream ses(*entry);
+    PackableStream ses(*entry->packer());
     ses << "\n\n\nThese statistics are experimental; their format and contents "
         "should not be relied upon, they are bound to change as "
         "the SBuf feature is evolved\n";

--- a/src/Store.h
+++ b/src/Store.h
@@ -61,7 +61,7 @@ public:
         assert (mem_obj);
         return mem_obj->endOffset() == 0;
     }
-    virtual bool isAccepting() const;
+    bool isAccepting() const;
     size_t bytesWanted(Range<size_t> const aRange, bool ignoreDelayPool = false) const;
     /// flags [truncated or too big] entry with ENTRY_BAD_LENGTH and releases it
     void lengthWentBad(const char *reason);
@@ -233,8 +233,8 @@ public:
 
     ESIElement::Pointer cachedESITree;
 #endif
-    virtual int64_t objectLen() const;
-    virtual int64_t contentLen() const;
+    int64_t objectLen() const;
+    int64_t contentLen() const;
 
     /// claim shared ownership of this entry (for use in a given context)
     /// matching lock() and unlock() contexts eases leak triage but is optional
@@ -254,8 +254,7 @@ public:
     /// Removes all unlocked (and marks for eventual removal all locked) Store
     /// entries, including attached and unattached entries that have our key.
     /// Also destroys us if we are unlocked or makes us private otherwise.
-    /// TODO: remove virtual.
-    virtual void release(const bool shareable = false);
+    void release(const bool shareable = false);
 
     /// One of the three methods to get rid of an unlocked StoreEntry object.
     /// May destroy this object if it is unlocked; does nothing otherwise.

--- a/src/Store.h
+++ b/src/Store.h
@@ -45,36 +45,36 @@ public:
     static DeferredRead::DeferrableRead DeferReader;
     bool checkDeferRead(int fd) const;
 
-    virtual const char *getMD5Text() const;
+    const char *getMD5Text() const;
     StoreEntry();
     virtual ~StoreEntry();
 
-    virtual HttpReply const *getReply() const;
-    virtual void write (StoreIOBuffer);
+    HttpReply const *getReply() const;
+    void write(StoreIOBuffer);
 
-    /** Check if the Store entry is emtpty
+    /** Check if the Store entry is empty
      * \retval true   Store contains 0 bytes of data.
      * \retval false  Store contains 1 or more bytes of data.
      * \retval false  Store contains negative content !!!!!!
      */
-    virtual bool isEmpty() const {
+    bool isEmpty() const {
         assert (mem_obj);
         return mem_obj->endOffset() == 0;
     }
     virtual bool isAccepting() const;
-    virtual size_t bytesWanted(Range<size_t> const aRange, bool ignoreDelayPool = false) const;
+    size_t bytesWanted(Range<size_t> const aRange, bool ignoreDelayPool = false) const;
     /// flags [truncated or too big] entry with ENTRY_BAD_LENGTH and releases it
     void lengthWentBad(const char *reason);
-    virtual void complete();
-    virtual store_client_t storeClientType() const;
-    virtual char const *getSerialisedMetaData();
+    void complete();
+    store_client_t storeClientType() const;
+    char const *getSerialisedMetaData();
     /// Store a prepared error response. MemObject locks the reply object.
     void storeErrorResponse(HttpReply *reply);
     void replaceHttpReply(HttpReply *, bool andStartWriting = true);
     void startWriting(); ///< pack and write reply headers and, maybe, body
     /// whether we may start writing to disk (now or in the future)
-    virtual bool mayStartSwapOut();
-    virtual void trimMemory(const bool preserveSwappable);
+    bool mayStartSwapOut();
+    void trimMemory(const bool preserveSwappable);
 
     // called when a decision to cache in memory has been made
     void memOutDecision(const bool willCacheInRam);
@@ -227,8 +227,6 @@ public:
     static void getPublicByRequest(StoreClient * aClient, HttpRequest * request);
     static void getPublic(StoreClient * aClient, const char *uri, const HttpRequestMethod& method);
 
-    virtual bool isNull() const { return false; } // TODO: Replace with nullptr.
-
     void *operator new(size_t byteCount);
     void operator delete(void *address);
 #if USE_SQUID_ESI
@@ -321,37 +319,6 @@ private:
 };
 
 std::ostream &operator <<(std::ostream &os, const StoreEntry &e);
-
-/// \ingroup StoreAPI
-class NullStoreEntry:public StoreEntry
-{
-
-public:
-    static NullStoreEntry *getInstance();
-
-    const char *getMD5Text() const;
-    HttpReply const *getReply() const { return NULL; }
-    void write (StoreIOBuffer) {}
-
-    bool isEmpty () const {return true;}
-
-    /* StoreEntry API */
-    virtual bool isNull() const { return true; }
-    virtual size_t bytesWanted(Range<size_t> const aRange, bool) const { return aRange.end; }
-
-    void operator delete(void *address);
-    void complete() {}
-
-private:
-    store_client_t storeClientType() const {return STORE_MEM_CLIENT;}
-
-    char const *getSerialisedMetaData();
-    virtual bool mayStartSwapOut() { return false; }
-
-    void trimMemory(const bool) {}
-
-    static NullStoreEntry _instance;
-};
 
 /// \ingroup StoreAPI
 typedef void (*STOREGETCLIENT) (StoreEntry *, void *cbdata);

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -29,7 +29,7 @@ public:
     // TODO: Remove? Probably added to make lookups asynchronous, but they are
     // still blocking. A lot more is needed to support async callbacks.
     /// Handle a StoreEntry::getPublic*() result.
-    /// An isNull() entry indicates a cache miss.
+    /// A nil entry indicates a cache miss.
     virtual void created(StoreEntry *) = 0;
 
     /// \return LogTags (if the class logs transactions) or nil (otherwise)

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -145,7 +145,7 @@ static void
 authenticateBasicStats(StoreEntry * sentry)
 {
     if (basicauthenticators)
-        basicauthenticators->packStatsInto(sentry, "Basic Authenticator Statistics");
+        basicauthenticators->packStatsInto(sentry->packer(), "Basic Authenticator Statistics");
 }
 
 char *

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -631,7 +631,7 @@ static void
 authenticateDigestStats(StoreEntry * sentry)
 {
     if (digestauthenticators)
-        digestauthenticators->packStatsInto(sentry, "Digest Authenticator Statistics");
+        digestauthenticators->packStatsInto(sentry->packer(), "Digest Authenticator Statistics");
 }
 
 /* NonceUserUnlink: remove the reference to auth_user and unlink the node from the list */

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -206,7 +206,7 @@ static void
 authenticateNegotiateStats(StoreEntry * sentry)
 {
     if (negotiateauthenticators)
-        negotiateauthenticators->packStatsInto(sentry, "Negotiate Authenticator Statistics");
+        negotiateauthenticators->packStatsInto(sentry->packer(), "Negotiate Authenticator Statistics");
 }
 
 /*

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -197,7 +197,7 @@ static void
 authenticateNTLMStats(StoreEntry * sentry)
 {
     if (ntlmauthenticators)
-        ntlmauthenticators->packStatsInto(sentry, "NTLM Authenticator Statistics");
+        ntlmauthenticators->packStatsInto(sentry->packer(), "NTLM Authenticator Statistics");
 }
 
 /*

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2388,7 +2388,7 @@ dump_cachemgrpasswd(StoreEntry * entry, const char *name, Mgr::ActionPasswordLis
             storeAppendPrintf(entry, "%s %s", name, list->passwd);
 
         for (auto w : list->actions)
-            entry->appendf(" " SQUIDSBUFPH, SQUIDSBUFPRINT(w));
+            entry->packer()->appendf(" " SQUIDSBUFPH, SQUIDSBUFPRINT(w));
 
         storeAppendPrintf(entry, "\n");
         list = list->next;
@@ -3934,7 +3934,7 @@ dump_generic_port(StoreEntry * e, const char *n, const AnyP::PortCfgPointer &s)
         storeAppendPrintf(e, " ssl-bump");
 #endif
 
-    s->secure.dumpCfg(e, "tls-");
+    s->secure.dumpCfg(e->packer(), "tls-");
 }
 
 static void

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1696,7 +1696,7 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry)
 {
     HttpRequest *r = http->request;
     http->storeEntry(newEntry);
-    StoreEntry *e = http->storeEntry();
+    const auto e = http->storeEntry();
 
     /* Release IP-cache entries on reload */
     /** \li If the request has no-cache flag set or some no_cache HACK in operation we

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1093,7 +1093,7 @@ externalAclStats(StoreEntry * sentry)
         storeAppendPrintf(sentry, "External ACL Statistics: %s\n", p->name);
         storeAppendPrintf(sentry, "Cache size: %d\n", p->cache->count);
         assert(p->theHelper);
-        p->theHelper->packStatsInto(sentry);
+        p->theHelper->packStatsInto(sentry->packer());
         storeAppendPrintf(sentry, "\n");
     }
 }

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -919,14 +919,14 @@ htcpSpecifier::checkHit()
 
     if (!checkHitRequest) {
         debugs(31, 3, "htcpCheckHit: NO; failed to parse URL");
-        checkedHit(NullStoreEntry::getInstance());
+        checkedHit(nullptr);
         return;
     }
 
     if (!checkHitRequest->header.parse(req_hdrs, reqHdrsSz)) {
         debugs(31, 3, "htcpCheckHit: NO; failed to parse request headers");
         checkHitRequest = nullptr;
-        checkedHit(NullStoreEntry::getInstance());
+        checkedHit(nullptr);
         return;
     }
 
@@ -938,7 +938,7 @@ htcpSpecifier::created(StoreEntry *e)
 {
     StoreEntry *hit = nullptr;
 
-    if (!e || e->isNull()) {
+    if (!e) {
         debugs(31, 3, "htcpCheckHit: NO; public object not found");
     } else if (!e->validToSend()) {
         debugs(31, 3, "htcpCheckHit: NO; entry not valid to send" );

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -954,7 +954,7 @@ htcpSpecifier::created(StoreEntry *e)
     checkedHit(hit);
 
     // TODO: StoreClients must either store/lock or abandon found entries.
-    //if (!e->isNull())
+    //if (e)
     //    e->abandon();
 }
 

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -156,9 +156,6 @@ ICPState::~ICPState()
 bool
 ICPState::confirmAndPrepHit(const StoreEntry &e)
 {
-    if (e.isNull())
-        return false;
-
     if (!e.validToSend())
         return false;
 
@@ -217,7 +214,7 @@ ICP2State::created(StoreEntry *e)
     debugs(12, 5, "icpHandleIcpV2: OPCODE " << icp_opcode_str[header.opcode]);
     icp_opcode codeToSend;
 
-    if (confirmAndPrepHit(*e)) {
+    if (e && confirmAndPrepHit(*e)) {
         codeToSend = ICP_HIT;
     } else {
 #if USE_ICMP

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -235,7 +235,7 @@ ICP2State::created(StoreEntry *e)
     icpCreateAndSend(codeToSend, flags, url, header.reqnum, src_rtt, fd, from, al);
 
     // TODO: StoreClients must either store/lock or abandon found entries.
-    //if (!e->isNull())
+    //if (e)
     //    e->abandon();
 
     delete this;

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -76,7 +76,7 @@ ICP3State::created(StoreEntry *e)
     icpCreateAndSend(codeToSend, 0, url, header.reqnum, 0, fd, from, al);
 
     // TODO: StoreClients must either store/lock or abandon found entries.
-    //if (!e->isNull())
+    //if (e)
     //    e->abandon();
 
     delete this;

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -165,7 +165,7 @@ memBufStats(std::ostream & stream)
 void
 Mem::Stats(StoreEntry * sentry)
 {
-    PackableStream stream(*sentry);
+    PackableStream stream(*sentry->packer());
     Report(stream);
     memStringStats(stream);
     memBufStats(stream);

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -363,7 +363,7 @@ void
 MimeIcon::created(StoreEntry *newEntry)
 {
     /* if the icon is already in the store, do nothing */
-    if (!newEntry->isNull())
+    if (newEntry)
         return;
     // XXX: if a 204 is cached due to earlier load 'failure' we should try to reload.
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1611,7 +1611,7 @@ dump_peer_options(StoreEntry * sentry, CachePeer * p)
     else if (p->connection_auth == 2)
         storeAppendPrintf(sentry, " connection-auth=auto");
 
-    p->secure.dumpCfg(sentry,"tls-");
+    p->secure.dumpCfg(sentry->packer(),"tls-");
     storeAppendPrintf(sentry, "\n");
 }
 

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -200,7 +200,7 @@ redirectStats(StoreEntry * sentry)
         return;
     }
 
-    redirectors->packStatsInto(sentry, "Redirector Statistics");
+    redirectors->packStatsInto(sentry->packer(), "Redirector Statistics");
 
     if (Config.onoff.redirector_bypass)
         storeAppendPrintf(sentry, "\nNumber of requests bypassed "
@@ -215,7 +215,7 @@ storeIdStats(StoreEntry * sentry)
         return;
     }
 
-    storeIds->packStatsInto(sentry, "StoreId helper Statistics");
+    storeIds->packStatsInto(sentry->packer(), "StoreId helper Statistics");
 
     if (Config.onoff.store_id_bypass)
         storeAppendPrintf(sentry, "\nNumber of requests bypassed "

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -133,7 +133,7 @@ extern PeerOptions ProxyOutgoingConfig;
 // parse the tls_outgoing_options directive
 void parse_securePeerOptions(Security::PeerOptions *);
 #define free_securePeerOptions(x) Security::ProxyOutgoingConfig.clear()
-#define dump_securePeerOptions(e,n,x) do { (e)->appendf(n); (x).dumpCfg((e),""); (e)->append("\n",1); } while(false)
+#define dump_securePeerOptions(e,n,x) do { (e)->packer()->appendf(n); (x).dumpCfg((e)->packer(),""); (e)->packer()->append("\n",1); } while(false)
 
 #endif /* SQUID_SRC_SECURITY_PEEROPTIONS_H */
 

--- a/src/ssl/context_storage.cc
+++ b/src/ssl/context_storage.cc
@@ -29,7 +29,7 @@ Ssl::CertificateStorageAction::Create(const Mgr::Command::Pointer &aCmd)
 
 void Ssl::CertificateStorageAction::dump (StoreEntry *sentry)
 {
-    PackableStream stream(*sentry);
+    PackableStream stream(*sentry->packer());
     const char delimiter = '\t';
     const char endString = '\n';
     // Page title.

--- a/src/store.cc
+++ b/src/store.cc
@@ -393,9 +393,6 @@ destroyStoreEntry(void *data)
     StoreEntry *e = static_cast<StoreEntry *>(static_cast<hash_link *>(data));
     assert(e != NULL);
 
-    if (e == NullStoreEntry::getInstance())
-        return;
-
     // Store::Root() is FATALly missing during shutdown
     if (e->hasDisk() && !shutting_down)
         e->disk().disconnect(*e);
@@ -498,36 +495,21 @@ void
 StoreEntry::getPublicByRequestMethod  (StoreClient *aClient, HttpRequest * request, const HttpRequestMethod& method)
 {
     assert (aClient);
-    StoreEntry *result = storeGetPublicByRequestMethod( request, method);
-
-    if (!result)
-        aClient->created (NullStoreEntry::getInstance());
-    else
-        aClient->created (result);
+    aClient->created(storeGetPublicByRequestMethod(request, method));
 }
 
 void
 StoreEntry::getPublicByRequest (StoreClient *aClient, HttpRequest * request)
 {
     assert (aClient);
-    StoreEntry *result = storeGetPublicByRequest (request);
-
-    if (!result)
-        result = NullStoreEntry::getInstance();
-
-    aClient->created (result);
+    aClient->created(storeGetPublicByRequest(request));
 }
 
 void
 StoreEntry::getPublic (StoreClient *aClient, const char *uri, const HttpRequestMethod& method)
 {
     assert (aClient);
-    StoreEntry *result = storeGetPublic (uri, method);
-
-    if (!result)
-        result = NullStoreEntry::getInstance();
-
-    aClient->created (result);
+    aClient->created(storeGetPublic(uri, method));
 }
 
 StoreEntry *
@@ -2166,34 +2148,6 @@ std::ostream &operator <<(std::ostream &os, const StoreEntry &e)
     }
 
     return os << '/' << &e << '*' << e.locks();
-}
-
-/* NullStoreEntry */
-
-NullStoreEntry NullStoreEntry::_instance;
-
-NullStoreEntry *
-NullStoreEntry::getInstance()
-{
-    return &_instance;
-}
-
-char const *
-NullStoreEntry::getMD5Text() const
-{
-    return "N/A";
-}
-
-void
-NullStoreEntry::operator delete(void*)
-{
-    fatal ("Attempt to delete NullStoreEntry\n");
-}
-
-char const *
-NullStoreEntry::getSerialisedMetaData()
-{
-    return NULL;
 }
 
 void

--- a/src/tests/CapturingStoreEntry.h
+++ b/src/tests/CapturingStoreEntry.h
@@ -23,20 +23,55 @@ public:
     String _appended_text;
     int _buffer_calls;
     int _flush_calls;
+};
 
-    virtual void buffer() {
-        _buffer_calls += 1;
+class CapturingStoreEntryPacker : public Packable
+{
+public:
+    CapturingStoreEntryPacker(CapturingStoreEntry &e) : entry(&e) {}
+
+    virtual void append(char const *buf, int len) override {
+         if (!buf || len < 0) // old 'String' can't handle these cases
+             return;
+         entry->_appended_text.append(buf, len);
     }
+    virtual void buffer() override { entry->_buffer_calls++; }
+    virtual void flush() override { entry->_flush_calls++; }
+    // TODO: fix duplication with StoreEntry::vappendf()
+    virtual void vappendf(const char *fmt, va_list vargs) override
+    {
+        LOCAL_ARRAY(char, buf, 4096);
+        *buf = 0;
+        int x;
 
-    virtual void flush() {
-        _flush_calls += 1;
-    }
-
-    virtual void append(char const * buf, int len) {
-        if (!buf || len < 0) // old 'String' can't handle these cases
+        va_list ap;
+        /* Fix of bug 753r. The value of vargs is undefined
+         * after vsnprintf() returns. Make a copy of vargs
+         * incase we loop around and call vsnprintf() again.
+         */
+        va_copy(ap,vargs);
+        errno = 0;
+        if ((x = vsnprintf(buf, sizeof(buf), fmt, ap)) < 0) {
+            fatal(xstrerr(errno));
             return;
-        _appended_text.append(buf, len);
+        }
+        va_end(ap);
+
+        if (x < static_cast<int>(sizeof(buf))) {
+            append(buf, x);
+            return;
+        }
+
+        // okay, do it the slow way.
+        char *buf2 = new char[x+1];
+        int y = vsnprintf(buf2, x+1, fmt, vargs);
+        assert(y >= 0 && y == x);
+        append(buf2, y);
+        delete[] buf2;
     }
+
+private:
+    CapturingStoreEntry *entry;
 };
 
 #endif

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -97,12 +97,6 @@ void StoreEntry::append(char const *, int) STUB
 void StoreEntry::vappendf(const char *, va_list) STUB
 void StoreEntry::setCollapsingRequirement(const bool required) STUB
 
-NullStoreEntry *NullStoreEntry::getInstance() STUB_RETVAL(NULL)
-const char *NullStoreEntry::getMD5Text() const STUB_RETVAL(NULL)
-void NullStoreEntry::operator delete(void *address) STUB
-// private virtual. Why is this linked from outside?
-const char *NullStoreEntry::getSerialisedMetaData() STUB_RETVAL(NULL)
-
 Store::Controller &Store::Root() STUB_RETREF(Store::Controller)
 void Store::Init(Store::Controller *root) STUB
 void Store::FreeMemory() STUB

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -75,6 +75,7 @@ testEvent::testDump()
     CalledEvent event;
     CalledEvent event2;
     CapturingStoreEntry * anEntry = new CapturingStoreEntry();
+    anEntry->packer(new CapturingStoreEntryPacker(*anEntry));
     String expect =  "Last event to run: last event\n"
                      "\n"
                      "Operation                \tNext Execution \tWeight\tCallback Valid?\n"

--- a/src/tests/testPackableStream.cc
+++ b/src/tests/testPackableStream.cc
@@ -34,9 +34,10 @@ testPackableStream::testGetStream()
     Store::Init();
 
     CapturingStoreEntry * anEntry = new CapturingStoreEntry();
+    anEntry->packer(new CapturingStoreEntryPacker(*anEntry));
     {
         anEntry->lock("test");
-        PackableStream stream(*anEntry);
+        PackableStream stream(*anEntry->packer());
         CPPUNIT_ASSERT_EQUAL(1, anEntry->_buffer_calls);
         CPPUNIT_ASSERT_EQUAL(0, anEntry->_flush_calls);
 

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -203,7 +203,7 @@ testRock::addEntry(const int i)
     StoreEntry *const pe = createEntry(i);
 
     pe->buffer();
-    pe->getReply()->packHeadersInto(pe);
+    pe->getReply()->packHeadersInto(pe->packer());
     pe->flush();
     pe->timestampsSet();
     pe->complete();

--- a/src/tests/testStore.cc
+++ b/src/tests/testStore.cc
@@ -108,7 +108,8 @@ testStore::testStats()
     TestStore *aStore(new TestStore);
     Store::Init(aStore);
     CPPUNIT_ASSERT_EQUAL(false, aStore->statsCalled);
-    Store::Stats(NullStoreEntry::getInstance());
+    StoreEntry entry;
+    Store::Stats(&entry);
     CPPUNIT_ASSERT_EQUAL(true, aStore->statsCalled);
     Store::FreeMemory();
 }

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -152,7 +152,7 @@ testUfs::testUfsSearch()
         pe->setPublicKey();
 
         pe->buffer();
-        pe->getReply()->packHeadersInto(pe);
+        pe->getReply()->packHeadersInto(pe->packer());
         pe->flush();
         pe->timestampsSet();
         pe->complete();

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -204,7 +204,7 @@ UrnState::created(StoreEntry *e)
         sc = storeClientListAdd(urlres_e, this);
         FwdState::Start(Comm::ConnectionPointer(), urlres_e, urlres_r.getRaw(), ale);
         // TODO: StoreClients must either store/lock or abandon found entries.
-        //if (!e->isNull())
+        //if (e)
         //    e->abandon();
     } else {
         urlres_e = e;

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -199,7 +199,7 @@ UrnState::fillChecklist(ACLFilledChecklist &checklist) const
 void
 UrnState::created(StoreEntry *e)
 {
-    if (e->isNull() || (e->hittingRequiresCollapsing() && !startCollapsingOn(*e, false))) {
+    if (!e || (e->hittingRequiresCollapsing() && !startCollapsingOn(*e, false))) {
         urlres_e = storeCreateEntry(urlres, urlres, RequestFlags(), Http::METHOD_GET);
         sc = storeClientListAdd(urlres_e, this);
         FwdState::Start(Comm::ConnectionPointer(), urlres_e, urlres_r.getRaw(), ale);


### PR DESCRIPTION
The purpose is to get rid of StoreEntry virtual table thus
optimizing virtual call expenses in most cases.