### PR TITLE
Must send Connection:close in requests on non-persistent connections

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -1926,9 +1926,9 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
         delete cc;
     }
 
-    /* maybe append Connection: keep-alive */
-    if (flags.keepalive) {
-        hdr_out->putStr(Http::HdrType::CONNECTION, "keep-alive");
+    /// RFC7230 section 6.1
+    if (!flags.keepalive) {
+        hdr_out->putStr(Http::HdrType::CONNECTION, "close");
     }
 
     /* append Front-End-Https */

--- a/src/http.cc
+++ b/src/http.cc
@@ -626,7 +626,7 @@ httpMakeVaryMark(HttpRequest * request, HttpReply const * reply)
 void
 HttpStateData::keepaliveAccounting(HttpReply *reply)
 {
-    if (flags.keepalive)
+    if (!flags.connectionClose)
         if (flags.peering && !flags.tunneling)
             ++ _peer->stats.n_keepalives_sent;
 
@@ -1044,10 +1044,10 @@ HttpStateData::statusIfComplete() const
         return COMPLETE_NONPERSISTENT_MSG;
 
     /** \par
-     * If we didn't send a keep-alive request header, then this
+     * If we sent the Connection:close request header, then this
      * can not be a persistent connection.
      */
-    if (!flags.keepalive)
+    if (flags.connectionClose)
         return COMPLETE_NONPERSISTENT_MSG;
 
     /** \par
@@ -1927,7 +1927,7 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
     }
 
     /// RFC7230 section 6.1
-    if (!flags.keepalive) {
+    if (flags.connectionClose) {
         hdr_out->putStr(Http::HdrType::CONNECTION, "close");
     }
 
@@ -2193,6 +2193,29 @@ HttpStateData::buildRequestPrefix(MemBuf * mb)
     return mb->size - offset;
 }
 
+void
+HttpStateData::refreshConnectionCloseFlag()
+{
+    if (request->flags.mustKeepalive)
+        flags.connectionClose = false;
+    else if (request->flags.pinned)
+        flags.connectionClose = !request->persistent();
+    else if (!Config.onoff.server_pconns)
+        flags.connectionClose = true;
+    else if (flags.tunneling)
+        // tunneled non pinned bumped requests must not keepalive
+        flags.connectionClose = request->flags.sslBumped;
+    else if (!_peer)
+        flags.connectionClose = false;
+    else if (_peer->stats.n_keepalives_sent < 10)
+        flags.connectionClose = false;
+    else if ((double) _peer->stats.n_keepalives_recv /
+             (double) _peer->stats.n_keepalives_sent > 0.50)
+        flags.connectionClose = false;
+    else
+        flags.connectionClose = true;
+}
+
 /* This will be called when connect completes. Write request. */
 bool
 HttpStateData::sendRequest()
@@ -2232,25 +2255,7 @@ HttpStateData::sendRequest()
                                     Dialer, this,  HttpStateData::wroteLast);
     }
 
-    /*
-     * Is keep-alive okay for all request methods?
-     */
-    if (request->flags.mustKeepalive)
-        flags.keepalive = true;
-    else if (request->flags.pinned)
-        flags.keepalive = request->persistent();
-    else if (!Config.onoff.server_pconns)
-        flags.keepalive = false;
-    else if (flags.tunneling)
-        // tunneled non pinned bumped requests must not keepalive
-        flags.keepalive = !request->flags.sslBumped;
-    else if (_peer == NULL)
-        flags.keepalive = true;
-    else if (_peer->stats.n_keepalives_sent < 10)
-        flags.keepalive = true;
-    else if ((double) _peer->stats.n_keepalives_recv /
-             (double) _peer->stats.n_keepalives_sent > 0.50)
-        flags.keepalive = true;
+    refreshConnectionCloseFlag();
 
     if (_peer && !flags.tunneling) {
         /*The old code here was

--- a/src/http.h
+++ b/src/http.h
@@ -137,6 +137,7 @@ private:
     mb_size_t buildRequestPrefix(MemBuf * mb);
     static bool decideIfWeDoRanges (HttpRequest * orig_request);
     bool peerSupportsConnectionPinning() const;
+    void refreshConnectionCloseFlag();
 
     /// Parser being used at present to parse the HTTP/ICY server response.
     Http1::ResponseParserPointer hp;

--- a/src/http/StateFlags.h
+++ b/src/http/StateFlags.h
@@ -16,7 +16,7 @@ class StateFlags
 {
 public:
     unsigned int front_end_https = 0; ///< send "Front-End-Https: On" header (off/on/auto=2)
-    bool keepalive = false;
+    bool connectionClose = false; ///< send Connection: close header
     bool only_if_cached = false;
     bool handling1xx = false;       ///< we are ignoring or forwarding 1xx response
     bool headers_parsed = false;


### PR DESCRIPTION
Before this fix, Squid did not send it, thus violating RFC7230
section 6.1 MUST requirement: 'A client that does not support
persistent connections MUST send the "close" connection option
in every request message'. Instead, it sent an excessive
Connection:keep-alive header, which is the default behavior for
HTTP/1.1 requests.