### PR TITLE
GCC-8 support for v3.5

### DIFF
--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -50,6 +50,7 @@ libcompat_squid_la_SOURCES = \
 	statvfs.h \
 	statvfs.cc \
 	stdio.h \
+	stdio.cc \
 	stdvarargs.h \
 	strnstr.cc \
 	strtoll.h \

--- a/compat/stdio.cc
+++ b/compat/stdio.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 1996-2019 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+int snprintfXXX(char *str, size_t size, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    const auto result = snprintf(str, size, fmt, args);
+    va_end(args);
+    return result;
+}
+

--- a/compat/stdio.h
+++ b/compat/stdio.h
@@ -63,7 +63,7 @@ inline FILE * tmpfile(void) { return tmpfile64(); }
 #endif
 
 // circumvents GCC 'format-truncation' warning, introduced since v7.1
-#define snprintfXXX(...) (snprintf(__VA_ARGS__) < 0 ? (void)0 : (void)0)
+int snprintfXXX(char *str, size_t size, const char *fmt, ...);
 
 #endif /* _SQUID_COMPAT_STDIO_H */
 

--- a/compat/stdio.h
+++ b/compat/stdio.h
@@ -62,5 +62,8 @@ inline FILE * tmpfile(void) { return tmpfile64(); }
 #define MAXPATHLEN SQUID_MAXPATHLEN
 #endif
 
+// circumvents GCC 'format-truncation' warning, introduced since v7.1
+#define snprintfXXX(...) (snprintf(__VA_ARGS__) < 0 ? (void)0 : (void)0)
+
 #endif /* _SQUID_COMPAT_STDIO_H */
 

--- a/helpers/external_acl/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/helpers/external_acl/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -721,7 +721,11 @@ BindLDAP(edui_ldap_t *l, char *dn, char *pw, unsigned int t)
             /* We got a basedn, but it's not part of dn */
             xstrncpy(l->dn, dn, sizeof(l->dn));
             strncat(l->dn, ",", FREE_SPACE(l->dn));
-            strncat(l->dn, l->basedn, FREE_SPACE(l->dn));
+            const auto dnFreeBytes = FREE_SPACE(l->dn);
+            const auto dnAppendBytes = dnFreeBytes < strlen(l->basedn) ? dnFreeBytes : strlen(l->basedn);
+            const auto dnOldLength = strlen(l->dn);
+            memmove(l->dn + dnOldLength, l->basedn, dnAppendBytes);
+            l->dn[dnOldLength + dnAppendBytes] = '\0';
         } else
             xstrncpy(l->dn, dn, sizeof(l->dn));
     }

--- a/helpers/external_acl/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/helpers/external_acl/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -721,9 +721,10 @@ BindLDAP(edui_ldap_t *l, char *dn, char *pw, unsigned int t)
             /* We got a basedn, but it's not part of dn */
             xstrncpy(l->dn, dn, sizeof(l->dn));
             strncat(l->dn, ",", FREE_SPACE(l->dn));
-            const auto dnFreeBytes = FREE_SPACE(l->dn);
-            const auto dnAppendBytes = dnFreeBytes < strlen(l->basedn) ? dnFreeBytes : strlen(l->basedn);
             const auto dnOldLength = strlen(l->dn);
+            const auto dnFreeBytes = sizeof(l->dn) - dnOldLength - 1;
+            const auto baseDnLength = strlen(l->basedn);
+            const auto dnAppendBytes = dnFreeBytes < baseDnLength ? dnFreeBytes : baseDnLength;
             memmove(l->dn + dnOldLength, l->basedn, dnAppendBytes);
             l->dn[dnOldLength + dnAppendBytes] = '\0';
         } else

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -423,7 +423,7 @@ httpHeaderStatInit(HttpHeaderStat * hs, const char *label)
 {
     assert(hs);
     assert(label);
-    memset(hs, 0, sizeof(HttpHeaderStat));
+    *hs = HttpHeaderStat();
     hs->label = label;
     hs->hdrUCountDistr.enumInit(32);    /* not a real enum */
     hs->fieldTypeDistr.enumInit(HDR_ENUM_END);

--- a/src/HttpHeaderStat.h
+++ b/src/HttpHeaderStat.h
@@ -15,19 +15,19 @@
 class HttpHeaderStat
 {
 public:
-    const char *label;
-    HttpHeaderMask *owner_mask;
+    const char *label = nullptr;
+    HttpHeaderMask *owner_mask = nullptr;
 
     StatHist hdrUCountDistr;
     StatHist fieldTypeDistr;
     StatHist ccTypeDistr;
     StatHist scTypeDistr;
 
-    int parsedCount;
-    int ccParsedCount;
-    int scParsedCount;
-    int destroyedCount;
-    int busyDestroyedCount;
+    int parsedCount = 0;
+    int ccParsedCount = 0;
+    int scParsedCount = 0;
+    int destroyedCount = 0;
+    int busyDestroyedCount = 0;
 };
 
 #endif /* HTTPHEADERSTAT_H_ */

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -77,7 +77,7 @@ HttpRequest::init()
 #endif
     port = 0;
     canonical = NULL;
-    memset(&flags, '\0', sizeof(flags));
+    flags = RequestFlags();
     range = NULL;
     ims = -1;
     imslen = 0;
@@ -182,8 +182,8 @@ HttpRequest::clone() const
     copy->pstate = pstate; // TODO: should we assert a specific state here?
     copy->body_pipe = body_pipe;
 
-    strncpy(copy->login, login, sizeof(login)); // MAX_LOGIN_SZ
-    strncpy(copy->host, host, sizeof(host)); // SQUIDHOSTNAMELEN
+    strncpy(copy->login, login, sizeof(copy->login)); // MAX_LOGIN_SZ
+    strncpy(copy->host, host, sizeof(copy->host)); // SQUIDHOSTNAMELEN
     copy->host_addr = host_addr;
 
     copy->port = port;

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -72,36 +72,36 @@ class PeerDigest
 {
 
 public:
-    CachePeer *peer;          /**< pointer back to peer structure, argh */
-    CacheDigest *cd;            /**< actual digest structure */
+    CachePeer *peer = nullptr;          /**< pointer back to peer structure, argh */
+    CacheDigest *cd = nullptr;            /**< actual digest structure */
     String host;                /**< copy of peer->host */
-    const char *req_result;     /**< text status of the last request */
+    const char *req_result = nullptr;     /**< text status of the last request */
 
     struct {
-        bool needed;          /**< there were requests for this digest */
-        bool usable;          /**< can be used for lookups */
-        bool requested;       /**< in process of receiving [fresh] digest */
+        bool needed = false;          /**< there were requests for this digest */
+        bool usable = false;          /**< can be used for lookups */
+        bool requested = false;       /**< in process of receiving [fresh] digest */
     } flags;
 
     struct {
         /* all times are absolute unless augmented with _delay */
-        time_t initialized; /* creation */
-        time_t needed;      /* first lookup/use by a peer */
-        time_t next_check;  /* next scheduled check/refresh event */
-        time_t retry_delay; /* delay before re-checking _invalid_ digest */
-        time_t requested;   /* requested a fresh copy of a digest */
-        time_t req_delay;   /* last request response time */
-        time_t received;    /* received the current copy of a digest */
-        time_t disabled;    /* disabled for good */
+        time_t initialized = 0; /* creation */
+        time_t needed = 0;      /* first lookup/use by a peer */
+        time_t next_check = 0;  /* next scheduled check/refresh event */
+        time_t retry_delay = 0; /* delay before re-checking _invalid_ digest */
+        time_t requested = 0;   /* requested a fresh copy of a digest */
+        time_t req_delay = 0;   /* last request response time */
+        time_t received = 0;    /* received the current copy of a digest */
+        time_t disabled = 0;    /* disabled for good */
     } times;
 
     struct {
         CacheDigestGuessStats guess;
-        int used_count;
+        int used_count = 0;
 
         struct {
-            int msgs;
-            kb_t kbytes;
+            int msgs = 0;
+            kb_t kbytes = {0, 0};
         } sent, recv;
     } stats;
 

--- a/src/StatCounters.h
+++ b/src/StatCounters.h
@@ -41,9 +41,9 @@ public:
         int mem_hits = 0;
         int disk_hits = 0;
         int errors = 0;
-        kb_t kbytes_in;
-        kb_t kbytes_out;
-        kb_t hit_kbytes_out;
+        kb_t kbytes_in = {0, 0};
+        kb_t kbytes_out = {0, 0};
+        kb_t hit_kbytes_out = {0, 0};
         StatHist missSvcTime;
         StatHist nearMissSvcTime;
         StatHist nearHitSvcTime;

--- a/src/StatCounters.h
+++ b/src/StatCounters.h
@@ -16,11 +16,11 @@
 class CacheDigestGuessStats
 {
 public:
-    int trueHits;
-    int falseHits;
-    int trueMisses;
-    int falseMisses;
-    int closeHits;     /// \todo: temporary remove it later
+    int trueHits = 0;
+    int falseHits = 0;
+    int trueMisses = 0;
+    int falseMisses = 0;
+    int closeHits = 0;     /// \todo: temporary remove it later
 };
 #endif
 
@@ -32,13 +32,15 @@ public:
 class StatCounters
 {
 public:
+    StatCounters() : timestamp(current_time) {}
+
     struct {
-        int clients;
-        int requests;
-        int hits;
-        int mem_hits;
-        int disk_hits;
-        int errors;
+        int clients = 0;
+        int requests = 0;
+        int hits = 0;
+        int mem_hits = 0;
+        int disk_hits = 0;
+        int errors = 0;
         kb_t kbytes_in;
         kb_t kbytes_out;
         kb_t hit_kbytes_out;
@@ -52,24 +54,24 @@ public:
     struct {
 
         struct {
-            int requests;
-            int errors;
+            int requests = 0;
+            int errors = 0;
             kb_t kbytes_in;
             kb_t kbytes_out;
         } all , http, ftp, other;
     } server;
 
     struct {
-        int pkts_sent;
-        int queries_sent;
-        int replies_sent;
-        int pkts_recv;
-        int queries_recv;
-        int replies_recv;
-        int hits_sent;
-        int hits_recv;
-        int replies_queued;
-        int replies_dropped;
+        int pkts_sent = 0;
+        int queries_sent = 0;
+        int replies_sent = 0;
+        int pkts_recv = 0;
+        int queries_recv = 0;
+        int replies_recv = 0;
+        int hits_sent = 0;
+        int hits_recv = 0;
+        int replies_queued = 0;
+        int replies_dropped = 0;
         kb_t kbytes_sent;
         kb_t q_kbytes_sent;
         kb_t r_kbytes_sent;
@@ -78,17 +80,17 @@ public:
         kb_t r_kbytes_recv;
         StatHist querySvcTime;
         StatHist replySvcTime;
-        int query_timeouts;
-        int times_used;
+        int query_timeouts = 0;
+        int times_used = 0;
     } icp;
 
     struct {
-        int pkts_sent;
-        int pkts_recv;
+        int pkts_sent = 0;
+        int pkts_recv = 0;
     } htcp;
 
     struct {
-        int requests;
+        int requests = 0;
     } unlink;
 
     struct {
@@ -96,12 +98,12 @@ public:
     } dns;
 
     struct {
-        int times_used;
+        int times_used = 0;
         kb_t kbytes_sent;
         kb_t kbytes_recv;
         kb_t memory;
-        int msgs_sent;
-        int msgs_recv;
+        int msgs_sent = 0;
+        int msgs_recv = 0;
 #if USE_CACHE_DIGESTS
 
         CacheDigestGuessStats guess;
@@ -111,13 +113,13 @@ public:
     } cd;
 
     struct {
-        int times_used;
+        int times_used = 0;
     } netdb;
-    int page_faults;
-    unsigned long int select_loops;
-    int select_fds;
-    double select_time;
-    double cputime;
+    int page_faults = 0;
+    unsigned long int select_loops = 0;
+    int select_fds = 0;
+    double select_time = 0.0;
+    double cputime = 0.0;
 
     struct timeval timestamp;
     StatHist comm_udp_incoming;
@@ -127,33 +129,33 @@ public:
 
     struct {
         struct {
-            int opens;
-            int closes;
-            int reads;
-            int writes;
-            int seeks;
-            int unlinks;
+            int opens = 0;
+            int closes = 0;
+            int reads = 0;
+            int writes = 0;
+            int seeks = 0;
+            int unlinks = 0;
         } disk;
 
         struct {
-            int accepts;
-            int sockets;
-            int connects;
-            int binds;
-            int closes;
-            int reads;
-            int writes;
-            int recvfroms;
-            int sendtos;
+            int accepts = 0;
+            int sockets = 0;
+            int connects = 0;
+            int binds = 0;
+            int closes = 0;
+            int reads = 0;
+            int writes = 0;
+            int recvfroms = 0;
+            int sendtos = 0;
         } sock;
-        int selects;
+        int selects = 0;
     } syscalls;
-    int aborted_requests;
+    int aborted_requests = 0;
 
     struct {
-        int files_cleaned;
-        int outs;
-        int ins;
+        int files_cleaned = 0;
+        int outs = 0;
+        int ins = 0;
     } swap;
 
 private:

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1431,7 +1431,7 @@ clientReplyContext::buildReplyHeader()
 
             if (squid_curtime - http->storeEntry()->timestamp >= 86400) {
                 char tbuf[512];
-                snprintf (tbuf, sizeof(tbuf), "%s %s %s",
+                snprintfXXX(tbuf, sizeof(tbuf), "%s %s %s",
                           "113", ThisCache,
                           "This cache hit is still fresh and more than 1 day old");
                 hdr->putStr(HDR_WARNING, tbuf);

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -876,13 +876,13 @@ Ftp::Gateway::htmlifyListEntry(const char *line)
 
     if (parts->type != 'd') {
         if (mimeGetViewOption(parts->name)) {
-            snprintf(view, 2048, "<a href=\"%s%s;type=a\"><img border=\"0\" src=\"%s\" "
+            snprintfXXX(view, sizeof(view), "<a href=\"%s%s;type=a\"><img border=\"0\" src=\"%s\" "
                      "alt=\"[VIEW]\"></a>",
                      prefix, href, mimeGetIconURL("internal-view"));
         }
 
         if (mimeGetDownloadOption(parts->name)) {
-            snprintf(download, 2048, "<a href=\"%s%s;type=i\"><img border=\"0\" src=\"%s\" "
+            snprintfXXX(download, sizeof(download), "<a href=\"%s%s;type=i\"><img border=\"0\" src=\"%s\" "
                      "alt=\"[DOWNLOAD]\"></a>",
                      prefix, href, mimeGetIconURL("internal-download"));
         }

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -846,9 +846,9 @@ Ftp::Gateway::htmlifyListEntry(const char *line)
 
         if (parts->link) {
             char *link2 = xstrdup(html_quote(rfc1738_escape(parts->link)));
-            snprintf(link, 2048, " -&gt; <a href=\"%s%s\">%s</a>",
-                     *link2 != '/' ? prefix : "", link2,
-                     html_quote(parts->link));
+            snprintfXXX(link, 2048, " -&gt; <a href=\"%s%s\">%s</a>",
+                        *link2 != '/' ? prefix : "", link2,
+                        html_quote(parts->link));
             safe_free(link2);
         }
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -515,7 +515,7 @@ debugLogTime(void)
         tm = localtime(&t);
         strftime(buf2, 127, "%Y/%m/%d %H:%M:%S", tm);
         buf2[127] = '\0';
-        snprintf(buf, 127, "%s.%03d", buf2, (int) current_time.tv_usec / 1000);
+        snprintfXXX(buf, 127, "%s.%03d", buf2, (int) current_time.tv_usec / 1000);
         last_t = t;
     } else if (t != last_t) {
         tm = localtime(&t);

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -515,7 +515,7 @@ debugLogTime(void)
         tm = localtime(&t);
         strftime(buf2, 127, "%Y/%m/%d %H:%M:%S", tm);
         buf2[127] = '\0';
-        snprintfXXX(buf, 127, "%s.%03d", buf2, (int) current_time.tv_usec / 1000);
+        snprintfXXX(buf, sizeof(buf), "%s.%03d", buf2, (int) current_time.tv_usec / 1000);
         last_t = t;
     } else if (t != last_t) {
         tm = localtime(&t);

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -304,8 +304,10 @@ idnsAddNameserver(const char *buf)
 
         nameservers = (ns *)xcalloc(nns_alloc, sizeof(*nameservers));
 
-        if (oldptr && oldalloc)
-            memcpy(nameservers, oldptr, oldalloc * sizeof(*nameservers));
+        if (oldptr && oldalloc) {
+            for (int i = 0; i <  oldalloc; ++i)
+                *(nameservers + i) = *(oldptr + i);
+        }
 
         if (oldptr)
             safe_free(oldptr);

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -2273,7 +2273,8 @@ ElementList::pop_front (size_t const count)
     if (!count)
         return;
 
-    memmove(elements, &elements[count], (elementcount - count)  * sizeof (ESIElement::Pointer));
+    for (unsigned int i = 0; i < elementcount-count; ++i)
+        elements[i] = elements[i+count];
 
     elementcount -= count;
 }
@@ -2285,7 +2286,6 @@ ElementList::push_back(ESIElement::Pointer &newElement)
                &allocedsize);
     assert (elements);
     allocedcount = elementcount;
-    memset(&elements[elementcount - 1], '\0', sizeof (ESIElement::Pointer));
     elements[elementcount - 1] = newElement;
 }
 

--- a/src/fqdncache.cc
+++ b/src/fqdncache.cc
@@ -721,7 +721,7 @@ fqdncache_init(void)
 
     memset(&FqdncacheStats, '\0', sizeof(FqdncacheStats));
 
-    memset(&lru_list, '\0', sizeof(lru_list));
+    lru_list = dlink_list();
 
     fqdncache_high = (long) (((float) Config.fqdncache.size *
                               (float) FQDN_HIGH_WATER) / (float) 100);

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -1394,7 +1394,7 @@ Fs::Ufs::UFSSwapDir::DirClean(int swap_index)
 
     for (n = 0; n < k; ++n) {
         debugs(36, 3, HERE << "Cleaning file "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << files[n]);
-        snprintf(p2, MAXPATHLEN + 1, "%s/%08X", p1, files[n]);
+        snprintfXXX(p2, MAXPATHLEN + 1, "%s/%08X", p1, files[n]);
         safeunlink(p2, 0);
         ++statCounter.swap.files_cleaned;
     }

--- a/src/icmp/Icmp.h
+++ b/src/icmp/Icmp.h
@@ -23,19 +23,21 @@
 
 /* This is a line-data format struct. DO NOT alter. */
 struct pingerEchoData {
+    pingerEchoData() { memset(payload, 0, sizeof(payload)); }
     Ip::Address to;
-    unsigned char opcode;
-    int psize;
+    unsigned char opcode = '\0';
+    int psize = 0;
     char payload[PINGER_PAYLOAD_SZ];
 };
 
 /* This is a line-data format struct. DO NOT alter. */
 struct pingerReplyData {
+    pingerReplyData() { memset(payload, 0, sizeof(payload)); }
     Ip::Address from;
-    unsigned char opcode;
-    int rtt;
-    int hops;
-    int psize;
+    unsigned char opcode = '\0';
+    int rtt = 0;
+    int hops = 0;
+    int psize = 0;
     char payload[PINGER_PAYLOAD_SZ];
 };
 

--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -159,7 +159,7 @@ IcmpPinger::Recv(void)
     int n;
     int guess_size;
 
-    memset(&pecho, '\0', sizeof(pecho));
+    pecho = pingerEchoData();
     n = recv(socket_from_squid, &pecho, sizeof(pecho), 0);
 
     if (n < 0) {

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -123,7 +123,6 @@ IcmpSquid::Recv()
     static Ip::Address F;
 
     Comm::SetSelect(icmp_sock, COMM_SELECT_READ, icmpSquidRecv, NULL, 0);
-    memset(&preply, '\0', sizeof(pingerReplyData));
     n = comm_udp_recv(icmp_sock,
                       (char *) &preply,
                       sizeof(pingerReplyData),

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -559,7 +559,7 @@ netdbReloadState(void)
         char *q;
         assert(s - buf < l);
         *s = '\0';
-        memset(&N, '\0', sizeof(netdbEntry));
+        N = netdbEntry();
         q = strtok(t, w_space);
         t = s + 1;
 

--- a/src/icmp/net_db.h
+++ b/src/icmp/net_db.h
@@ -43,19 +43,20 @@ public:
 class netdbEntry
 {
 public:
+    netdbEntry() { memset(network, 0, sizeof(network)); }
     hash_link hash;     /* must be first */
     char network[MAX_IPSTRLEN];
-    int pings_sent;
-    int pings_recv;
-    double hops;
-    double rtt;
-    time_t next_ping_time;
-    time_t last_use_time;
-    int link_count;
-    net_db_name *hosts;
-    net_db_peer *peers;
-    int n_peers_alloc;
-    int n_peers;
+    int pings_sent = 0;
+    int pings_recv = 0;
+    double hops = 0.;
+    double rtt = 0.;
+    time_t next_ping_time = 0;
+    time_t last_use_time = 0;
+    int link_count = 0;
+    net_db_name *hosts = nullptr;
+    net_db_peer *peers = nullptr;
+    int n_peers_alloc = 0;
+    int n_peers = 0;
 };
 
 void netdbInit(void);

--- a/src/ident/Ident.cc
+++ b/src/ident/Ident.cc
@@ -242,7 +242,7 @@ Ident::Start(const Comm::ConnectionPointer &conn, IDCB * callback, void *data)
 
     conn->local.toUrl(key1, IDENT_KEY_SZ);
     conn->remote.toUrl(key2, IDENT_KEY_SZ);
-    snprintf(key, IDENT_KEY_SZ, "%s,%s", key1, key2);
+    snprintfXXX(key, IDENT_KEY_SZ, "%s,%s", key1, key2);
 
     if (!ident_hash) {
         Init();

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -466,7 +466,6 @@ Ipc::StoreMap::sliceAt(const SliceId sliceId) const
 Ipc::StoreMapAnchor::StoreMapAnchor(): start(0)
 {
     memset(&key, 0, sizeof(key));
-    memset(&basics, 0, sizeof(basics));
     // keep in sync with rewind()
 }
 
@@ -503,7 +502,7 @@ Ipc::StoreMapAnchor::rewind()
     assert(writing());
     start = 0;
     memset(&key, 0, sizeof(key));
-    memset(&basics, 0, sizeof(basics));
+    basics.clear();
     // but keep the lock
 }
 

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -68,13 +68,23 @@ public:
 
     // STORE_META_STD TLV field from StoreEntry
     struct Basics {
-        time_t timestamp;
-        time_t lastref;
-        time_t expires;
-        time_t lastmod;
-        Atomic::WordT<uint64_t> swap_file_sz; // [app]
-        uint16_t refcount;
-        uint16_t flags;
+        typedef Atomic::WordT<uint64_t> SwapFileSz;
+        void clear() {
+            timestamp = 0;
+            lastref = 0;
+            expires = 0;
+            lastmod = 0;
+            swap_file_sz = SwapFileSz(0);
+            refcount = 0;
+            flags = 0;
+        }
+        time_t timestamp = 0;
+        time_t lastref = 0;
+        time_t expires = 0;
+        time_t lastmod = 0;
+        SwapFileSz swap_file_sz = SwapFileSz(0); // [app]
+        uint16_t refcount = 0;
+        uint16_t flags = 0;
     } basics;
 
     /// where the chain of StoreEntry slices begins [app]

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -570,7 +570,7 @@ ipcache_init(void)
     int n;
     debugs(14, DBG_IMPORTANT, "Initializing IP Cache...");
     memset(&IpcacheStats, '\0', sizeof(IpcacheStats));
-    memset(&lru_list, '\0', sizeof(lru_list));
+    lru_list = dlink_list();
     memset(&static_addrs, '\0', sizeof(ipcache_addrs));
 
     static_addrs.in_addrs = static_cast<Ip::Address *>(xcalloc(1, sizeof(Ip::Address)));

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -72,7 +72,7 @@ peerDigestInit(PeerDigest * pd, CachePeer * p)
 {
     assert(pd && p);
 
-    memset(pd, 0, sizeof(*pd));
+    *pd = PeerDigest();
     /*
      * DPW 2007-04-12
      * Lock on to the peer here.  The corresponding cbdataReferenceDone()

--- a/src/ssl/PeerConnector.cc
+++ b/src/ssl/PeerConnector.cc
@@ -613,10 +613,10 @@ Ssl::PeerConnector::handleNegotiateError(const int ret)
         //
         if (srvBio->bumpMode() == Ssl::bumpPeek && (resumingSession = srvBio->resumingSession())) {
             // we currently splice all resumed sessions unconditionally
-            if (const bool spliceResumed = true) {
-                checkForPeekAndSpliceMatched(Ssl::bumpSplice);
-                return;
-            } // else fall through to find a matching ssl_bump action (with limited info)
+            // if (const bool spliceResumed = true) {
+            checkForPeekAndSpliceMatched(Ssl::bumpSplice);
+            return;
+            // } // else fall through to find a matching ssl_bump action (with limited info)
         }
 
         // If we are in peek-and-splice mode and still we did not write to

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -45,12 +45,12 @@ class StoreDigestState
 
 public:
     StoreDigestCBlock cblock;
-    int rebuild_lock;       /* bucket number */
-    StoreEntry * rewrite_lock;  /* points to store entry with the digest */
+    int rebuild_lock = 0;                 ///< bucket number
+    StoreEntry * rewrite_lock = nullptr;  ///< points to store entry with the digest
     StoreSearchPointer theSearch;
-    int rewrite_offset;
-    int rebuild_count;
-    int rewrite_count;
+    int rewrite_offset = 0;
+    int rebuild_count = 0;
+    int rewrite_count = 0;
 };
 
 typedef struct {
@@ -138,7 +138,7 @@ storeDigestInit(void)
            (int) Config.digest.rebuild_period << "/" <<
            (int) Config.digest.rewrite_period << " sec");
 
-    memset(&sd_state, 0, sizeof(sd_state));
+    sd_state = StoreDigestState();
 #else
     store_digest = NULL;
     debugs(71, 3, "Local cache digest is 'off'");

--- a/src/store_dir.cc
+++ b/src/store_dir.cc
@@ -580,16 +580,18 @@ storeDirGetUFSStats(const char *path, int *totl_kb, int *free_kb, int *totl_in, 
 void
 allocate_new_swapdir(SquidConfig::_cacheSwap * swap)
 {
-    if (swap->swapDirs == NULL) {
+    if (!swap->swapDirs) {
         swap->n_allocated = 4;
-        swap->swapDirs = static_cast<SwapDir::Pointer *>(xcalloc(swap->n_allocated, sizeof(SwapDir::Pointer)));
+        swap->swapDirs = new SwapDir::Pointer[swap->n_allocated];
     }
 
     if (swap->n_allocated == swap->n_configured) {
         swap->n_allocated <<= 1;
-        SwapDir::Pointer *const tmp = static_cast<SwapDir::Pointer *>(xcalloc(swap->n_allocated, sizeof(SwapDir::Pointer)));
-        memcpy(tmp, swap->swapDirs, swap->n_configured * sizeof(SwapDir *));
-        xfree(swap->swapDirs);
+        const auto tmp = new SwapDir::Pointer[swap->n_allocated];
+        for (int i = 0; i < swap->n_configured; ++i) {
+            tmp[i] = swap->swapDirs[i];
+        }
+        delete[] swap->swapDirs;
         swap->swapDirs = tmp;
     }
 }
@@ -597,23 +599,21 @@ allocate_new_swapdir(SquidConfig::_cacheSwap * swap)
 void
 free_cachedir(SquidConfig::_cacheSwap * swap)
 {
-    int i;
     /* DON'T FREE THESE FOR RECONFIGURE */
 
     if (reconfiguring)
         return;
 
-    for (i = 0; i < swap->n_configured; ++i) {
-        /* TODO XXX this lets the swapdir free resources asynchronously
-        * swap->swapDirs[i]->deactivate();
-        * but there may be such a means already.
-        * RBC 20041225
-        */
-        swap->swapDirs[i] = NULL;
-    }
+    /* TODO XXX this lets the swapdir free resources asynchronously
+    * swap->swapDirs[i]->deactivate();
+    * but there may be such a means already.
+    * RBC 20041225
+    */
 
-    safe_free(swap->swapDirs);
-    swap->swapDirs = NULL;
+    // only free's the array memory itself
+    // the SwapDir objects may remain (ref-counted)
+    delete[] swap->swapDirs;
+    swap->swapDirs = nullptr;
     swap->n_allocated = 0;
     swap->n_configured = 0;
 }

--- a/src/tests/stub_MemObject.cc
+++ b/src/tests/stub_MemObject.cc
@@ -40,7 +40,7 @@ MemObject::MemObject() :
     swap_hdr_sz(0),
     _reply(NULL)
 {
-    memset(&clients, 0, sizeof(clients));
+    clients = dlink_list();
     memset(&start_ping, 0, sizeof(start_ping));
     memset(&abort, 0, sizeof(abort));
 } // NOP instead of elided due to Store

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -316,7 +316,7 @@ death(int sig)
 #endif /* _SQUID_SOLARIS_and HAVE_LIBOPCOM_STACK */
 #if HAVE_BACKTRACE_SYMBOLS_FD
     {
-        static void *(callarray[8192]);
+        static void *callarray[8192];
         int n;
         n = backtrace(callarray, 8192);
         backtrace_symbols_fd(callarray, n, fileno(debug_log));

--- a/tools/squidclient/squidclient.cc
+++ b/tools/squidclient/squidclient.cc
@@ -377,12 +377,12 @@ main(int argc, char *argv[])
 
     if (version[0] == '-' || !version[0]) {
         /* HTTP/0.9, no headers, no version */
-        snprintf(msg, BUFSIZ, "%s %s\r\n", method, url);
+        snprintfXXX(msg, BUFSIZ, "%s %s\r\n", method, url);
     } else {
         if (!xisdigit(version[0])) // not HTTP/n.n
-            snprintf(msg, BUFSIZ, "%s %s %s\r\n", method, url, version);
+            snprintfXXX(msg, BUFSIZ, "%s %s %s\r\n", method, url, version);
         else
-            snprintf(msg, BUFSIZ, "%s %s HTTP/%s\r\n", method, url, version);
+            snprintfXXX(msg, BUFSIZ, "%s %s HTTP/%s\r\n", method, url, version);
 
         if (host) {
             snprintf(buf, BUFSIZ, "Host: %s\r\n", host);


### PR DESCRIPTION
b56b37 already adjusts master for GCC-8 support. Unfortunately, that
revision is rather huge (including many out-of-scope and master-specific
changes) and porting it to v3.5 seems hardly possible. This solution 
includes some issue-related changes taken from there that could be
ported and some v3.5-specific adjustments for the rest of the code.

