### PR TITLE
Rock: allow read while writing

### DIFF
--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -119,6 +119,7 @@ public:
         /// Decision states for StoreEntry::swapoutPossible() and related code.
         typedef enum { swNeedsCheck = 0, swImpossible = -1, swPossible = +1, swStarted } Decision;
         Decision decision = swNeedsCheck; ///< current decision state
+        bool ioPending = false; ///< prevents reentrant swapout operations
     };
 
     SwapOut swapout;

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -646,8 +646,7 @@ MemStore::startCaching(StoreEntry &e)
     slot->set(e);
     // Do not allow others to feed off an unknown-size entry because we will
     // stop swapping it out if it grows too large.
-    if (e.mem_obj->expectedReplySize() >= 0)
-        map->startAppending(index);
+    map->tryAppending(index, e);
     e.memOutDecision(true);
     return true;
 }

--- a/src/StoreIOState.h
+++ b/src/StoreIOState.h
@@ -80,6 +80,9 @@ public:
     // * header updates that create a fresh chain (while keeping the stale one usable).
     bool touchingStoreEntry() const;
 
+    /// whether there is some data available for read_()
+    virtual bool hasMoreData(const off_t) const = 0;
+
     sdirno swap_dirn;
     sfileno swap_filen;
     StoreEntry *e;      /* Need this so the FS layers can play god */

--- a/src/fs/rock/RockIoState.h
+++ b/src/fs/rock/RockIoState.h
@@ -37,6 +37,7 @@ public:
     virtual void read_(char *buf, size_t size, off_t offset, STRCB * callback, void *callback_data);
     virtual bool write(char const *buf, size_t size, off_t offset, FREE * free_func);
     virtual void close(int how);
+    virtual bool hasMoreData(const off_t) const;
 
     /// whether we are still waiting for the I/O results (i.e., not closed)
     bool stillWaiting() const { return theFile != NULL; }
@@ -67,6 +68,7 @@ private:
     void writeToDisk(const SlotId nextSlot);
     void writeBufToDisk(const SlotId nextSlot, const bool eof, const bool lastWrite);
     SlotId reserveSlotForWriting();
+    void advanceSid(const off_t coreOff, SlotId &readableSlot, int64_t &slotOffset) const;
 
     void callBack(int errflag);
 

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -50,7 +50,7 @@ public:
     virtual void create();
     virtual void parse(int index, char *path);
     virtual bool smpAware() const { return true; }
-    virtual bool hasReadableEntry(const StoreEntry &) const;
+    virtual bool hasReadableEntry(const StoreEntry &, bool *isEmpty = nullptr) const;
 
     // temporary path to the shared memory map of first slots of cached entries
     SBuf inodeMapPath() const;

--- a/src/fs/ufs/UFSStoreState.h
+++ b/src/fs/ufs/UFSStoreState.h
@@ -32,6 +32,7 @@ public:
     virtual void ioCompletedNotification();
     virtual void readCompleted(const char *buf, int len, int errflag, RefCount<ReadRequest>);
     virtual void writeCompleted(int errflag, size_t len, RefCount<WriteRequest>);
+    virtual bool hasMoreData(const off_t) const { return false; }
     RefCount<DiskFile> theFile;
     bool opening;
     bool creating;

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -75,7 +75,7 @@ public:
     virtual bool smpAware() const override { return false; }
     /// as long as ufs relies on the global store_table to index entries,
     /// it is wrong to ask individual ufs cache_dirs whether they have an entry
-    virtual bool hasReadableEntry(const StoreEntry &) const override { return false; }
+    virtual bool hasReadableEntry(const StoreEntry &, bool *isEmpty = nullptr) const override { return false; }
 
     void unlinkFile(sfileno f);
     // move down when unlink is a virtual method

--- a/src/store.cc
+++ b/src/store.cc
@@ -300,9 +300,11 @@ StoreEntry::storeClientType() const
 
     /* here and past, entry is STORE_PENDING */
     /*
-     * If this is the first client, let it be the mem client
+     * If this is the first client, let it be the mem client.
+     * This check covers SMP cases as well (for SMP the first client
+     * should be transients writer).
      */
-    if (mem_obj->nclients == 1)
+    if (mem_obj->nclients == 1 && !Store::Root().transientsReader(*this))
         return STORE_MEM_CLIENT;
 
     /*

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -316,9 +316,9 @@ Store::Controller::markedForDeletionAndAbandoned(const StoreEntry &e) const
 }
 
 bool
-Store::Controller::hasReadableDiskEntry(const StoreEntry &e) const
+Store::Controller::hasReadableDiskEntry(const StoreEntry &e, bool *isEmpty) const
 {
-    return swapDir->hasReadableEntry(e);
+    return swapDir->hasReadableEntry(e, isEmpty);
 }
 
 StoreEntry *

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -68,7 +68,7 @@ public:
     bool markedForDeletionAndAbandoned(const StoreEntry &) const;
 
     /// whether there is a disk entry with e.key
-    bool hasReadableDiskEntry(const StoreEntry &) const;
+    bool hasReadableDiskEntry(const StoreEntry &, bool *isEmpty = nullptr) const;
 
     /// Additional unknown-size entry bytes required by Store in order to
     /// reduce the risk of selecting the wrong disk cache for the growing entry.

--- a/src/store/Disk.h
+++ b/src/store/Disk.h
@@ -76,7 +76,8 @@ public:
     virtual void finalizeSwapoutFailure(StoreEntry &) = 0;
 
     /// whether this cache dir has an entry with `e.key`
-    virtual bool hasReadableEntry(const StoreEntry &e) const = 0;
+    /// \param isEmpty if provided, whether this entry still lacks data
+    virtual bool hasReadableEntry(const StoreEntry &e, bool *isEmpty = nullptr) const = 0;
 
 protected:
     void parseOptions(int reconfiguring);

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -558,10 +558,10 @@ Store::Disks::SmpAware()
 }
 
 bool
-Store::Disks::hasReadableEntry(const StoreEntry &e) const
+Store::Disks::hasReadableEntry(const StoreEntry &e, bool *isEmpty) const
 {
     for (int i = 0; i < Config.cacheSwap.n_configured; ++i)
-        if (Dir(i).active() && Dir(i).hasReadableEntry(e))
+        if (Dir(i).active() && Dir(i).hasReadableEntry(e, isEmpty))
             return true;
     return false;
 }

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -51,7 +51,7 @@ public:
     /// whether any disk cache is SMP-aware
     static bool SmpAware();
     /// whether any of disk caches has entry with e.key
-    bool hasReadableEntry(const StoreEntry &) const;
+    bool hasReadableEntry(const StoreEntry &, bool *isEmpty = nullptr) const;
 
 private:
     /* migration logic */

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -199,7 +199,7 @@ store_client::store_client(StoreEntry *e) :
     owner(cbdataReference(data)),
 #endif
     entry(e),
-    type(e->storeClientType()),
+    type(e->storeClientType()), // XXX: do not use storeClientType() before MemObject::addClient()
     object_ok(true)
 {
     flags.disk_io_pending = false;
@@ -375,7 +375,20 @@ store_client::doCopy(StoreEntry *anEntry)
     }
 
     /* Check that we actually have data */
-    if (anEntry->store_status == STORE_PENDING && copyInto.offset >= mem->endOffset()) {
+
+    const int clientType = getType();
+
+    bool waitingForMore = anEntry->store_status == STORE_PENDING && copyInto.offset >= mem->endOffset();
+
+    if (waitingForMore && clientType == STORE_DISK_CLIENT) {
+        bool isEmpty = false;
+        if (!swapin_sio)
+            waitingForMore = Store::Root().hasReadableDiskEntry(*anEntry, &isEmpty) && isEmpty;
+        else
+            waitingForMore = !swapin_sio->hasMoreData(copyInto.offset + mem->swap_hdr_sz);
+    }
+
+    if (waitingForMore) {
         debugs(90, 3, "store_client::doCopy: Waiting for more");
         flags.store_copying = false;
         return;
@@ -393,7 +406,7 @@ store_client::doCopy(StoreEntry *anEntry)
      * if needed.
      */
 
-    if (STORE_DISK_CLIENT == getType() && swapin_sio == NULL) {
+    if (clientType == STORE_DISK_CLIENT && swapin_sio == nullptr) {
         if (!startSwapin())
             return; // failure
     }
@@ -405,6 +418,8 @@ bool
 store_client::startSwapin()
 {
     debugs(90, 3, "store_client::doCopy: Need to open swap in file");
+    assert(entry->hasDisk());
+
     /* gotta open the swapin file */
 
     if (storeTooManyDiskFilesOpen()) {
@@ -456,9 +471,14 @@ store_client::scheduleDiskRead()
 
     assert(!flags.disk_io_pending);
 
-    debugs(90, 3, "reading " << *entry << " from disk");
-
-    fileRead();
+    MemObject *mem = entry->mem_obj;
+    assert(swapin_sio);
+    if (swapin_sio->hasMoreData(copyInto.offset + mem->swap_hdr_sz)) {
+        debugs(90, 3, "reading " << *entry << " from disk");
+        fileRead();
+    } else {
+        debugs(33, 3, "waiting for more disk data");
+    }
 
     flags.store_copying = false;
 }
@@ -484,7 +504,7 @@ store_client::fileRead()
     flags.disk_io_pending = true;
 
     if (mem->swap_hdr_sz != 0)
-        if (entry->swappingOut())
+        if (entry->swappingOut() && mem->swapout.sio)
             assert(mem->swapout.sio->offset() > copyInto.offset + (int64_t)mem->swap_hdr_sz);
 
     storeRead(swapin_sio,

--- a/src/tests/TestSwapDir.h
+++ b/src/tests/TestSwapDir.h
@@ -35,7 +35,7 @@ public:
     virtual void parse(int, char*) override;
     virtual void evictCached(StoreEntry &) override {}
     virtual void evictIfFound(const cache_key *) override {}
-    virtual bool hasReadableEntry(const StoreEntry &) const override { return false; }
+    virtual bool hasReadableEntry(const StoreEntry &, bool *isEmpty = nullptr) const override { return false; }
     virtual bool smpAware() const override { return false; }
 };
 


### PR DESCRIPTION
Before this fix, SMP Squid with disk-only shared cache (rock) did
not allow to acquire a being written(swapping out) entry, due to the
exclusive write lock for the entry. This problem did not only
affect shared disk cache clients, but local clients also
(i.e., clients hitting the Squid worker, performing swapout)
Such clients got swapin errors and were re-tried, because the disk
entry was still locked for writing.

This patch makes use of the existing 'appending' mechanism for Rock
cache (which shared memory cache utilizes already). With this
approach, the entry is locked for writing during a short time, i.e.,
while the entry metadata being written.

Note that this solution has a limitation: reading clients can't get
immediately all being swapped out data. This limitation exists because
the swapping out client fragments the data before storing them on disk:
* doPages() by 4096 bytes blocks (a page)
* Rock::IoState::tryWrite() by slotSize (16384 bytes/4 pages)

Also: fixed an assertion in Rock::SwapDir::openStoreIO(), stated that
the StoreEntry and disk entry keys were equal. This is wrong for
attached to disk cache StoreEntries, which become private just before
swapin starts.

Also: do not allow reentrant runs StoreEntry::swapout()/doPages(),
(rock code structures do not allow this). Use a new
MemObject::SwapOut::ioPending for this protection. There is already
a similar store_client::flags.disk_io_pending flag preventing
concurrent reads for the same store client. With this patch,
the situation with reentrant swapout() calls can happen after
Rock::SwapDir::writeCompleted() calls StoreEntry::invokeHandlers().
I did not check whether there are other existing ways for swapout()
reentrancy.