### PR TITLE
SQUID-441: Cannot remove XAU and XFF from Connect request

### DIFF
--- a/doc/release-notes/release-5.sgml
+++ b/doc/release-notes/release-5.sgml
@@ -85,8 +85,8 @@ Most user-facing changes are reflected in squid.conf (see below).
    previous destination have been received and tried.
 
 <p>The Cache Manager <em>mgr:ipcache</em> report no longer contains
-   <q>IPcache Entries In Use</q> but that info is now available as
-   <q>cbdata ipcache_entry</q> row on the <em>mgr:mem</em> page.
+   "IPcache Entries In Use" but that info is now available as
+   "cbdata ipcache_entry" row on the <em>mgr:mem</em> page.
 
 
 <sect1>Kerberos Group Helper
@@ -199,7 +199,7 @@ This section gives a thorough account of those changes in three categories:
 	<p>Replaced by <em>mark_client_packet</em>.
 
 	<tag>dns_v4_first</tag>
-	<p>Removed. The new <q>Happy Eyeballs</q> algorithm uses received IP
+	<p>Removed. The new "Happy Eyeballs" algorithm uses received IP
 	   addresses as soon as they are needed.
 	<p>Firewall rules prohibiting IPv6 TCP connections remain the preferred
 	   configuration method for 'disabling' IPv6 connectivity, with DNS

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -21,6 +21,7 @@
 
 class ErrorState;
 class AccessLogEntry;
+class HttpHeader;
 typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
 
 namespace Http
@@ -83,6 +84,7 @@ protected:
     void watchForClosures();
     void handleException(const std::exception&);
     void startReadingResponse();
+    void buildHttpHeaders(HttpHeader &hdr_out);
     void writeRequest();
     void handleWrittenRequest(const CommIoCbParams&);
     void handleReadyRead(const CommIoCbParams&);


### PR DESCRIPTION
When Http::Tunneler is used with stare/peek/server-first bumping modes then
it is actually forwards a CONNECT request to the upstream proxy.
When the client-first (bump on step1) bumping mode is used, the squid
forwarding code actually receives a "GET https://..." request to forward.
The Http::Tunneler uses this GET request in acl checks while building
the outgoing HttpHeaders, causes acl mismatch for example when the
"method" acl is used.

This patch builds and uses a new HttpRequest object based on CONNECT method
to use with these acl checks.