### PR TITLE
RFC 7230 forbids generation of userinfo subcomponent of https URL

### DIFF
--- a/src/url.cc
+++ b/src/url.cc
@@ -518,7 +518,7 @@ URL::absolute() const
         if (getScheme() != AnyP::PROTO_URN) {
             absolute_.append("//", 2);
             const bool omitUserInfo = getScheme() == AnyP::PROTO_HTTP ||
-                                      getScheme() != AnyP::PROTO_HTTPS ||
+                                      getScheme() == AnyP::PROTO_HTTPS ||
                                       userInfo().isEmpty();
             if (!omitUserInfo) {
                 absolute_.append(userInfo());


### PR DESCRIPTION
Cherry-picked master commit 196c524.