### PR TITLE
Ignore ECONNABORTED in accept(2)

### DIFF
--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -358,6 +358,9 @@ typedef char * caddr_t;
 #ifndef ENOTSUP
 #define ENOTSUP WSAEOPNOTSUPP
 #endif
+#ifndef ECONNABORTED
+#define ECONNABORTED WSAECONNABORTED
+#endif
 
 #undef h_errno
 #define h_errno errno /* we'll set it ourselves */

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -365,10 +365,10 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
 
         PROF_stop(comm_accept);
 
-        if (ignoreErrno(errcode)) {
+        if (ignoreErrno(errcode) || errcode == ECONNABORTED) {
             debugs(50, 5, status() << ": " << xstrerr(errcode));
             return Comm::NOMESSAGE;
-        } else if (ENFILE == errno || EMFILE == errno) {
+        } else if (errcode == ENFILE || errcode == EMFILE) {
             debugs(50, 3, status() << ": " << xstrerr(errcode));
             return Comm::COMM_ERROR;
         } else {


### PR DESCRIPTION
An aborted connection attempt does not affect listening socket's
ability to accept other connections. If the error is not ignored, Squid
gets stuck after logging an oldAccept error like this one:

    oldAccept ...: (53) Software caused connection abort

This bug fix was motivated by accept(2) changes in OpenBSD v6.5 that
resulted in new ECONNABORTED errors under regular deployment conditions:
https://github.com/openbsd/src/commit/c255b5a

Cherry-picked master commit fb730aa.