### PR TITLE
Fixed disker-to-worker queue overflows

### DIFF
--- a/src/ipc/Queue.cc
+++ b/src/ipc/Queue.cc
@@ -196,6 +196,18 @@ Ipc::BaseMultiQueue::remoteReader(const int remoteProcessId)
     return const_cast<QueueReader &>(reader);
 }
 
+bool
+Ipc::BaseMultiQueue::outFull() const {
+    int popProcessId = theLastPopProcessId;
+    for (int i = 0; i < remotesCount(); ++i) {
+        if (++popProcessId >= remotesIdOffset() + remotesCount())
+            popProcessId = remotesIdOffset();
+        if (outQueue(popProcessId).full())
+            return true;
+    }
+    return false;
+}
+
 // FewToFewBiQueue
 
 Ipc::FewToFewBiQueue::Owner *

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -185,6 +185,10 @@ public:
     /// number of items in outgoing queue to a given remote process
     int outSize(const int remoteProcessId) const { return outQueue(remoteProcessId).size(); }
 
+    /// Whether an outgoing queue is full. The remote process ID for this queue
+    /// corresponds to the process which incoming queue is likely to be popped next.
+    bool outFull() const;
+
 protected:
     /// incoming queue from a given remote process
     virtual const OneToOneUniQueue &inQueue(const int remoteProcessId) const = 0;


### PR DESCRIPTION
Before this fix, Squid sometimes logged the following error:

  BUG: Worker I/O pop queue overflow

The bug could be triggered when a worker queued N new requests for a
disker, which had been still processing its previous request. As a
result, the disker's outgoing queue got N+1 responses and overflowed
(N is the max queue capacity). With fix applied, disker checks whether
its outgoing queue has free space before popping a pending request. To
make this solution work, I fixed the worker to send notification each
time it pops a disker response (so that the disker could continue
in case it got stuck on its full outgoing queue).