### PR TITLE
Fixed parsing of TLS messages that span multiple records

### DIFF
--- a/src/parser/BinaryTokenizer.h
+++ b/src/parser/BinaryTokenizer.h
@@ -104,6 +104,9 @@ public:
     /// the number of already parsed bytes
     uint64_t parsed() const { return parsed_; }
 
+    /// the number of unparsed bytes
+    uint64_t unparsed() const { return data_.length() - parsed_; }
+
     /// yet unparsed bytes
     SBuf leftovers() const { return data_.substr(parsed_); }
 

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -271,7 +271,7 @@ Security::HandshakeParser::parseModernRecords()
         }
         catch (const Parser::BinaryTokenizer::InsufficientInput &ii) {
             if (!parsedRecords)
-                throw ii;
+                return;
 
             doneWithRecords = true;
         }
@@ -545,11 +545,11 @@ Security::HandshakeParser::parseHello(const SBuf &data)
         // data contains everything read so far, but we may read more later
         tkRecords.reinput(data, true);
         tkRecords.rollback();
-        while (!done)
-            parseRecords();
-        debugs(83, 7, "success; got: " << done);
+        parseRecords();
+        if (done)
+            debugs(83, 7, "success; got: " << done);
         // we are done; tkRecords may have leftovers we are not interested in
-        return true;
+        return done;
     }
     catch (const Parser::BinaryTokenizer::InsufficientInput &) {
         debugs(83, 5, "need more data");

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -52,7 +52,6 @@ std::ostream &operator <<(std::ostream &os, Security::TlsDetails const &details)
     return details.print(os);
 }
 
-class TLSPlaintext;
 /// Incremental TLS/SSL Handshake parser.
 class HandshakeParser
 {

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -52,6 +52,7 @@ std::ostream &operator <<(std::ostream &os, Security::TlsDetails const &details)
     return details.print(os);
 }
 
+class TLSPlaintext;
 /// Incremental TLS/SSL Handshake parser.
 class HandshakeParser
 {
@@ -79,7 +80,7 @@ private:
     bool isSslv2Record(const SBuf &raw) const;
     void parseRecords();
     void parseModernRecords();
-    void parseOneModernRecord(bool concatRecords);
+    void commitModernRecord(const TLSPlaintext &);
     void parseVersion2Record();
     void parseMessages();
 

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -77,8 +77,9 @@ public:
 
 private:
     bool isSslv2Record(const SBuf &raw) const;
-    void parseRecord();
-    void parseModernRecord();
+    void parseRecords();
+    void parseModernRecords();
+    void parseOneModernRecord(bool concatRecords);
     void parseVersion2Record();
     void parseMessages();
 

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -80,7 +80,7 @@ private:
     bool isSslv2Record(const SBuf &raw) const;
     void parseRecords();
     void parseModernRecords();
-    void commitModernRecord(const TLSPlaintext &);
+    void parseOneModernRecord();
     void parseVersion2Record();
     void parseMessages();
 


### PR DESCRIPTION
... if the servers contain huge certificates, eg while connecting to
1000-sans.badssl.com.  In this cases the server handshake 
messages (which include server certificates) may sent to more than
one TLS records. If squid reads these TLS records in one read, it
fails to parse them correctly and the connection freezes in
squid side waiting for more server TLS data.
    
This is a Measurement Factory project