### PR TITLE
Detail TLS and CONNECT cache_peer negotiation failures

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -905,8 +905,7 @@ FwdState::connectedToPeer(Security::EncryptorAnswer &answer)
         answer.error.clear(); // preserve error for errorSendComplete()
         if (CachePeer *p = serverConnection()->getPeer())
             peerConnectFailed(p);
-        if (Comm::IsConnOpen(serverConnection()))
-            serverConnection()->close();
+        serverConnection()->close();
         retryOrBail();
         return;
     }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -807,7 +807,7 @@ FwdState::establishTunnelThruProxy(const Comm::ConnectionPointer &conn)
                                             Http::Tunneler::CbDialer<FwdState>(&FwdState::tunnelEstablishmentDone, this));
     HttpRequest::Pointer requestPointer = request;
     const auto tunneler = new Http::Tunneler(conn, requestPointer, callback, connectingTimeout(serverConnection()), al);
-    tunneler->usesPconn_ = true;
+    tunneler->usesPconn_ = true; // TODO: Replace this hack with proper Connection-Pool association
 #if USE_DELAY_POOLS
     Must(serverConnection()->getPeer());
     if (!serverConnection()->getPeer()->options.no_delay)

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -843,9 +843,6 @@ FwdState::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 
     // TODO: Reuse to-peer connections after a CONNECT error response.
 
-    if (const auto peer = serverConnection()->getPeer())
-        peerConnectFailed(peer);
-
     const auto error = answer.squidError.get();
     Must(error);
     answer.squidError.clear(); // preserve error for fail()

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -779,7 +779,7 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
     }
 
     // Check if we need to TLS before use
-    if (const CachePeer *peer = conn->getPeer()) {
+    if (const auto *peer = conn->getPeer()) {
         // Assume that it is only possible for the client-first from the
         // bumping modes to try connect to a remote server. The bumped
         // requests with other modes are using pinned connections or fails.

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -809,7 +809,7 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
     }
 
     // Check if we need to TLS before use
-    if (const auto *peer = conn->getPeer()) {
+    if (const auto *peer = answer.conn->getPeer()) {
         // Assume that it is only possible for the client-first from the
         // bumping modes to try connect to a remote server. The bumped
         // requests with other modes are using pinned connections or fails.
@@ -824,12 +824,12 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
                 !peer->options.originserver && // the "through a proxy" part
                 !peer->secure.encryptTransport) // the "exclude HTTPS proxies" part
 
-            return advanceDestination("establish tunnel thru proxy", conn, [this,&conn] {
-                establishTunnelThruProxy(conn);
+            return advanceDestination("establish tunnel thru proxy", answer.conn, [this,&answer] {
+                establishTunnelThruProxy(answer.conn);
             });
     }
 
-    secureConnectionToPeerIfNeeded(conn);
+    secureConnectionToPeerIfNeeded(answer.conn);
 }
 
 void
@@ -1078,8 +1078,6 @@ FwdState::usePinned()
     assert(connManager);
     if (connManager->pinnedAuth())
         request->flags.auth = true;
-
-    syncWithServerConn(connManager->pinning.host);
 
     // the server may close the pinned connection before this request
     const auto reused = true;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -998,8 +998,6 @@ FwdState::connectStart()
     assert(!destinations->empty());
     assert(!opening());
 
-    FwdStateEnterThrowingCode();
-
     // Ditch error page if it was created before.
     // A new one will be created if there's another problem
     delete err;
@@ -1026,8 +1024,6 @@ FwdState::connectStart()
     destinations->notificationPending = true; // start() is async
     connOpener = cs;
     AsyncJob::Start(cs);
-
-    FwdStateExitThrowingCode([] { /* no conn to cleanup yet */ });
 }
 
 /// send request on an existing connection dedicated to the requesting client

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -807,7 +807,6 @@ FwdState::establishTunnelThruProxy(const Comm::ConnectionPointer &conn)
                                             Http::Tunneler::CbDialer<FwdState>(&FwdState::tunnelEstablishmentDone, this));
     HttpRequest::Pointer requestPointer = request;
     const auto tunneler = new Http::Tunneler(conn, requestPointer, callback, connectingTimeout(serverConnection()), al);
-    tunneler->usesPconn_ = true;
 #if USE_DELAY_POOLS
     Must(serverConnection()->getPeer());
     if (!serverConnection()->getPeer()->options.no_delay)
@@ -885,7 +884,6 @@ FwdState::secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &conn)
         else
 #endif
             connector = new Security::BlindPeerConnector(requestPointer, conn, callback, al, sslNegotiationTimeout);
-        connector->usesPconn_ = true;
         AsyncJob::Start(connector); // will call our callback
         return;
     }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -807,6 +807,7 @@ FwdState::establishTunnelThruProxy(const Comm::ConnectionPointer &conn)
                                             Http::Tunneler::CbDialer<FwdState>(&FwdState::tunnelEstablishmentDone, this));
     HttpRequest::Pointer requestPointer = request;
     const auto tunneler = new Http::Tunneler(conn, requestPointer, callback, connectingTimeout(serverConnection()), al);
+    tunneler->usesPconn_ = true;
 #if USE_DELAY_POOLS
     Must(serverConnection()->getPeer());
     if (!serverConnection()->getPeer()->options.no_delay)
@@ -884,6 +885,7 @@ FwdState::secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &conn)
         else
 #endif
             connector = new Security::BlindPeerConnector(requestPointer, conn, callback, al, sslNegotiationTimeout);
+        connector->usesPconn_ = true;
         AsyncJob::Start(connector); // will call our callback
         return;
     }

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -135,10 +135,10 @@ private:
     void connectedToPeer(Security::EncryptorAnswer &answer);
     static void RegisterWithCacheManager(void);
 
-    void establishTunnelThruProxy();
+    void establishTunnelThruProxy(const Comm::ConnectionPointer &);
     void tunnelEstablishmentDone(Http::TunnelerAnswer &answer);
-    void secureConnectionToPeerIfNeeded();
-    void successfullyConnectedToPeer();
+    void secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &);
+    void successfullyConnectedToPeer(const Comm::ConnectionPointer &);
 
     /// stops monitoring server connection for closure and updates pconn stats
     void closeServerConnection(const char *reason);

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -102,6 +102,9 @@ public:
 
     void dontRetry(bool val) { flags.dont_retry = val; }
 
+    /// get rid of a to-server connection that failed to become serverConn
+    void closePendingConnection(const Comm::ConnectionPointer &conn, const char *reason);
+
     /** return a ConnectionPointer to the current server connection (may or may not be open) */
     Comm::ConnectionPointer const & serverConnection() const { return serverConn; };
 
@@ -131,6 +134,9 @@ private:
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;
 
+    template <typename StepStart>
+    void advanceDestination(const char *stepDescription, const Comm::ConnectionPointer &conn, const StepStart &startStep);
+
     ErrorState *makeConnectingError(const err_type type) const;
     void connectedToPeer(Security::EncryptorAnswer &answer);
     static void RegisterWithCacheManager(void);
@@ -138,6 +144,7 @@ private:
     void establishTunnelThruProxy(const Comm::ConnectionPointer &);
     void tunnelEstablishmentDone(Http::TunnelerAnswer &answer);
     void secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &);
+    void secureConnectionToPeer(const Comm::ConnectionPointer &conn);
     void successfullyConnectedToPeer(const Comm::ConnectionPointer &);
 
     /// stops monitoring server connection for closure and updates pconn stats

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -89,7 +89,6 @@ void
 Http::Tunneler::handleConnectionClosure(const CommCloseCbParams &params)
 {
     bailWith(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
-    mustStop("server connection gone");
 }
 
 /// make sure we quit if/when the connection is gone
@@ -112,7 +111,6 @@ void
 Http::Tunneler::handleTimeout(const CommTimeoutCbParams &)
 {
     bailWith(new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al));
-    mustStop("server connection timedout");
 }
 
 void

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -117,7 +117,6 @@ Http::Tunneler::handleException(const std::exception& e)
 {
     debugs(83, 2, e.what() << status());
     bailWith(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
-    connection->close();
 }
 
 void
@@ -243,7 +242,6 @@ Http::Tunneler::handleReadyRead(const CommIoCbParams &io)
         const auto error = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, request.getRaw(), al);
         error->xerrno = rd.xerrno;
         bailWith(error);
-        connection->close();
         return;
     }
     }
@@ -354,14 +352,22 @@ Http::Tunneler::bailWith(ErrorState *error)
     Must(error);
     answer().squidError = error;
     callBack();
+    disconnect(true);
 }
 
 void
-Http::Tunneler::callBack()
+Http::Tunneler::sendSuccess()
 {
-    debugs(83, 5, connection << status());
-    auto cb = callback;
-    callback = nullptr;
+    assert(answer().positive());
+    callBack();
+    disconnect(false);
+}
+
+void
+Http::Tunneler::disconnect(const bool andClose)
+{
+    if (!connection)
+        return;
 
     // remove close handler
     comm_remove_close_handler(connection->fd, closer);
@@ -370,6 +376,18 @@ Http::Tunneler::callBack()
     // remove connection timeout handler
     commUnsetConnTimeout(connection);
 
+    if (andClose) {
+        connection->close();
+        connection = nullptr;
+    }
+}
+
+void
+Http::Tunneler::callBack()
+{
+    debugs(83, 5, connection << status());
+    auto cb = callback;
+    callback = nullptr;
     ScheduleCallHere(cb);
 }
 
@@ -380,19 +398,13 @@ Http::Tunneler::swanSong()
 
     if (callback) {
         if (requestWritten && tunnelEstablished) {
-            assert(answer().positive());
-            callBack(); // success
+            sendSuccess();
         } else {
             // we should have bailed when we discovered the job-killing problem
             debugs(83, DBG_IMPORTANT, "BUG: Unexpected state while establishing a CONNECT tunnel " << connection << status());
             bailWith(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
         }
         assert(!callback);
-    }
-
-    if (closer) {
-        comm_remove_close_handler(connection->fd, closer);
-        closer = nullptr;
     }
 
     if (reader) {

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -27,6 +27,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Http, Tunneler);
 
 Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest::Pointer &req, AsyncCall::Pointer &aCallback, time_t timeout, const AccessLogEntryPointer &alp):
     AsyncJob("Http::Tunneler"),
+    usesPconn_(false),
     connection(conn),
     request(req),
     callback(aCallback),
@@ -383,6 +384,8 @@ Http::Tunneler::disconnect(const bool andClose)
     commUnsetConnTimeout(connection);
 
     if (andClose) {
+        if (usesPconn_)
+            fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
         connection->close();
         connection = nullptr;
     }

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -374,9 +374,10 @@ Http::Tunneler::disconnect(const bool andClose)
     if (!connection)
         return;
 
-    // remove close handler
-    comm_remove_close_handler(connection->fd, closer);
-    closer = nullptr;
+    if (closer) {
+        comm_remove_close_handler(connection->fd, closer);
+        closer = nullptr;
+    }
 
     // remove connection timeout handler
     commUnsetConnTimeout(connection);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -361,6 +361,7 @@ Http::Tunneler::bailWith(ErrorState *error)
 
     if (noteFwdPconnUse)
         fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
+    // TODO: Reuse to-peer connections after a CONNECT error response.
     connection->close();
     connection = nullptr;
 }

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -85,8 +85,8 @@ Http::Tunneler::start()
 void
 Http::Tunneler::handleConnectionClosure(const CommCloseCbParams &params)
 {
+    bailWith(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
     mustStop("server connection gone");
-    callback = nullptr; // the caller must monitor closures
 }
 
 /// make sure we quit if/when the connection is gone
@@ -104,12 +104,20 @@ Http::Tunneler::watchForClosures()
     comm_add_close_handler(connection->fd, closer);
 }
 
+/// The connection read timeout callback handler.
+void
+Http::Tunneler::handleTimeout(const CommTimeoutCbParams &)
+{
+    bailWith(new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al));
+    mustStop("server connection timedout");
+}
+
 void
 Http::Tunneler::handleException(const std::exception& e)
 {
     debugs(83, 2, e.what() << status());
-    connection->close();
     bailWith(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
+    connection->close();
 }
 
 void
@@ -235,6 +243,7 @@ Http::Tunneler::handleReadyRead(const CommIoCbParams &io)
         const auto error = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, request.getRaw(), al);
         error->xerrno = rd.xerrno;
         bailWith(error);
+        connection->close();
         return;
     }
     }
@@ -254,8 +263,11 @@ Http::Tunneler::readMore()
     Comm::Read(connection, reader);
 
     AsyncCall::Pointer nil;
+    typedef CommCbMemFunT<Http::Tunneler, CommTimeoutCbParams> TimeoutDialer;
+    AsyncCall::Pointer timeoutCall = JobCallback(93, 5,
+                                     TimeoutDialer, this, Http::Tunneler::handleTimeout);
     const auto timeout = Comm::MortalReadTimeout(startTime, lifetimeLimit);
-    commSetConnTimeout(connection, timeout, nil);
+    commSetConnTimeout(connection, timeout, timeoutCall);
 }
 
 /// Parses [possibly incomplete] CONNECT response and reacts to it.
@@ -350,6 +362,14 @@ Http::Tunneler::callBack()
     debugs(83, 5, connection << status());
     auto cb = callback;
     callback = nullptr;
+
+    // remove close handler
+    comm_remove_close_handler(connection->fd, closer);
+    closer = nullptr;
+
+    // remove connection timeout handler
+    commUnsetConnTimeout(connection);
+
     ScheduleCallHere(cb);
 }
 

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -27,7 +27,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Http, Tunneler);
 
 Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest::Pointer &req, AsyncCall::Pointer &aCallback, time_t timeout, const AccessLogEntryPointer &alp):
     AsyncJob("Http::Tunneler"),
-    usesPconn_(false),
+    noteFwdPconnUse(false),
     connection(conn),
     request(req),
     callback(aCallback),
@@ -359,7 +359,7 @@ Http::Tunneler::bailWith(ErrorState *error)
     callBack();
     disconnect();
 
-    if (usesPconn_)
+    if (noteFwdPconnUse)
         fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
     connection->close();
     connection = nullptr;

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -121,6 +121,18 @@ Http::Tunneler::handleException(const std::exception& e)
 }
 
 void
+Http::Tunneler::callException(const std::exception &e)
+{
+    debugs(83, 5, status());
+    try {
+        handleException(e);
+    } catch (const std::exception &ex) {
+        debugs(83, DBG_CRITICAL, ex.what());
+    }
+    AsyncJob::callException(e);
+}
+
+void
 Http::Tunneler::startReadingResponse()
 {
     debugs(83, 5, connection << status());

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -44,6 +44,7 @@ Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest:
     assert(callback);
     assert(dynamic_cast<Http::TunnelerAnswer *>(callback->getDialer()));
     url = request->url.authority();
+    watchForClosures();
 }
 
 Http::Tunneler::~Tunneler()
@@ -80,7 +81,6 @@ Http::Tunneler::start()
     Must(peer); // bail if our peer was reconfigured away
     request->prepForPeering(*peer);
 
-    watchForClosures();
     writeRequest();
     startReadingResponse();
 }

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -144,8 +144,8 @@ Http::Tunneler::startReadingResponse()
 void
 Http::Tunneler::writeRequest()
 {
-    Must(Comm::IsConnOpen(connection));
-    Must(!fd_table[connection->fd].closing());
+    if (!Comm::IsConnOpen(connection) || fd_table[connection->fd].closing())
+        return;
 
     debugs(83, 5, connection);
 

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -132,6 +132,9 @@ Http::Tunneler::startReadingResponse()
 void
 Http::Tunneler::writeRequest()
 {
+    Must(Comm::IsConnOpen(connection));
+    Must(!fd_table[connection->fd].closing());
+
     debugs(83, 5, connection);
 
     Http::StateFlags flags;

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -18,6 +18,8 @@
 #include "http/one/ResponseParser.h"
 #include "http/StateFlags.h"
 #include "HttpRequest.h"
+#include "neighbors.h"
+#include "pconn.h"
 #include "SquidConfig.h"
 #include "StatCounters.h"
 
@@ -25,6 +27,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Http, Tunneler);
 
 Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest::Pointer &req, AsyncCall::Pointer &aCallback, time_t timeout, const AccessLogEntryPointer &alp):
     AsyncJob("Http::Tunneler"),
+    usesPconn_(false),
     connection(conn),
     request(req),
     callback(aCallback),
@@ -351,6 +354,10 @@ Http::Tunneler::bailWith(ErrorState *error)
 {
     Must(error);
     answer().squidError = error;
+
+    if (CachePeer *p = connection->getPeer())
+        peerConnectFailed(p);
+
     callBack();
     disconnect(true);
 }
@@ -377,6 +384,8 @@ Http::Tunneler::disconnect(const bool andClose)
     commUnsetConnTimeout(connection);
 
     if (andClose) {
+        if (usesPconn_)
+            fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
         connection->close();
         connection = nullptr;
     }
@@ -386,6 +395,7 @@ void
 Http::Tunneler::callBack()
 {
     debugs(83, 5, connection << status());
+    answer().conn = connection;
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -27,7 +27,6 @@ CBDATA_NAMESPACED_CLASS_INIT(Http, Tunneler);
 
 Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest::Pointer &req, AsyncCall::Pointer &aCallback, time_t timeout, const AccessLogEntryPointer &alp):
     AsyncJob("Http::Tunneler"),
-    usesPconn_(false),
     connection(conn),
     request(req),
     callback(aCallback),
@@ -384,8 +383,6 @@ Http::Tunneler::disconnect(const bool andClose)
     commUnsetConnTimeout(connection);
 
     if (andClose) {
-        if (usesPconn_)
-            fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
         connection->close();
         connection = nullptr;
     }

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -395,7 +395,8 @@ void
 Http::Tunneler::callBack()
 {
     debugs(83, 5, connection << status());
-    answer().conn = connection;
+    if (answer().positive())
+        answer().conn = connection;
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -357,7 +357,12 @@ Http::Tunneler::bailWith(ErrorState *error)
         peerConnectFailed(p);
 
     callBack();
-    disconnect(true);
+    disconnect();
+
+    if (usesPconn_)
+        fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
+    connection->close();
+    connection = nullptr;
 }
 
 void
@@ -365,11 +370,11 @@ Http::Tunneler::sendSuccess()
 {
     assert(answer().positive());
     callBack();
-    disconnect(false);
+    disconnect();
 }
 
 void
-Http::Tunneler::disconnect(const bool andClose)
+Http::Tunneler::disconnect()
 {
     if (!connection)
         return;
@@ -381,13 +386,6 @@ Http::Tunneler::disconnect(const bool andClose)
 
     // remove connection timeout handler
     commUnsetConnTimeout(connection);
-
-    if (andClose) {
-        if (usesPconn_)
-            fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
-        connection->close();
-        connection = nullptr;
-    }
 }
 
 void

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -81,6 +81,7 @@ protected:
 
     void handleConnectionClosure(const CommCloseCbParams&);
     void watchForClosures();
+    void handleTimeout(const CommTimeoutCbParams &);
     void handleException(const std::exception&);
     void startReadingResponse();
     void writeRequest();

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -30,11 +30,9 @@ namespace Http
 ///
 /// The caller receives a call back with Http::TunnelerAnswer.
 ///
-/// The caller must monitor the connection for closure because this job will not
-/// inform the caller about such events.
+/// The job reports success, errors or connection closures to the caller.
 ///
-/// This job never closes the connection, even on errors. If a 3rd-party closes
-/// the connection, this job simply quits without informing the caller.
+/// This job may close the connection on timeout.
 class Tunneler: virtual public AsyncJob
 {
     CBDATA_CLASS(Tunneler);

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -97,7 +97,7 @@ protected:
     void callBack();
 
     /// A bailWith(), sendSuccess() helper: stops monitoring the connection.
-    void disconnect(const bool andClose);
+    void disconnect();
 
     TunnelerAnswer &answer();
 

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -65,7 +65,8 @@ public:
     void setDelayId(DelayId delay_id) {delayId = delay_id;}
 #endif
 
-    bool usesPconn_; ///< whether persistent connections are supported
+    /// hack: whether the connection requires fwdPconnPool->noteUses()
+    bool noteFwdPconnUse;
 
 protected:
     /* AsyncJob API */

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -88,8 +88,20 @@ protected:
     void readMore();
     void handleResponse(const bool eof);
     void bailOnResponseError(const char *error, HttpReply *);
+
+    /// Return an error to the caller
     void bailWith(ErrorState*);
+
+    /// Return a ready to use connection to the caller
+    void sendSuccess();
+
+    /// Callback the caller class, and pass the ready to use
+    /// connection or an error if Tunneler failed.
     void callBack();
+
+    /// Stop monitoring the connection
+    /// \param andClose if true also closes the connection
+    void disconnect(const bool andClose);
 
     TunnelerAnswer &answer();
 

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -26,13 +26,9 @@ typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
 namespace Http
 {
 
-/// Establishes an HTTP CONNECT tunnel through a forward proxy.
-///
-/// The caller receives a call back with Http::TunnelerAnswer.
-///
-/// The job reports success, errors or connection closures to the caller.
-///
-/// This job may close the connection on timeout.
+/// Negotiates an HTTP CONNECT tunnel through a forward proxy using a given
+/// (open and, if needed, encrypted) TCP connection to that proxy. Owns the
+/// connection during these negotiations. The caller receives TunnelerAnswer.
 class Tunneler: virtual public AsyncJob
 {
     CBDATA_CLASS(Tunneler);
@@ -70,6 +66,7 @@ public:
 #endif
 
     bool usesPconn_; ///< whether persistent connections are supported
+
 protected:
     /* AsyncJob API */
     virtual ~Tunneler();
@@ -90,18 +87,16 @@ protected:
     void handleResponse(const bool eof);
     void bailOnResponseError(const char *error, HttpReply *);
 
-    /// Return an error to the caller
+    /// Sends the given error to the initiator.
     void bailWith(ErrorState*);
 
-    /// Return a ready to use connection to the caller
+    /// Sends the ready-to-use tunnel to the initiator.
     void sendSuccess();
 
-    /// Callback the caller class, and pass the ready to use
-    /// connection or an error if Tunneler failed.
+    /// A bailWith(), sendSuccess() helper: sends results to the initiator.
     void callBack();
 
-    /// Stop monitoring the connection
-    /// \param andClose if true also closes the connection
+    /// A bailWith(), sendSuccess() helper: stops monitoring the connection.
     void disconnect(const bool andClose);
 
     TunnelerAnswer &answer();

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -69,6 +69,7 @@ public:
     void setDelayId(DelayId delay_id) {delayId = delay_id;}
 #endif
 
+    bool usesPconn_; ///< whether persistent connections are supported
 protected:
     /* AsyncJob API */
     virtual ~Tunneler();

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -65,6 +65,9 @@ public:
     void setDelayId(DelayId delay_id) {delayId = delay_id;}
 #endif
 
+    /* AsyncJob API */
+    virtual void callException(const std::exception &e);
+
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;
 

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -69,7 +69,6 @@ public:
     void setDelayId(DelayId delay_id) {delayId = delay_id;}
 #endif
 
-    bool usesPconn_; ///< whether persistent connections are supported
 protected:
     /* AsyncJob API */
     virtual ~Tunneler();

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -66,7 +66,7 @@ public:
 #endif
 
     /* AsyncJob API */
-    virtual void callException(const std::exception &e);
+    virtual void callException(const std::exception &);
 
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -88,16 +88,16 @@ protected:
     void handleResponse(const bool eof);
     void bailOnResponseError(const char *error, HttpReply *);
 
-    /// Sends the given error to the initiator.
+    /// sends the given error to the initiator
     void bailWith(ErrorState*);
 
-    /// Sends the ready-to-use tunnel to the initiator.
+    /// sends the ready-to-use tunnel to the initiator
     void sendSuccess();
 
-    /// A bailWith(), sendSuccess() helper: sends results to the initiator.
+    /// a bailWith(), sendSuccess() helper: sends results to the initiator
     void callBack();
 
-    /// A bailWith(), sendSuccess() helper: stops monitoring the connection.
+    /// a bailWith(), sendSuccess() helper: stops monitoring the connection
     void disconnect();
 
     TunnelerAnswer &answer();

--- a/src/clients/HttpTunnelerAnswer.cc
+++ b/src/clients/HttpTunnelerAnswer.cc
@@ -32,6 +32,8 @@ Http::operator <<(std::ostream &os, const TunnelerAnswer &answer)
     if (answer.peerResponseStatus != Http::scNone)
         os << ' ' << answer.peerResponseStatus;
 
+    os << ' ' << answer.conn;
+
     os << ']';
     return os;
 }

--- a/src/clients/HttpTunnelerAnswer.cc
+++ b/src/clients/HttpTunnelerAnswer.cc
@@ -32,7 +32,8 @@ Http::operator <<(std::ostream &os, const TunnelerAnswer &answer)
     if (answer.peerResponseStatus != Http::scNone)
         os << ' ' << answer.peerResponseStatus;
 
-    os << ' ' << answer.conn;
+    if (answer.conn)
+        os << ' ' << answer.conn;
 
     os << ']';
     return os;

--- a/src/clients/HttpTunnelerAnswer.h
+++ b/src/clients/HttpTunnelerAnswer.h
@@ -43,6 +43,8 @@ public:
 
     /// the status code of the successfully parsed CONNECT response (or scNone)
     StatusCode peerResponseStatus = scNone;
+
+    Comm::ConnectionPointer conn;
 };
 
 std::ostream &operator <<(std::ostream &, const Http::TunnelerAnswer &);

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -7,6 +7,7 @@
  */
 
 #include "squid.h"
+#include "AccessLogEntry.h"
 #include "CachePeer.h"
 #include "comm/Connection.h"
 #include "errorpage.h"

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -561,18 +561,23 @@ Security::PeerConnector::bail(ErrorState *error)
         peerConnectFailed(p);
 
     callBack();
-    disconnect(true);
+    disconnect();
+
+    if (usesPconn_)
+        fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
+    serverConn->close();
+    serverConn = nullptr;
 }
 
 void
 Security::PeerConnector::sendSuccess()
 {
     callBack();
-    disconnect(false);
+    disconnect();
 }
 
 void
-Security::PeerConnector::disconnect(const bool andClose)
+Security::PeerConnector::disconnect()
 {
     if (closeHandler) {
         comm_remove_close_handler(serverConnection()->fd, closeHandler);
@@ -580,13 +585,6 @@ Security::PeerConnector::disconnect(const bool andClose)
     }
 
     commUnsetConnTimeout(serverConnection());
-
-    if (andClose) {
-        if (usesPconn_)
-            fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
-        serverConn->close();
-        serverConn = nullptr;
-    }
 }
 
 void

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -56,11 +56,6 @@ Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerCon
     comm_add_close_handler(serverConn->fd, closeHandler);
 }
 
-Security::PeerConnector::~PeerConnector()
-{
-    // TODO: Remove if it stays empty.
-}
-
 bool Security::PeerConnector::doneAll() const
 {
     return (!callback || callback->canceled()) && AsyncJob::doneAll();
@@ -91,7 +86,7 @@ void
 Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
 {
     debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
-    auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
+    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
 }
@@ -100,7 +95,7 @@ void
 Security::PeerConnector::connectionClosed(const char *reason)
 {
     debugs(83, 5, reason << " socket closed/closing. this=" << (void*)this);
-    auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
+    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
 }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -82,8 +82,7 @@ Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
     auto anErr = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
     anErr->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(anErr);
-    if (Comm::IsConnOpen(serverConnection()))
-        serverConnection()->close();
+    serverConnection()->close();
     mustStop("Timedout");
 }
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -34,7 +34,6 @@ CBDATA_NAMESPACED_CLASS_INIT(Security, PeerConnector);
 
 Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerConn, AsyncCall::Pointer &aCallback, const AccessLogEntryPointer &alp, const time_t timeout) :
     AsyncJob("Security::PeerConnector"),
-    usesPconn_(false),
     serverConn(aServerConn),
     al(alp),
     callback(aCallback),
@@ -583,8 +582,6 @@ Security::PeerConnector::disconnect(const bool andClose)
     commUnsetConnTimeout(serverConnection());
 
     if (andClose) {
-        if (usesPconn_)
-            fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
         serverConn->close();
         serverConn = nullptr;
     }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -76,11 +76,25 @@ Security::PeerConnector::commCloseHandler(const CommCloseCbParams &params)
 }
 
 void
+Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
+{
+    debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
+    auto anErr = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
+    anErr->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+    bail(anErr);
+    if (Comm::IsConnOpen(serverConnection()))
+        serverConnection()->close();
+    mustStop("Timedout");
+}
+
+void
 Security::PeerConnector::connectionClosed(const char *reason)
 {
     debugs(83, 5, reason << " socket closed/closing. this=" << (void*)this);
+    auto anErr = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
+    anErr->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+    bail(anErr);
     mustStop(reason);
-    callback = NULL;
 }
 
 bool
@@ -471,9 +485,11 @@ Security::PeerConnector::noteWantRead()
 #endif
 
     // read timeout to avoid getting stuck while reading from a silent server
-    AsyncCall::Pointer nil;
+    typedef CommCbMemFunT<Security::PeerConnector, CommTimeoutCbParams> TimeoutDialer;
+    AsyncCall::Pointer timeoutCall = JobCallback(83, 5,
+                                     TimeoutDialer, this, Security::PeerConnector::commTimeoutHandler);
     const auto timeout = Comm::MortalReadTimeout(startTime, negotiationTimeout);
-    commSetConnTimeout(serverConnection(), timeout, nil);
+    commSetConnTimeout(serverConnection(), timeout, timeoutCall);
 
     Comm::SetSelect(fd, COMM_SELECT_READ, &NegotiateSsl, new Pointer(this), 0);
 }
@@ -564,6 +580,9 @@ Security::PeerConnector::callBack()
 
     // remove close handler
     comm_remove_close_handler(serverConnection()->fd, closeHandler);
+
+    // remove timeout handler
+    commUnsetConnTimeout(serverConnection());
 
     CbDialer *dialer = dynamic_cast<CbDialer*>(cb->getDialer());
     Must(dialer);

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -87,7 +87,9 @@ Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
 {
     debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
     const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
+#if USE_OPENSSL
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+#endif
     bail(err);
 }
 
@@ -96,7 +98,9 @@ Security::PeerConnector::connectionClosed(const char *reason)
 {
     debugs(83, 5, reason << " socket closed/closing. this=" << (void*)this);
     const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
+#if USE_OPENSSL
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+#endif
     bail(err);
 }
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -82,7 +82,6 @@ Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
     auto anErr = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
     anErr->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(anErr);
-    serverConnection()->close();
     mustStop("Timedout");
 }
 
@@ -217,7 +216,7 @@ Security::PeerConnector::negotiate()
     if (!sslFinalized())
         return;
 
-    callBack();
+    sendSuccess();
 }
 
 bool
@@ -254,7 +253,6 @@ Security::PeerConnector::sslFinalized()
 
             noteNegotiationDone(anErr);
             bail(anErr);
-            serverConn->close();
             return true;
         }
     }
@@ -294,7 +292,7 @@ Security::PeerConnector::sslCrtvdHandleReply(Ssl::CertValidationResponse::Pointe
 
     if (!errDetails && !validatorFailed) {
         noteNegotiationDone(NULL);
-        callBack();
+        sendSuccess();
         return;
     }
 
@@ -309,7 +307,6 @@ Security::PeerConnector::sslCrtvdHandleReply(Ssl::CertValidationResponse::Pointe
 
     noteNegotiationDone(anErr);
     bail(anErr);
-    serverConn->close();
     return;
 }
 #endif
@@ -559,12 +556,29 @@ Security::PeerConnector::bail(ErrorState *error)
     dialer->answer().error = error;
 
     callBack();
-    // Our job is done. The callabck recepient will probably close the failed
-    // peer connection and try another peer or go direct (if possible). We
-    // can close the connection ourselves (our error notification would reach
-    // the recepient before the fd-closure notification), but we would rather
-    // minimize the number of fd-closure notifications and let the recepient
-    // manage the TCP state of the connection.
+    disconnect(true);
+}
+
+void
+Security::PeerConnector::sendSuccess()
+{
+    callBack();
+    disconnect(false);
+}
+
+void
+Security::PeerConnector::disconnect(const bool andClose)
+{
+    // remove close handler
+    comm_remove_close_handler(serverConnection()->fd, closeHandler);
+
+    // remove timeout handler
+    commUnsetConnTimeout(serverConnection());
+
+    if (andClose) {
+        serverConn->close();
+        serverConn = nullptr;
+    }
 }
 
 void
@@ -576,13 +590,6 @@ Security::PeerConnector::callBack()
     // Do this now so that if we throw below, swanSong() assert that we _tried_
     // to call back holds.
     callback = NULL; // this should make done() true
-
-    // remove close handler
-    comm_remove_close_handler(serverConnection()->fd, closeHandler);
-
-    // remove timeout handler
-    commUnsetConnTimeout(serverConnection());
-
     CbDialer *dialer = dynamic_cast<CbDialer*>(cb->getDialer());
     Must(dialer);
     dialer->answer().conn = serverConnection();

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -83,9 +83,9 @@ void
 Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
 {
     debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
-    auto anErr = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
-    anErr->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
-    bail(anErr);
+    auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
+    err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+    bail(err);
     mustStop("Timedout");
 }
 
@@ -93,9 +93,9 @@ void
 Security::PeerConnector::connectionClosed(const char *reason)
 {
     debugs(83, 5, reason << " socket closed/closing. this=" << (void*)this);
-    auto anErr = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
-    anErr->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
-    bail(anErr);
+    auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
+    err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+    bail(err);
     mustStop(reason);
 }
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -15,8 +15,11 @@
 #include "Downloader.h"
 #include "errorpage.h"
 #include "fde.h"
+#include "FwdState.h"
 #include "http/Stream.h"
 #include "HttpRequest.h"
+#include "neighbors.h"
+#include "pconn.h"
 #include "security/NegotiationHistory.h"
 #include "security/PeerConnector.h"
 #include "SquidConfig.h"
@@ -31,6 +34,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Security, PeerConnector);
 
 Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerConn, AsyncCall::Pointer &aCallback, const AccessLogEntryPointer &alp, const time_t timeout) :
     AsyncJob("Security::PeerConnector"),
+    usesPconn_(false),
     serverConn(aServerConn),
     al(alp),
     callback(aCallback),
@@ -555,6 +559,9 @@ Security::PeerConnector::bail(ErrorState *error)
     Must(dialer);
     dialer->answer().error = error;
 
+    if (CachePeer *p = serverConnection()->getPeer())
+        peerConnectFailed(p);
+
     callBack();
     disconnect(true);
 }
@@ -576,6 +583,8 @@ Security::PeerConnector::disconnect(const bool andClose)
     commUnsetConnTimeout(serverConnection());
 
     if (andClose) {
+        if (usesPconn_)
+            fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
         serverConn->close();
         serverConn = nullptr;
     }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -34,6 +34,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Security, PeerConnector);
 
 Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerConn, AsyncCall::Pointer &aCallback, const AccessLogEntryPointer &alp, const time_t timeout) :
     AsyncJob("Security::PeerConnector"),
+    usesPconn_(false),
     serverConn(aServerConn),
     al(alp),
     callback(aCallback),
@@ -582,6 +583,8 @@ Security::PeerConnector::disconnect(const bool andClose)
     commUnsetConnTimeout(serverConnection());
 
     if (andClose) {
+        if (usesPconn_)
+            fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
         serverConn->close();
         serverConn = nullptr;
     }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -100,6 +100,25 @@ Security::PeerConnector::connectionClosed(const char *reason)
     bail(err);
 }
 
+void
+Security::PeerConnector::handleException(const std::exception& e)
+{
+    debugs(83, 2, e.what() << status());
+    bail(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
+}
+
+void
+Security::PeerConnector::callException(const std::exception &e)
+{
+    debugs(83, 5, status());
+    try {
+        handleException(e);
+    } catch (const std::exception &ex) {
+        debugs(83, DBG_CRITICAL, ex.what());
+    }
+    AsyncJob::callException(e);
+}
+
 bool
 Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
 {

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -86,7 +86,6 @@ Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
     auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
-    mustStop("Timedout");
 }
 
 void
@@ -96,7 +95,6 @@ Security::PeerConnector::connectionClosed(const char *reason)
     auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
-    mustStop(reason);
 }
 
 bool

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -576,10 +576,8 @@ Security::PeerConnector::sendSuccess()
 void
 Security::PeerConnector::disconnect(const bool andClose)
 {
-    // remove close handler
     comm_remove_close_handler(serverConnection()->fd, closeHandler);
 
-    // remove timeout handler
     commUnsetConnTimeout(serverConnection());
 
     if (andClose) {

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -574,7 +574,10 @@ Security::PeerConnector::sendSuccess()
 void
 Security::PeerConnector::disconnect(const bool andClose)
 {
-    comm_remove_close_handler(serverConnection()->fd, closeHandler);
+    if (closeHandler) {
+        comm_remove_close_handler(serverConnection()->fd, closeHandler);
+        closeHandler = nullptr;
+    }
 
     commUnsetConnTimeout(serverConnection());
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -559,7 +559,7 @@ Security::PeerConnector::bail(ErrorState *error)
     Must(dialer);
     dialer->answer().error = error;
 
-    if (CachePeer *p = serverConnection()->getPeer())
+    if (auto *p = serverConnection()->getPeer())
         peerConnectFailed(p);
 
     callBack();

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -34,7 +34,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Security, PeerConnector);
 
 Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerConn, AsyncCall::Pointer &aCallback, const AccessLogEntryPointer &alp, const time_t timeout) :
     AsyncJob("Security::PeerConnector"),
-    usesPconn_(false),
+    noteFwdPconnUse(false),
     serverConn(aServerConn),
     al(alp),
     callback(aCallback),
@@ -563,7 +563,7 @@ Security::PeerConnector::bail(ErrorState *error)
     callBack();
     disconnect();
 
-    if (usesPconn_)
+    if (noteFwdPconnUse)
         fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
     serverConn->close();
     serverConn = nullptr;

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -101,7 +101,7 @@ Security::PeerConnector::connectionClosed(const char *reason)
 }
 
 void
-Security::PeerConnector::handleException(const std::exception& e)
+Security::PeerConnector::handleException(const std::exception &e)
 {
     debugs(83, 2, e.what() << status());
     bail(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -139,16 +139,16 @@ protected:
     /// mimics FwdState to minimize changes to FwdState::initiate/negotiateSsl
     Comm::ConnectionPointer const &serverConnection() const { return serverConn; }
 
-    /// Sends the given error to the initiator.
+    /// sends the given error to the initiator
     void bail(ErrorState *error);
 
-    /// Sends the encrypted connection to the initiator.
+    /// sends the encrypted connection to the initiator
     void sendSuccess();
 
-    /// A bail(), sendSuccess() helper: sends results to the initiator.
+    /// a bail(), sendSuccess() helper: sends results to the initiator
     void callBack();
 
-    /// A bail(), sendSuccess() helper: stops monitoring the connection.
+    /// a bail(), sendSuccess() helper: stops monitoring the connection
     void disconnect();
 
     /// If called the certificates validator will not used

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -59,7 +59,7 @@ public:
                   AsyncCall::Pointer &aCallback,
                   const AccessLogEntryPointer &alp,
                   const time_t timeout = 0);
-    virtual ~PeerConnector();
+    virtual ~PeerConnector() = default;
 
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -64,6 +64,9 @@ public:
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;
 
+    // AsyncJob API
+    virtual void callException(const std::exception &);
+
 protected:
     // AsyncJob API
     virtual void start();
@@ -79,6 +82,9 @@ protected:
 
     /// Inform us that the connection is closed. Does the required clean-up.
     void connectionClosed(const char *reason);
+
+    /// Handle exceptions
+    void handleException(const std::exception &);
 
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -153,7 +153,7 @@ protected:
     void callBack();
 
     /// A bail(), sendSuccess() helper: stops monitoring the connection.
-    void disconnect(const bool andClose);
+    void disconnect();
 
     /// If called the certificates validator will not used
     void bypassCertValidator() {useCertValidator_ = false;}

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -81,7 +81,6 @@ public:
                   const time_t timeout = 0);
     virtual ~PeerConnector();
 
-    bool usesPconn_; ///< Whether persistent connections are supported
 protected:
     // AsyncJob API
     virtual void start();

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -81,9 +81,9 @@ protected:
     void connectionClosed(const char *reason);
 
     /// Sets up TCP socket-related notification callbacks if things go wrong.
-    /// If socket already closed return false, else install the comm_close
+    /// If socket already closed throws, else install the comm_close
     /// handler to monitor the socket.
-    bool prepareSocket();
+    void prepareSocket();
 
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -61,7 +61,8 @@ public:
                   const time_t timeout = 0);
     virtual ~PeerConnector();
 
-    bool usesPconn_; ///< whether the connection came from a fwdPconnPool
+    /// hack: whether the connection requires fwdPconnPool->noteUses()
+    bool noteFwdPconnUse;
 
 protected:
     // AsyncJob API

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -163,9 +163,16 @@ protected:
 
     void bail(ErrorState *error); ///< Return an error to the PeerConnector caller
 
+    /// Return a ready to use connection to the caller
+    void sendSuccess();
+
     /// Callback the caller class, and pass the ready to communicate secure
     /// connection or an error if PeerConnector failed.
     void callBack();
+
+    /// Stop monitoring the connection
+    /// \param andClose if true also closes the connection
+    void disconnect(const bool andClose);
 
     /// If called the certificates validator will not used
     void bypassCertValidator() {useCertValidator_ = false;}

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -42,8 +42,7 @@ namespace Security
  * was not fully established. The error object is suitable for error response
  * generation.
  \par
- * The caller must monitor the connection for closure because this
- * job will not inform the caller about such events.
+ * The job reports to the caller connection closures.
  \par
  * PeerConnector class currently supports a form of TLS negotiation timeout,
  * which is accounted only when sets the read timeout from encrypted peers/servers.
@@ -57,8 +56,7 @@ namespace Security
  * start monitoring earlier and close on timeouts. This change may need to be
  * discussed on squid-dev.
  \par
- * This job never closes the connection, even on errors. If a 3rd-party
- * closes the connection, this job simply quits without informing the caller.
+ * This job may close the connection on timeouts.
  */
 class PeerConnector: virtual public AsyncJob
 {

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -81,6 +81,7 @@ public:
                   const time_t timeout = 0);
     virtual ~PeerConnector();
 
+    bool usesPconn_; ///< Whether persistent connections are supported
 protected:
     // AsyncJob API
     virtual void start();

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -90,6 +90,9 @@ protected:
     virtual void swanSong();
     virtual const char *status() const;
 
+    /// The connection read timeout callback handler.
+    void commTimeoutHandler(const CommTimeoutCbParams &);
+
     /// The comm_close callback handler.
     void commCloseHandler(const CommCloseCbParams &params);
 

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -80,11 +80,6 @@ protected:
     /// Inform us that the connection is closed. Does the required clean-up.
     void connectionClosed(const char *reason);
 
-    /// Sets up TCP socket-related notification callbacks if things go wrong.
-    /// If socket already closed throws, else install the comm_close
-    /// handler to monitor the socket.
-    void prepareSocket();
-
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -57,7 +57,7 @@ void PeerConnector::swanSong() STUB
 const char *PeerConnector::status() const STUB_RETVAL("")
 void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB
 void PeerConnector::connectionClosed(const char *) STUB
-bool PeerConnector::prepareSocket() STUB_RETVAL(false)
+void PeerConnector::prepareSocket() STUB
 bool PeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
 void PeerConnector::negotiate() STUB
 bool PeerConnector::sslFinalized() STUB_RETVAL(false)

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -50,14 +50,15 @@ namespace Security
 {
 PeerConnector::PeerConnector(const Comm::ConnectionPointer &, AsyncCall::Pointer &, const AccessLogEntryPointer &, const time_t) :
     AsyncJob("Security::PeerConnector") {STUB}
-PeerConnector::~PeerConnector() {STUB}
 void PeerConnector::start() STUB
 bool PeerConnector::doneAll() const STUB_RETVAL(true)
 void PeerConnector::swanSong() STUB
+void PeerConnector::callException(const std::exception &) STUB
+void PeerConnector::handleException(const std::exception &) STUB
 const char *PeerConnector::status() const STUB_RETVAL("")
 void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB
+void PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &) STUB
 void PeerConnector::connectionClosed(const char *) STUB
-void PeerConnector::prepareSocket() STUB
 bool PeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
 void PeerConnector::negotiate() STUB
 bool PeerConnector::sslFinalized() STUB_RETVAL(false)
@@ -67,7 +68,9 @@ void PeerConnector::noteWantWrite() STUB
 void PeerConnector::noteNegotiationError(const int, const int, const int) STUB
 //    virtual Security::ContextPointer getTlsContext() = 0;
 void PeerConnector::bail(ErrorState *) STUB
+void PeerConnector::sendSuccess() STUB
 void PeerConnector::callBack() STUB
+void PeerConnector::disconnect() STUB
 void PeerConnector::recordNegotiationDetails() STUB
 }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1027,6 +1027,11 @@ TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answ
         return;
     }
 
+    if (!Comm::IsConnOpen(answer.conn) || fd_table[answer.conn->fd].closing()) {
+        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al), "connecion gone");
+        return;
+    }
+
     connectedToPeer(answer.conn);
 }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -767,6 +767,11 @@ static void
 tunnelStartShoveling(TunnelStateData *tunnelState)
 {
     assert(!tunnelState->waitingForConnectExchange);
+    assert(tunnelState->server.conn);
+    AsyncCall::Pointer timeoutCall = commCbCall(5, 4, "tunnelTimeout",
+                                     CommTimeoutCbPtrFun(tunnelTimeout, tunnelState));
+    commSetConnTimeout(tunnelState->server.conn, Config.Timeout.read, timeoutCall);
+
     *tunnelState->status_ptr = Http::scOkay;
     if (tunnelState->logTag_ptr)
         tunnelState->logTag_ptr->update(LOG_TCP_TUNNEL);
@@ -861,9 +866,6 @@ TunnelStateData::notePeerReadyToShovel(const Comm::ConnectionPointer &conn)
     server.conn = conn;
     // Start monitoring for server-side connection problems
     comm_add_close_handler(server.conn->fd, tunnelServerClosed, this);
-    AsyncCall::Pointer timeoutCall = commCbCall(5, 4, "tunnelTimeout",
-                                     CommTimeoutCbPtrFun(tunnelTimeout, this));
-    commSetConnTimeout(server.conn, Config.Timeout.read, timeoutCall);
 
     if (!clientExpectsConnectResponse())
         tunnelStartShoveling(this); // ssl-bumped connection, be quiet
@@ -1274,10 +1276,6 @@ switchToTunnel(HttpRequest *request, Comm::ConnectionPointer &clientConn, Comm::
         request->prepForPeering(*peer);
     else
         request->prepForDirect();
-
-    AsyncCall::Pointer timeoutCall = commCbCall(5, 4, "tunnelTimeout",
-                                     CommTimeoutCbPtrFun(tunnelTimeout, tunnelState));
-    commSetConnTimeout(srvConn, Config.Timeout.read, timeoutCall);
 
     // we drain any already buffered from-server data below (rBufData)
     fd_table[srvConn->fd].useDefaultIo();

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -113,7 +113,7 @@ public:
     void startConnecting();
 
     /// called when negotiations with the peer have been successfully completed
-    void notePeerReadyToShovel();
+    void notePeerReadyToShovel(const Comm::ConnectionPointer &conn);
 
     class Connection
     {
@@ -177,7 +177,7 @@ public:
     void copyRead(Connection &from, IOCB *completion);
 
     /// continue to set up connection to a peer, going async for SSL peers
-    void connectToPeer();
+    void connectToPeer(const Comm::ConnectionPointer &conn);
 
     /* PeerSelectionInitiator API */
     virtual void noteDestination(Comm::ConnectionPointer conn) override;
@@ -829,7 +829,7 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
     if (answer.positive()) {
         // copy any post-200 OK bytes to our buffer
         preReadServerData = answer.leftovers;
-        notePeerReadyToShovel();
+        notePeerReadyToShovel(answer.conn);
         return;
     }
 
@@ -841,8 +841,8 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 
     if (!clientExpectsConnectResponse()) {
         // closing the non-HTTP client connection is the best we can do
-        debugs(50, 3, server.conn << " closing on CONNECT-to-peer error");
-        server.closeIfOpen();
+        debugs(50, 3, client.conn << " closing on CONNECT-to-peer error");
+        client.closeIfOpen();
         return;
     }
 
@@ -853,8 +853,9 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 }
 
 void
-TunnelStateData::notePeerReadyToShovel()
+TunnelStateData::notePeerReadyToShovel(const Comm::ConnectionPointer &conn)
 {
+    server.conn = conn;
     // Start monitoring for server-side connection problems
     comm_add_close_handler(server.conn->fd, tunnelServerClosed, this);
     AsyncCall::Pointer timeoutCall = commCbCall(5, 4, "tunnelTimeout",
@@ -911,7 +912,6 @@ void
 TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *origin, const bool reused)
 {
     Must(Comm::IsConnOpen(conn));
-    server.conn = conn;
 
     if (reused)
         ResetMarkingsToServer(request.getRaw(), *conn);
@@ -943,9 +943,9 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
     }
 
     if (!toOrigin)
-        connectToPeer();
+        connectToPeer(conn);
     else {
-        notePeerReadyToShovel();
+        notePeerReadyToShovel(conn);
     }
 }
 
@@ -996,20 +996,21 @@ tunnelStart(ClientHttpRequest * http)
 }
 
 void
-TunnelStateData::connectToPeer()
+TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
 {
-    if (CachePeer *p = server.conn->getPeer()) {
+    if (CachePeer *p = conn->getPeer()) {
         if (p->secure.encryptTransport) {
             AsyncCall::Pointer callback = asyncCall(5,4,
                                                     "TunnelStateData::ConnectedToPeer",
                                                     MyAnswerDialer(&TunnelStateData::connectedToPeer, this));
-            auto *connector = new Security::BlindPeerConnector(request, server.conn, callback, al);
+            auto *connector = new Security::BlindPeerConnector(request, conn, callback, al);
             AsyncJob::Start(connector); // will call our callback
             return;
         }
     }
 
     Security::EncryptorAnswer nil;
+    nil.conn = conn;
     connectedToPeer(nil);
 }
 
@@ -1027,7 +1028,7 @@ TunnelStateData::connectedToPeer(Security::EncryptorAnswer &answer)
     AsyncCall::Pointer callback = asyncCall(5,4,
                                             "TunnelStateData::tunnelEstablishmentDone",
                                             Http::Tunneler::CbDialer<TunnelStateData>(&TunnelStateData::tunnelEstablishmentDone, this));
-    const auto tunneler = new Http::Tunneler(server.conn, request, callback, Config.Timeout.lifetime, al);
+    const auto tunneler = new Http::Tunneler(answer.conn, request, callback, Config.Timeout.lifetime, al);
 #if USE_DELAY_POOLS
     tunneler->setDelayId(server.delayId);
 #endif

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -855,6 +855,12 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 void
 TunnelStateData::notePeerReadyToShovel()
 {
+    // Start monitoring for server-side connection problems
+    comm_add_close_handler(server.conn->fd, tunnelServerClosed, this);
+    AsyncCall::Pointer timeoutCall = commCbCall(5, 4, "tunnelTimeout",
+                                     CommTimeoutCbPtrFun(tunnelTimeout, this));
+    commSetConnTimeout(server.conn, Config.Timeout.read, timeoutCall);
+
     if (!clientExpectsConnectResponse())
         tunnelStartShoveling(this); // ssl-bumped connection, be quiet
     else {
@@ -926,7 +932,6 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
     netdbPingSite(request->url.host());
 
     request->peer_host = conn->getPeer() ? conn->getPeer()->host : nullptr;
-    comm_add_close_handler(conn->fd, tunnelServerClosed, this);
 
     bool toOrigin = false; // same semantics as StateFlags::toOrigin
     if (const auto * const peer = conn->getPeer()) {
@@ -942,10 +947,6 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
     else {
         notePeerReadyToShovel();
     }
-
-    AsyncCall::Pointer timeoutCall = commCbCall(5, 4, "tunnelTimeout",
-                                     CommTimeoutCbPtrFun(tunnelTimeout, this));
-    commSetConnTimeout(conn, Config.Timeout.read, timeoutCall);
 }
 
 void

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -111,6 +111,7 @@ public:
     /// starts connecting to the next hop, either for the first time or while
     /// recovering from the previous connect failure
     void startConnecting();
+    void closePendingConnection(const Comm::ConnectionPointer &conn, const char *reason);
 
     void retryOrBail();
 
@@ -180,6 +181,7 @@ public:
 
     /// continue to set up connection to a peer, going async for SSL peers
     void connectToPeer(const Comm::ConnectionPointer &conn);
+    void secureConnectionToPeer(const Comm::ConnectionPointer &);
 
     /* PeerSelectionInitiator API */
     virtual void noteDestination(Comm::ConnectionPointer conn) override;
@@ -238,6 +240,10 @@ private:
 
     /// called after connection setup (including any encryption)
     void connectedToPeer(const Comm::ConnectionPointer &conn);
+    void establishTunnelThruProxy(const Comm::ConnectionPointer &);
+
+    template <typename StepStart>
+    void advanceDestination(const char *stepDescription, const Comm::ConnectionPointer &conn, const StepStart &startStep);
 
     /// details of the "last tunneling attempt" failure (if it failed)
     ErrorState *savedError = nullptr;
@@ -263,17 +269,6 @@ static CLCB tunnelClientClosed;
 static CTCB tunnelTimeout;
 static EVH tunnelDelayedClientRead;
 static EVH tunnelDelayedServerRead;
-
-// TODO: Extract destination-specific handling from TunnelStateData and
-// surround it with a single try/catch,retry block written without these macros.
-/// emulate AsyncJob call protections
-#define TunnelStateEnterThrowingCode() try {
-#define TunnelStateExitThrowingCode(cleanupCode) } \
-    catch (...) { \
-    debugs (26, 2, "exception: " << CurrentException); \
-    cleanupCode(); \
-    retryOrBail(); \
-    }
 
 static void
 tunnelServerClosed(const CommCloseCbParams &params)
@@ -693,6 +688,15 @@ tunnelTimeout(const CommTimeoutCbParams &io)
 }
 
 void
+TunnelStateData::closePendingConnection(const Comm::ConnectionPointer &conn, const char *reason)
+{
+    debugs(26, 3, "because " << reason << "; " << conn);
+    assert(!server.conn);
+    if (IsConnOpen(conn))
+        conn->close();
+}
+
+void
 TunnelStateData::Connection::closeIfOpen()
 {
     if (Comm::IsConnOpen(conn))
@@ -847,18 +851,23 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 
     waitingForConnectExchange = false;
 
-    if (answer.positive()) {
+    bool sawProblem = false;
+
+    if (!answer.positive()) {
+        sawProblem = true;
+        Must(!Comm::IsConnOpen(answer.conn));
+    } else if (!Comm::IsConnOpen(answer.conn) || fd_table[answer.conn->fd].closing()) {
+        sawProblem = true;
+        closePendingConnection(answer.conn, "conn was closed while waiting for tunnelEstablishmentDone");
+    }
+
+    if (!sawProblem) {
+        assert(answer.positive()); // paranoid
         // copy any post-200 OK bytes to our buffer
         preReadServerData = answer.leftovers;
         notePeerReadyToShovel(answer.conn);
         return;
     }
-
-    // TODO: Reuse to-peer connections after a CONNECT error response.
-
-    // TODO: We can and, hence, should close now, but tunnelServerClosed()
-    // cannot yet tell whether ErrorState is still writing an error response.
-    // server.closeIfOpen();
 
     if (!clientExpectsConnectResponse()) {
         // closing the non-HTTP client connection is the best we can do
@@ -867,10 +876,17 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
         return;
     }
 
-    ErrorState *error = answer.squidError.get();
-    Must(error);
-    answer.squidError.clear(); // preserve error for errorSendComplete()
-    sendError(error, "tunneler returns error");
+    ErrorState *error = nullptr;
+    if (answer.positive()) {
+        error = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al);
+    } else {
+        error = answer.squidError.get();
+        Must(error);
+        answer.squidError.clear(); // preserve error for errorSendComplete()
+    }
+    assert(error);
+    saveError(error);
+    retryOrBail();
 }
 
 void
@@ -1039,19 +1055,46 @@ void
 TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
 {
     if (const auto *p = conn->getPeer()) {
-        if (p->secure.encryptTransport) {
-            TunnelStateEnterThrowingCode();
+        if (p->secure.encryptTransport)
+            return advanceDestination("secure connection to peer", conn, [this,&conn] {
+                secureConnectionToPeer(conn);
+            });
+    }
+
+    connectedToPeer(conn);
+}
+
+/// encrypts an established TCP connection to peer
+void
+TunnelStateData::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
+{
+    { // TODO: Remove this diff reduction before commit
+        { // TODO: Remove this diff reduction before commit
             AsyncCall::Pointer callback = asyncCall(5,4,
                                                     "TunnelStateData::ConnectedToPeer",
                                                     MyAnswerDialer(&TunnelStateData::noteSecurityPeerConnectorAnswer, this));
             const auto connector = new Security::BlindPeerConnector(request, conn, callback, al);
             AsyncJob::Start(connector); // will call our callback
-            TunnelStateExitThrowingCode([&conn] { conn->close(); });
-            return;
         }
     }
+}
 
-    connectedToPeer(conn);
+/// starts a preparation step for an established connection; retries on failures
+template <typename StepStart>
+void
+TunnelStateData::advanceDestination(const char *stepDescription, const Comm::ConnectionPointer &conn, const StepStart &startStep)
+{
+    // TODO: Extract destination-specific handling from TunnelStateData so that
+    // all the awkward, limited-scope advanceDestination() calls can be replaced
+    // with a single simple try/catch,retry block.
+    try {
+        startStep();
+        // now wait for the step callback
+    } catch (...) {
+        debugs (26, 2, "exception while trying to " << stepDescription << ": " << CurrentException);
+        closePendingConnection(conn, "connection preparation exception");
+        retryOrBail();
+    }
 }
 
 /// callback handler for the connection encryptor
@@ -1075,7 +1118,17 @@ TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answ
 void
 TunnelStateData::connectedToPeer(const Comm::ConnectionPointer &conn)
 {
-    TunnelStateEnterThrowingCode();
+    advanceDestination("establish tunnel thru proxy", conn, [this,&conn] {
+        establishTunnelThruProxy(conn);
+    });
+    // XXX: In tests, if establishTunnelThruProxy() throws and
+    // advanceDestination() does not close, then conn remains open forever(?).
+    // The expected outcome is a "BUG #3329" warning in ~Connection.
+}
+
+void
+TunnelStateData::establishTunnelThruProxy(const Comm::ConnectionPointer &conn)
+{
     assert(!waitingForConnectExchange);
 
     AsyncCall::Pointer callback = asyncCall(5,4,
@@ -1088,10 +1141,6 @@ TunnelStateData::connectedToPeer(const Comm::ConnectionPointer &conn)
     AsyncJob::Start(tunneler);
     waitingForConnectExchange = true;
     // and wait for the tunnelEstablishmentDone() call
-
-    // XXX: In tests, this conn remains open forever(?) if we do not close it
-    // here. The expected outcome is a "BUG #3329" warning in ~Connection.
-    TunnelStateExitThrowingCode([&conn] { conn->close(); });
 }
 
 void

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -929,18 +929,13 @@ tunnelErrorComplete(int fd/*const Comm::ConnectionPointer &*/, void *data, size_
 void
 TunnelStateData::retryOrBail()
 {
-    assert(!serverDestinations.empty());
-    debugs(26, 4, "removing the failed one from " << serverDestinations.size() <<
-           " destinations: " << serverDestinations.front());
-    serverDestinations.erase(serverDestinations.begin());
-
     // Since no TCP payload has been passed to client or server, we may
     // TCP-connect to other destinations (including alternate IPs).
 
     if (!FwdState::EnoughTimeToReForward(startTime))
         return sendError(savedError, "forwarding timeout");
 
-    if (!serverDestinations.empty())
+    if (!destinations->empty())
         return startConnecting();
 
     if (!PeerSelectionInitiator::subscribed)

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -231,8 +231,11 @@ private:
 
     void usePinned();
 
-    /// callback handler after connection setup (including any encryption)
-    void connectedToPeer(Security::EncryptorAnswer &answer);
+    /// callback handler for the Security::PeerConnector encryptor
+    void noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answer);
+
+    /// called after connection setup (including any encryption)
+    void connectedToPeer(const Comm::ConnectionPointer &conn);
 
     /// details of the "last tunneling attempt" failure (if it failed)
     ErrorState *savedError = nullptr;
@@ -1002,20 +1005,19 @@ TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
         if (p->secure.encryptTransport) {
             AsyncCall::Pointer callback = asyncCall(5,4,
                                                     "TunnelStateData::ConnectedToPeer",
-                                                    MyAnswerDialer(&TunnelStateData::connectedToPeer, this));
+                                                    MyAnswerDialer(&TunnelStateData::noteSecurityPeerConnectorAnswer, this));
             auto *connector = new Security::BlindPeerConnector(request, conn, callback, al);
             AsyncJob::Start(connector); // will call our callback
             return;
         }
     }
 
-    Security::EncryptorAnswer nil;
-    nil.conn = conn;
-    connectedToPeer(nil);
+    connectedToPeer(conn);
 }
 
+    /// callback handler for the connection encryptor
 void
-TunnelStateData::connectedToPeer(Security::EncryptorAnswer &answer)
+TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answer)
 {
     if (ErrorState *error = answer.error.get()) {
         answer.error.clear(); // sendError() will own the error
@@ -1023,12 +1025,18 @@ TunnelStateData::connectedToPeer(Security::EncryptorAnswer &answer)
         return;
     }
 
+    connectedToPeer(answer.conn);
+}
+
+void
+TunnelStateData::connectedToPeer(const Comm::ConnectionPointer &conn)
+{
     assert(!waitingForConnectExchange);
 
     AsyncCall::Pointer callback = asyncCall(5,4,
                                             "TunnelStateData::tunnelEstablishmentDone",
                                             Http::Tunneler::CbDialer<TunnelStateData>(&TunnelStateData::tunnelEstablishmentDone, this));
-    const auto tunneler = new Http::Tunneler(answer.conn, request, callback, Config.Timeout.lifetime, al);
+    const auto tunneler = new Http::Tunneler(conn, request, callback, Config.Timeout.lifetime, al);
 #if USE_DELAY_POOLS
     tunneler->setDelayId(server.delayId);
 #endif

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -112,6 +112,8 @@ public:
     /// recovering from the previous connect failure
     void startConnecting();
 
+    void retryOrBail();
+
     /// called when negotiations with the peer have been successfully completed
     void notePeerReadyToShovel(const Comm::ConnectionPointer &conn);
 
@@ -261,6 +263,17 @@ static CLCB tunnelClientClosed;
 static CTCB tunnelTimeout;
 static EVH tunnelDelayedClientRead;
 static EVH tunnelDelayedServerRead;
+
+// TODO: Extract destination-specific handling from TunnelStateData and
+// surround it with a single try/catch,retry block written without these macros.
+/// emulate AsyncJob call protections
+#define TunnelStateEnterThrowingCode() try {
+#define TunnelStateExitThrowingCode(cleanupCode) } \
+    catch (...) { \
+    debugs (26, 2, "exception: " << CurrentException); \
+    cleanupCode(); \
+    retryOrBail(); \
+    }
 
 static void
 tunnelServerClosed(const CommCloseCbParams &params)
@@ -896,6 +909,28 @@ tunnelErrorComplete(int fd/*const Comm::ConnectionPointer &*/, void *data, size_
         tunnelState->server.conn->close();
 }
 
+/// reacts to the current destination failure
+void
+TunnelStateData::retryOrBail()
+{
+    assert(!serverDestinations.empty());
+    debugs(26, 4, "removing the failed one from " << serverDestinations.size() <<
+           " destinations: " << serverDestinations.front());
+    serverDestinations.erase(serverDestinations.begin());
+
+    // Since no TCP payload has been passed to client or server, we may
+    // TCP-connect to other destinations (including alternate IPs).
+
+    if (!FwdState::EnoughTimeToReForward(startTime))
+        return sendError(savedError, "forwarding timeout");
+
+    if (!serverDestinations.empty())
+        return startConnecting();
+
+    if (!PeerSelectionInitiator::subscribed)
+        return sendError(savedError, "tried all destinations");
+}
+
 void
 TunnelStateData::noteConnection(HappyConnOpener::Answer &answer)
 {
@@ -906,7 +941,7 @@ TunnelStateData::noteConnection(HappyConnOpener::Answer &answer)
         syncHierNote(answer.conn, request->url.host());
         saveError(error);
         answer.error.clear(); // savedError has it now
-        sendError(savedError, "tried all destinations");
+        retryOrBail();
         return;
     }
 
@@ -1005,11 +1040,13 @@ TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
 {
     if (const auto *p = conn->getPeer()) {
         if (p->secure.encryptTransport) {
+            TunnelStateEnterThrowingCode();
             AsyncCall::Pointer callback = asyncCall(5,4,
                                                     "TunnelStateData::ConnectedToPeer",
                                                     MyAnswerDialer(&TunnelStateData::noteSecurityPeerConnectorAnswer, this));
             const auto connector = new Security::BlindPeerConnector(request, conn, callback, al);
             AsyncJob::Start(connector); // will call our callback
+            TunnelStateExitThrowingCode([&conn] { conn->close(); });
             return;
         }
     }
@@ -1038,6 +1075,7 @@ TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answ
 void
 TunnelStateData::connectedToPeer(const Comm::ConnectionPointer &conn)
 {
+    TunnelStateEnterThrowingCode();
     assert(!waitingForConnectExchange);
 
     AsyncCall::Pointer callback = asyncCall(5,4,
@@ -1050,6 +1088,10 @@ TunnelStateData::connectedToPeer(const Comm::ConnectionPointer &conn)
     AsyncJob::Start(tunneler);
     waitingForConnectExchange = true;
     // and wait for the tunnelEstablishmentDone() call
+
+    // XXX: In tests, this conn remains open forever(?) if we do not close it
+    // here. The expected outcome is a "BUG #3329" warning in ~Connection.
+    TunnelStateExitThrowingCode([&conn] { conn->close(); });
 }
 
 void
@@ -1169,6 +1211,8 @@ TunnelStateData::cancelOpening(const char *reason)
 void
 TunnelStateData::startConnecting()
 {
+    TunnelStateEnterThrowingCode();
+
     if (request)
         request->hier.startPeerClock();
 
@@ -1182,6 +1226,8 @@ TunnelStateData::startConnecting()
     destinations->notificationPending = true; // start() is async
     connOpener = cs;
     AsyncJob::Start(cs);
+
+    TunnelStateExitThrowingCode([] { /* no conn to cleanup yet */ });
 }
 
 /// send request on an existing connection dedicated to the requesting client

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1017,7 +1017,7 @@ TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
     connectedToPeer(conn);
 }
 
-    /// callback handler for the connection encryptor
+/// callback handler for the connection encryptor
 void
 TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answer)
 {

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1211,8 +1211,6 @@ TunnelStateData::cancelOpening(const char *reason)
 void
 TunnelStateData::startConnecting()
 {
-    TunnelStateEnterThrowingCode();
-
     if (request)
         request->hier.startPeerClock();
 
@@ -1226,8 +1224,6 @@ TunnelStateData::startConnecting()
     destinations->notificationPending = true; // start() is async
     connOpener = cs;
     AsyncJob::Start(cs);
-
-    TunnelStateExitThrowingCode([] { /* no conn to cleanup yet */ });
 }
 
 /// send request on an existing connection dedicated to the requesting client

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1001,12 +1001,12 @@ tunnelStart(ClientHttpRequest * http)
 void
 TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
 {
-    if (CachePeer *p = conn->getPeer()) {
+    if (const auto *p = conn->getPeer()) {
         if (p->secure.encryptTransport) {
             AsyncCall::Pointer callback = asyncCall(5,4,
                                                     "TunnelStateData::ConnectedToPeer",
                                                     MyAnswerDialer(&TunnelStateData::noteSecurityPeerConnectorAnswer, this));
-            auto *connector = new Security::BlindPeerConnector(request, conn, callback, al);
+            const auto connector = new Security::BlindPeerConnector(request, conn, callback, al);
             AsyncJob::Start(connector); // will call our callback
             return;
         }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -180,7 +180,7 @@ public:
     void copyRead(Connection &from, IOCB *completion);
 
     /// continue to set up connection to a peer, going async for SSL peers
-    void connectToPeer(const Comm::ConnectionPointer &conn);
+    void connectToPeer(const Comm::ConnectionPointer &);
     void secureConnectionToPeer(const Comm::ConnectionPointer &);
 
     /* PeerSelectionInitiator API */
@@ -236,10 +236,10 @@ private:
     void usePinned();
 
     /// callback handler for the Security::PeerConnector encryptor
-    void noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answer);
+    void noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &);
 
     /// called after connection setup (including any encryption)
-    void connectedToPeer(const Comm::ConnectionPointer &conn);
+    void connectedToPeer(const Comm::ConnectionPointer &);
     void establishTunnelThruProxy(const Comm::ConnectionPointer &);
 
     template <typename StepStart>


### PR DESCRIPTION
Before PeerConnector and Tunneler were introduced, FwdState and
TunnelStateData naturally owned their to-server connection. When CONNECT
and TLS negotiation were outsourced, we kept that ownership to minimize
changes and simplify negotiation code. That was wrong because FwdState
and TunnelStateData, as connection owners, had to monitor for connection
closures but could not distinguish basic TCP peer closures from complex
CONNECT/TLS negotiation failures that required further detailing. The
user got generic error messages instead of details known to negotiators.

Now, Ssl::PeerConnector and Http::Tunneler jobs own the connection they
work with and, hence, are responsible for monitoring it and, upon
successful negotiation, returning it to the initiators. In case of
problems, these jobs send detail errors to the initiators instead.

Passing connection ownership to and from a helper job is difficult
because the connection may be either closed or begin to close (e.g. by
shutdown) while the callback is pending without working close handlers.
Many changes focus on keeping Connection::fd in sync with Comm.

Also improved tunnel.cc mimicking of (better) FwdState code: Partially
open connections after Comm::ConnOpener failures are now closed, and
HTTP::Tunneler failures are now retried.

This is a Measurement Factory project.