### PR TITLE
Initial SO_REUSEPORT support implementation

### DIFF
--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -39,6 +39,7 @@ AnyP::PortCfg::PortCfg() :
     ftp_track_dirs(false),
     vport(0),
     disable_pmtu_discovery(0),
+    workerQueues(false),
     listenConn()
 #if USE_OPENSSL
     ,
@@ -89,6 +90,7 @@ AnyP::PortCfg::clone() const
     b->vhost = vhost;
     b->vport = vport;
     b->connection_auth_disabled = connection_auth_disabled;
+    b->workerQueues = workerQueues;
     b->ftp_track_dirs = ftp_track_dirs;
     b->disable_pmtu_discovery = disable_pmtu_discovery;
     b->tcp_keepalive = tcp_keepalive;

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -54,6 +54,7 @@ public:
 
     int vport;               ///< virtual port support. -1 if dynamic, >0 static
     int disable_pmtu_discovery;
+    bool workerQueues; ///< whether worker-specific listening queues are enabled
 
     struct {
         unsigned int idle;

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3670,6 +3670,8 @@ parse_port_option(AnyP::PortCfgPointer &s, char *token)
         s->secure.parse(token+4);
     } else if (strcmp(token, "ftp-track-dirs") == 0) {
         s->ftp_track_dirs = true;
+    } else if (strcmp(token, "worker-queues") == 0) {
+        s->workerQueues = true;
     } else {
         debugs(3, DBG_CRITICAL, "FATAL: Unknown " << cfg_directive << " option '" << token << "'.");
         self_destruct();

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2137,6 +2137,10 @@ DOC_START
 			The proxy_protocol_access is required to whitelist
 			downstream proxies which can be trusted.
 
+	   worker-queues
+			Whether the listening port may be shared among
+			several workers.
+
 	If you run Squid on a dual-homed machine with an internal
 	and an external interface we recommend you to specify the
 	internal address:port in http_port. This way Squid will only be

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3526,7 +3526,8 @@ clientHttpConnectionsOpen(void)
         s->listenConn->local = s->s;
 
         s->listenConn->flags = COMM_NONBLOCKING | (s->flags.tproxyIntercept ? COMM_TRANSPARENT : 0) |
-                               (s->flags.natIntercept ? COMM_INTERCEPTION : 0);
+                               (s->flags.natIntercept ? COMM_INTERCEPTION : 0) |
+                               (s->workerQueues ? COMM_REUSEPORT : 0);
 
         typedef CommCbFunPtrCallT<CommAcceptCbPtrFun> AcceptCall;
         if (s->transport.protocol == AnyP::PROTO_HTTP) {

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -32,6 +32,7 @@
 #include "pconn.h"
 #include "profiler/Profiler.h"
 #include "sbuf/SBuf.h"
+#include "sbuf/Stream.h"
 #include "SquidConfig.h"
 #include "StatCounters.h"
 #include "StoreIOBuffer.h"
@@ -475,7 +476,18 @@ comm_apply_flags(int new_socket,
             debugs(5, DBG_IMPORTANT,"WARNING: Squid is attempting to bind() port " << addr << " without being a listener.");
         if ( addr.isNoAddr() )
             debugs(5,0,"CRITICAL: Squid is attempting to bind() port " << addr << "!!");
-
+        if (flags & COMM_REUSEPORT) {
+            int on = 1;
+            if (setsockopt(new_socket, SOL_SOCKET, SO_REUSEPORT, (char *) &on, sizeof(on)) < 0) {
+                const int savedErrno = errno;
+                const auto errorMessage = ToSBuf("cannot enable SO_REUSEPORT socket option when binding to ",
+                                                 addr, ": ", xstrerr(savedErrno));
+                if (reconfiguring)
+                    debugs(5, DBG_IMPORTANT, errorMessage);
+                else
+                    throw TextException(errorMessage);
+            }
+        }
         if (commBind(new_socket, *AI) != Comm::OK) {
             comm_close(new_socket);
             return -1;

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -47,6 +47,7 @@ namespace Comm
 #define COMM_DOBIND             0x08  // requires a bind()
 #define COMM_TRANSPARENT        0x10  // arrived via TPROXY
 #define COMM_INTERCEPTION       0x20  // arrived via NAT
+#define COMM_REUSEPORT          0x40
 
 /**
  * Store data about the physical and logical attributes of a connection.

--- a/src/ipc/StartListening.cc
+++ b/src/ipc/StartListening.cc
@@ -39,7 +39,8 @@ Ipc::StartListening(int sock_type, int proto, const Comm::ConnectionPointer &lis
     Must(cbd);
     cbd->conn = listenConn;
 
-    if (UsingSmp()) { // if SMP is on, share
+    if ((listenConn->flags & COMM_REUSEPORT) && UsingSmp()) {
+        // ask Coordinator for the listening socket; all askers share the queue
         OpenListenerParams p;
         p.sock_type = sock_type;
         p.proto = proto;


### PR DESCRIPTION
This feature allows sharing the same listening port among several
workers. It is controlled by a new 'worker-queues' configuration flag
for *_port option.