### PR TITLE
Fixed incremental parsing of large chunked quoted extensions

### DIFF
--- a/src/http/one/TeChunkedParser.cc
+++ b/src/http/one/TeChunkedParser.cc
@@ -139,13 +139,8 @@ Http::One::TeChunkedParser::parseChunkExtension(Http1::Tokenizer &tok, bool skip
             debugs(94, 5, "skipping unknown chunk extension " << ext);
 
             // unknown might have a value token or quoted-string
-            if (tok.quotedStringOrToken(value) && !tok.atEnd()) {
-                buf_ = tok.remaining(); // parse checkpoint
-                continue;
-            }
-
-            // otherwise need more data OR corrupt syntax
-            break;
+            if (!tok.quotedStringOrToken(value))
+                return false; // needs more data
         }
 
         if (!tok.atEnd())

--- a/src/http/one/Tokenizer.cc
+++ b/src/http/one/Tokenizer.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "Debug.h"
 #include "http/one/Tokenizer.h"
+#include "sbuf/Stream.h"
 
 bool
 Http::One::Tokenizer::quotedString(SBuf &returnedToken, const bool http1p0)
@@ -24,11 +25,11 @@ Http::One::Tokenizer::quotedString(SBuf &returnedToken, const bool http1p0)
 bool
 Http::One::Tokenizer::quotedStringOrToken(SBuf &returnedToken, const bool http1p0)
 {
-    checkpoint();
-
-    if (!skip('"'))
-        return prefix(returnedToken, CharacterSet::TCHAR);
-
+    if (!skip('"')) {
+        if (prefix(returnedToken, CharacterSet::TCHAR))
+            return true;
+        throw TexcHere("invalid token");
+    }
     return qdText(returnedToken, http1p0);
 }
 
@@ -80,8 +81,7 @@ Http::One::Tokenizer::qdText(SBuf &returnedToken, const bool http1p0)
             SBuf escaped;
             if (!prefix(escaped, qPairChars, 1)) {
                 returnedToken.clear();
-                restoreLastCheckpoint();
-                return false;
+                throw TexcHere("invalid escaped characters");
             }
             returnedToken.append(escaped);
             continue;
@@ -92,15 +92,12 @@ Http::One::Tokenizer::qdText(SBuf &returnedToken, const bool http1p0)
         } else if (atEnd()) {
             // need more data
             returnedToken.clear();
-            restoreLastCheckpoint();
             return false;
         }
 
         // else, we have an error
-        debugs(24, 8, "invalid bytes for set " << tokenChars.name);
         returnedToken.clear();
-        restoreLastCheckpoint();
-        return false;
+        throw TexcHere(ToSBuf("invalid bytes for set ", tokenChars.name));
     }
 
     // found the whole string

--- a/src/http/one/Tokenizer.h
+++ b/src/http/one/Tokenizer.h
@@ -54,15 +54,18 @@ public:
      *
      * \param escaped HTTP/1.0 does not permit \-escaped characters
      */
+    // TODO: unused
     bool quotedString(SBuf &value, const bool http1p0 = false);
 
-    /**
-     * Attempt to parse a (token / quoted-string ) lexical construct.
-     */
+    /// Attempts to parse a (token / quoted-string ) lexical construct.
+    /// throws if case of invalid input characters
+    /// \returns true on success
+    /// \returns false on incomplete quoted string (more data is needed)
     bool quotedStringOrToken(SBuf &value, const bool http1p0 = false);
 
 private:
     /// parse the internal component of a quote-string, and terminal DQUOTE
+    /// throws if invalid characters were detected
     bool qdText(SBuf &value, const bool http1p0);
 
     void checkpoint() { savedCheckpoint_ = buf(); savedStats_ = parsedSize(); }


### PR DESCRIPTION
Before this change, Http::One::Parser::skipLineTerminator() unexpectedly
threw during parsing a long quoted chunk extension value, exceeding the
current buffer size. In this case, the Tokenizer improperly restored its
buffer with restoreLastCheckpoint(). As a result, this buffer contained
the beginning of the unparsed extension value. Consequently, here is
another problem (hidden by the first one) with
Http::One::TeChunkedParser::parseChunkExtension(), which expects both
extension name and value for the next round incremental parsing.

I assume these problems was caused by
Http::One::Tokenizer::qdText() inability to distinguish two cases
(returning false for both):

* the end of quoted string not yet reached

* an input error, e.g., wrong/unexpected character

I separated these two situations, throwing in (2). Similar throwing
approach is already used in skipLineTerminator().

Also removed checkpoints setting/restoring in while parsing quoted
strings(as unnecessary overhead).