### PR TITLE
Bug 4894: -k restart shuts the instance down instead

### DIFF
--- a/include/hash.h
+++ b/include/hash.h
@@ -44,7 +44,7 @@ SQUIDCEXTERN void hashFreeMemory(hash_table *);
 SQUIDCEXTERN void hashFreeItems(hash_table *, HASHFREE *);
 SQUIDCEXTERN HASHHASH hash_string;
 SQUIDCEXTERN HASHHASH hash4;
-SQUIDCEXTERN const char *hashKeyStr(hash_link *);
+SQUIDCEXTERN const char *hashKeyStr(const hash_link *);
 
 /*
  *  Here are some good prime number choices.  It's important not to

--- a/lib/hash.cc
+++ b/lib/hash.cc
@@ -314,7 +314,7 @@ hashPrime(int n)
  * return the key of a hash_link as a const string
  */
 const char *
-hashKeyStr(hash_link * hl)
+hashKeyStr(const hash_link * hl)
 {
     return (const char *) hl->key;
 }

--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -120,7 +120,7 @@ AccessLogEntry::~AccessLogEntry()
 const SBuf *
 AccessLogEntry::effectiveVirginUrl() const
 {
-    const SBuf *effectiveUrl = request ? &request->url.absolute() : &virginUrlForMissingRequest_;
+    const SBuf *effectiveUrl = request ? &request->effectiveRequestUri() : &virginUrlForMissingRequest_;
     if (effectiveUrl && !effectiveUrl->isEmpty())
         return effectiveUrl;
     // We can not use ALE::url here because it may contain a request URI after

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -109,7 +109,7 @@ ACLFilledChecklist::verifyAle() const
             showDebugWarning("URL");
             // XXX: al->url should be the request URL from client,
             // but request->url may be different (e.g.,redirected)
-            al->url = request->url.absolute();
+            al->url = request->effectiveRequestUri();
         }
     }
 

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1199,7 +1199,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
                 ConnStateData *conn = al->request->clientConnectionManager.get();
                 if (conn && Comm::IsConnOpen(conn->clientConnection)) {
                     if (auto ssl = fd_table[conn->clientConnection->fd].ssl.get())
-                        out = sslGetUserAttribute(ssl, format->data.header.header);
+                        out = sslGetUserAttribute(ssl, fmt->data.header.header);
                 }
             }
             break;
@@ -1209,7 +1209,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
                 ConnStateData *conn = al->request->clientConnectionManager.get();
                 if (conn && Comm::IsConnOpen(conn->clientConnection)) {
                     if (auto ssl = fd_table[conn->clientConnection->fd].ssl.get())
-                        out = sslGetCAAttribute(ssl, format->data.header.header);
+                        out = sslGetCAAttribute(ssl, fmt->data.header.header);
                 }
             }
             break;

--- a/src/globals.h
+++ b/src/globals.h
@@ -63,6 +63,7 @@ extern IoStats IOStats;
 extern struct timeval squid_start;
 extern int starting_up; /* 1 */
 extern int shutting_down;   /* 0 */
+extern int restarting_kids;   /* 0 */
 extern int reconfiguring;   /* 0 */
 extern time_t hit_only_mode_until;  /* 0 */
 extern double request_failure_ratio;    /* 0.0 */


### PR DESCRIPTION
"-k restart" uses SIGTTIN.  Before this fix, Squid interpreted SIGTTIN
sent to the master process as a shutdown signal (except the process exit
status).

With fix applied:

* If squid instance has multiple kids, the master process
  restarts them, including all hopeless kids.  This covers all daemon
  Squid installations and foreground mode (--foreground option).

* If Squid instance is a single process the command kills Squid
  instance. This covers non-Daemon mode (-N option).