### PR TITLE
Supply transaction annotations with eCAP meta headers

### DIFF
--- a/src/adaptation/History.cc
+++ b/src/adaptation/History.cc
@@ -152,6 +152,15 @@ Adaptation::History::recordAdaptationService(SBuf &srvId)
 }
 
 void
+Adaptation::History::addMetaHeader(const SBuf &key, const SBuf &value)
+{
+    if (!metaHeaders)
+        metaHeaders = new NotePairs;
+    if (!metaHeaders->hasPair(key, value))
+        metaHeaders->add(key, value);
+}
+
+void
 Adaptation::History::setFutureServices(const DynamicGroupCfg &services)
 {
     if (!theFutureServices.empty())

--- a/src/adaptation/History.h
+++ b/src/adaptation/History.h
@@ -55,13 +55,17 @@ public:
     void recordMeta(const HttpHeader *lm);
 
     void recordAdaptationService(SBuf &srvId);
+
+    /// appends a meta header, does nothing if it already exists
+    void addMetaHeader(const SBuf &key, const SBuf &value);
+
 public:
     /// Last received meta header (REQMOD or RESPMOD, whichever comes last).
     HttpHeader lastMeta;
     /// All REQMOD and RESPMOD meta headers merged. Last field wins conflicts.
     HttpHeader allMeta;
-    /// key:value pairs set by adaptation_meta, to be added to
-    /// AccessLogEntry::notes when ALE becomes available
+    /// key:value pairs set by adaptation_meta and(or) eCAP response meta headers.
+    /// This is a part of the transaction annotation.
     NotePairs::Pointer metaHeaders;
 
     typedef std::vector<SBuf> AdaptationServices;

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1504,13 +1504,8 @@ void Adaptation::Icap::ModXact::makeRequestHeaders(MemBuf &buf)
             buf.append(": ", 2);
             buf.append(matched.rawContent(), matched.length());
             buf.append("\r\n", 2);
-            Adaptation::History::Pointer ah = request->adaptHistory(false);
-            if (ah != NULL) {
-                if (ah->metaHeaders == NULL)
-                    ah->metaHeaders = new NotePairs;
-                if (!ah->metaHeaders->hasPair(h->key(), matched))
-                    ah->metaHeaders->add(h->key(), matched);
-            }
+            if (auto ah = request->adaptHistory(false))
+                ah->addMetaHeader(h->key(), matched);
         }
     }
 


### PR DESCRIPTION
'note' ACL was added at 39baccc and its documentation describes the
sources of transaction annotation, including 'eCAP responses'. However
this statement proved to be wrong: eCAP meta headers are not accessible
via %note. I fixed this inconsistency, copying the missing meta headers
into the related Adaptation::History::metaHeaders.