### PR TITLE
Bug 4796: comm.cc !isOpen(conn->fd) assertion when rotating logs

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -591,13 +591,6 @@ parseConfigFileOrThrow(const char *file_name)
      */
     configDoConfigure();
 
-    if (!Config.chroot_dir) {
-        leave_suid();
-        setUmask(Config.umask);
-        _db_init(Debug::cache_log, Debug::debugOptions);
-        enter_suid();
-    }
-
     if (opt_send_signal == -1) {
         Mgr::RegisterAction("config",
                             "Current Squid Configuration",

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1210,7 +1210,7 @@ commSetTcpKeepalive(int fd, int idle, int interval, int timeout)
 void
 comm_init(void)
 {
-    fd_table =(fde *) xcalloc(Squid_MaxFD, sizeof(fde));
+    assert(fd_table);
 
     /* make sure the accept() socket FIFO delay queue exists */
     Comm::AcceptLimiter::Instance();
@@ -1235,8 +1235,6 @@ comm_exit(void)
 {
     delete TheHalfClosed;
     TheHalfClosed = NULL;
-
-    safe_free(fd_table);
     Comm::CallbackTableDestruct();
 }
 

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1235,6 +1235,7 @@ comm_exit(void)
 {
     delete TheHalfClosed;
     TheHalfClosed = NULL;
+
     Comm::CallbackTableDestruct();
 }
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "Debug.h"
+#include "fd.h"
 #include "ipc/Kids.h"
 #include "SquidTime.h"
 #include "util.h"
@@ -96,9 +97,14 @@ DebugFile::reset(FILE *newFile, const char *newName)
     // callers must use nullptr instead of the used-as-the-last-resort stderr
     assert(newFile != stderr || !stderr);
 
-    if (file_)
+    if (file_) {
+        fd_close(fileno(file_));
         fclose(file_);
+    }
     file_ = newFile; // may be nil
+
+    if (file_)
+        fd_open(fileno(file_), FD_LOG, Debug::cache_log);
 
     xfree(name);
     name = newName ? xstrdup(newName) : nullptr;

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -81,8 +81,11 @@ fdUpdateBiggest(int fd, int opening)
 void
 fd_close(int fd)
 {
-    fde *F = &fd_table[fd];
+    // have nothing to do if called from an exit() callback
+    if (!fd_table)
+        return;
 
+    fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open);
 

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -81,10 +81,6 @@ fdUpdateBiggest(int fd, int opening)
 void
 fd_close(int fd)
 {
-    // have nothing to do if called from an exit() callback
-    if (!fd_table)
-        return;
-
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open);

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -82,6 +82,7 @@ void
 fd_close(int fd)
 {
     fde *F = &fd_table[fd];
+
     assert(fd >= 0);
     assert(F->flags.open);
 

--- a/src/fde.cc
+++ b/src/fde.cc
@@ -97,7 +97,7 @@ fde::remoteAddr() const
 }
 
 void
-fde::CreateTable()
+fde::Init()
 {
     assert(!Table);
     Table = static_cast<fde *>(xcalloc(Squid_MaxFD, sizeof(fde)));

--- a/src/fde.cc
+++ b/src/fde.cc
@@ -96,3 +96,10 @@ fde::remoteAddr() const
     return buf;
 }
 
+void
+fde::CreateTable()
+{
+    assert(!Table);
+    Table = static_cast<fde *>(xcalloc(Squid_MaxFD, sizeof(fde)));
+}
+

--- a/src/fde.h
+++ b/src/fde.h
@@ -51,7 +51,7 @@ class fde
 
 public:
 
-    static void CreateTable() { assert(!Table); Table = static_cast<fde *>(xcalloc(Squid_MaxFD, sizeof(fde))); }
+    static void CreateTable();
 
     fde() {
         *ipaddr = 0;

--- a/src/fde.h
+++ b/src/fde.h
@@ -50,6 +50,9 @@ class fde
 {
 
 public:
+
+    static void CreateTable() { assert(!Table); Table = static_cast<fde *>(xcalloc(Squid_MaxFD, sizeof(fde))); }
+
     fde() {
         *ipaddr = 0;
         *desc = 0;
@@ -58,8 +61,6 @@ public:
         read_method = nullptr;
         write_method = nullptr;
     }
-
-    static void CreateTable() { assert(!Table); Table = static_cast<fde *>(xcalloc(Squid_MaxFD, sizeof(fde))); }
 
     /// Clear the fde class back to NULL equivalent.
     void clear() { *this = fde(); }

--- a/src/fde.h
+++ b/src/fde.h
@@ -59,6 +59,8 @@ public:
         write_method = nullptr;
     }
 
+    static void CreateTable() { assert(!Table); Table = static_cast<fde *>(xcalloc(Squid_MaxFD, sizeof(fde))); }
+
     /// Clear the fde class back to NULL equivalent.
     void clear() { *this = fde(); }
 

--- a/src/fde.h
+++ b/src/fde.h
@@ -51,7 +51,7 @@ class fde
 
 public:
 
-    static void CreateTable();
+    static void Init();
 
     fde() {
         *ipaddr = 0;

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -40,6 +40,7 @@ COPIED_SOURCE= \
 	globals.cc \
 	SquidConfig.cc \
 	SquidNew.cc \
+	stub_fd.cc \
 	stub_HelperChildConfig.cc \
 	stub_libmem.cc \
 	stub_SBuf.cc \
@@ -100,6 +101,9 @@ SquidNew.cc: $(top_srcdir)/src/SquidNew.cc
 
 stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc
 	cp $(top_srcdir)/src/tests/stub_HelperChildConfig.cc $@
+
+stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc STUB.h
+	cp $(top_srcdir)/src/tests/stub_fd.cc $@
 
 stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc STUB.h
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@

--- a/src/main.cc
+++ b/src/main.cc
@@ -1467,6 +1467,8 @@ StartUsingConfig()
     } else if (Config.chroot_dir) {
         RunConfigUsers();
         enter_suid();
+        // TODO: don't we need to RunConfigUsers() in the configured
+        // chroot environment?
         mainSetCwd();
         leave_suid();
         ConfigureDebugging();
@@ -1474,6 +1476,8 @@ StartUsingConfig()
         ConfigureDebugging();
         RunConfigUsers();
         enter_suid();
+        // TODO: since RunConfigUsers() may use a relative path, we
+        // need to change the process root first
         mainSetCwd();
         leave_suid();
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -1146,10 +1146,6 @@ mainInitialize(void)
     if (icpPortNumOverride != 1)
         Config.Port.icp = (unsigned short) icpPortNumOverride;
 
-    // Do not register cache.log descriptor with Comm (for now).
-    // See https://bugs.squid-cache.org/show_bug.cgi?id=4796
-    // fd_open(fileno(debug_log), FD_LOG, Debug::cache_log);
-
     debugs(1, DBG_CRITICAL, "Starting Squid Cache version " << version_string << " for " << CONFIG_HOST_TYPE << "...");
     debugs(1, DBG_CRITICAL, "Service Name: " << service_name);
 
@@ -1460,6 +1456,7 @@ static void
 CleanupFdTable()
 {
     safe_free(fd_table);
+    fd_table = nullptr;
 }
 
 static void StartUsingConfig()
@@ -2160,13 +2157,13 @@ SquidShutdown()
 
     comm_exit();
 
-    CleanupFdTable();
-
     RunRegisteredHere(RegisteredRunner::finishShutdown);
 
     memClean();
 
     debugs(1, DBG_IMPORTANT, "Squid Cache (Version " << version_string << "): Exiting normally.");
+
+    CleanupFdTable();
 
     /*
      * DPW 2006-10-23

--- a/src/main.cc
+++ b/src/main.cc
@@ -1448,7 +1448,6 @@ StartUsingFdTable()
     // we should not create cache.log outside chroot environment, if any
     if (!Config.chroot_dir || Chrooted)
         _db_init(Debug::cache_log, Debug::debugOptions);
-
 }
 
 static void

--- a/src/main.cc
+++ b/src/main.cc
@@ -1434,11 +1434,12 @@ ConfigureCurrentKid(const CommandLine &cmdLine)
     }
 }
 
+/// Start directing debugs() messages to the configured cache.log.
+/// Until this function is called, all allowed messages go to stderr.
 static void
 ConfigureDebugging()
 {
     if (opt_no_daemon) {
-        /* we have to init fdstat here. */
         fd_open(0, FD_LOG, "stdin");
         fd_open(1, FD_LOG, "stdout");
         fd_open(2, FD_LOG, "stderr");
@@ -1459,8 +1460,8 @@ static void
 StartUsingConfig()
 {
     setMaxFD();
-    fde::CreateTable();
-    const bool skipCwdAdjusting = IamMasterProcess() && InDaemonMode();
+    fde::Init();
+    const auto skipCwdAdjusting = IamMasterProcess() && InDaemonMode();
     if (skipCwdAdjusting) {
         ConfigureDebugging();
         RunConfigUsers();

--- a/src/main.cc
+++ b/src/main.cc
@@ -1438,7 +1438,7 @@ static void
 StartUsingFdTable()
 {
     setMaxFD();
-    fd_table = static_cast<fde *>(xcalloc(Squid_MaxFD, sizeof(fde)));
+    fde::CreateTable();
     if (opt_no_daemon) {
         /* we have to init fdstat here. */
         fd_open(0, FD_LOG, "stdin");

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -143,7 +143,7 @@ testRock::commonInit()
 
     Mem::Init();
 
-    fde::CreateTable();
+    fde::Init();
 
     comm_init();
 

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "ConfigParser.h"
 #include "DiskIO/DiskIOModule.h"
+#include "fde.h"
 #include "fs/rock/RockSwapDir.h"
 #include "globals.h"
 #include "HttpHeader.h"
@@ -141,6 +142,8 @@ testRock::commonInit()
     visible_appname_string = xstrdup(APP_FULLNAME);
 
     Mem::Init();
+
+    fde::CreateTable();
 
     comm_init();
 

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -8,6 +8,7 @@
 
 #include "squid.h"
 #include "DiskIO/DiskIOModule.h"
+#include "fde.h"
 #include "fs/ufs/UFSSwapDir.h"
 #include "globals.h"
 #include "HttpHeader.h"
@@ -71,6 +72,8 @@ testUfs::commonInit()
     storeReplAdd("lru", createRemovalPolicy_lru);
 
     Mem::Init();
+
+    fde::CreateTable();
 
     comm_init();
 

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -73,7 +73,7 @@ testUfs::commonInit()
 
     Mem::Init();
 
-    fde::CreateTable();
+    fde::Init();
 
     comm_init();
 


### PR DESCRIPTION
This is a long-term solution (overriding the short-term solution at
2cd72a2). Now, we manage fd_table descriptors meta information directly
within debug.cc.

While fixing this bug, I had to resolve dependencies in main.cc between
_db_init(), setMaxFD(), and comm_init(). When fixing this, I noticed
that the two old _db_init() calls were misplaced:

* The first call happens too early, allowing another Squid instance to
  pollute cache.log with messages, unrelated to this instance. For
  example, it logged  "FATAL: Squid is already running" message when
  attempting to start the second Squid instance.

* The second call happens too late, since there are some earlier
  debugs(), expected to be written into cache.log (e.g., debugs() in
  comm_init()).

Also, call _db_init() twice looks wrong.

To address these problems, I had to move _db_init() into a new place. I
believe that the correct place is just after locking the PID file since
cache.log is a common resource requiring protection. This change led to
some other adjustments, like moving mainSetCwd() into a new place (prior
to _db_init()). However, these additional changes should not affect
chroot-sensitive code such as UseConfigRunners().

With this patch applied, some early debugs() messages are not written
into cache.log anymore:

* Exception messages like "Squid is already running" from another Squid
  instance. This is an improvement: Messages about other Squid instances
  do not belong to the running instance log.

* Messages(mostly error/warning messages) from "finalizeConfig" callers,
  for example, "WARNING: mem-cache size is too small..." for the shared
  memory finalizer. This loss is regrettable. Long-term, these messages
  should be reported after configuration is finalized (TODO). Delayed
  reporting will help when we start rejecting invalid reconfigurations.

* Messages from a few early enter_suid()/leave_suid() calls, such as
  "enter_suid: PID" and "leave_suid: PID". This is an improvement: These
  debugging messages should not be printed by default.

* A few early messages in SquidMain() between parseConfigFile() and
  StartUsingConfig(), e.g., "Doing post-config initialization". This is
  an improvement: These debugging messages should not be printed by
  default.

Also removed outdated 'TEST_ACCESS' hack for simplicity sake.
