### PR TITLE
Fixed Transients xitTable.io == ioWriting assertion

### DIFF
--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -624,6 +624,13 @@ MemStore::shouldCache(StoreEntry &e) const
         return false;
     }
 
+    // in collapsed forwarding, restrict caching to master worker to avoid
+    // collapsed workers releasing each other caching attempts
+    if (e.transientsReader()) {
+        debugs(20, 5, "CF slaves do not mem-cache: " << e);
+        return false;
+    }
+
     const int64_t expectedSize = e.mem_obj->expectedReplySize(); // may be < 0
     const int64_t loadedSize = e.mem_obj->endOffset();
     const int64_t ramSize = max(loadedSize, expectedSize);

--- a/src/Store.h
+++ b/src/Store.h
@@ -165,6 +165,8 @@ public:
     /// whether there is a corresponding locked shared memory table entry
     bool hasMemStore() const { return mem_obj && mem_obj->memCache.index >= 0; }
 
+    /// whether the entry is in "writing to Transients" I/O state
+    bool transientsWriter() const { return mem_obj && mem_obj->xitTable.io == MemObject::ioWriting; }
     /// whether this is a collapsed forwarding-created public entry that still
     /// has not received its response headers; new requests may collapse on it
     bool collapsingInitiator() const;

--- a/src/Store.h
+++ b/src/Store.h
@@ -165,8 +165,9 @@ public:
     /// whether there is a corresponding locked shared memory table entry
     bool hasMemStore() const { return mem_obj && mem_obj->memCache.index >= 0; }
 
-    /// whether the entry is in "writing to Transients" I/O state
-    bool transientsWriter() const { return mem_obj && mem_obj->xitTable.io == MemObject::ioWriting; }
+    /// whether the entry has a Transients read lock
+    bool transientsReader() const { return hasTransients() && mem_obj->xitTable.io == MemObject::ioReading; }
+
     /// whether this is a collapsed forwarding-created public entry that still
     /// has not received its response headers; new requests may collapse on it
     bool collapsingInitiator() const;

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -393,7 +393,9 @@ void
 Store::Controller::memoryOut(StoreEntry &e, const bool preserveSwappable)
 {
     bool keepInLocalMemory = false;
-    if (memStore)
+    /// For collapsed entries allow only the collapsing initiator(transients writer)
+    /// to write, do not allow collapsed slaves to overwrite the shared entry.
+    if (memStore && (!e.hasTransients() || e.transientsWriter()))
         memStore->write(e); // leave keepInLocalMemory false
     else
         keepInLocalMemory = keepForLocalMemoryCache(e);

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -393,9 +393,7 @@ void
 Store::Controller::memoryOut(StoreEntry &e, const bool preserveSwappable)
 {
     bool keepInLocalMemory = false;
-    /// For collapsed entries allow only the collapsing initiator(transients writer)
-    /// to write, do not allow collapsed slaves to overwrite the shared entry.
-    if (memStore && (!e.hasTransients() || e.transientsWriter()))
+    if (memStore)
         memStore->write(e); // leave keepInLocalMemory false
     else
         keepInLocalMemory = keepForLocalMemoryCache(e);


### PR DESCRIPTION
In this approach, the only collapsing initiator is allowed to write.
Preventing collapsed slaves (which are Transients readers) from
writing should fix the assertion.
