### PR TITLE
Disabled on-disk partial writes in rock

### DIFF
--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -210,15 +210,15 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
             const auto sidNext = dir->reserveSlotForWriting(); // throws
             assert(sidNext >= 0);
             writeToDisk(sidNext);
-        } else if (false && Store::Root().transientReaders(*e)) {
-            // XXX: partial writes cause errors in SwapDir::droppedEarlierRequest(),
-            // sometimes getting unexpected '-1' slice id. We need to fix that bug
-            // before re-enabling this feature.
-            // XXX: the effective benefit of partial writes is limited by doPages()
-            // buffering (up to SM_PAGE_SIZE).
+            // } else if (Store::Root().transientReaders(*e)) {
+            // XXX: Partial writes cannot be read -- no map->startAppending()!
+            // XXX: Partial writes confuse SwapDir::droppedEarlierRequest(),
+            // resulting in released entries and, hence, misses and CF retries.
+            // XXX: The effective benefit of partial writes is reduced by
+            // doPages() buffering SM_PAGE_SIZE*n leftovers.
 
-            // write partial buffer for all remote hit readers to see
-            writeBufToDisk(-1, false, false);
+            // // write partial buffer for all remote hit readers to see
+            // writeBufToDisk(-1, false, false);
         }
     }
 

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -210,7 +210,13 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
             const auto sidNext = dir->reserveSlotForWriting(); // throws
             assert(sidNext >= 0);
             writeToDisk(sidNext);
-        } else if (Store::Root().transientReaders(*e)) {
+        } else if (false && Store::Root().transientReaders(*e)) {
+            // XXX: partial writes cause errors in SwapDir::droppedEarlierRequest(),
+            // sometimes getting unexpected '-1' slice id. We need to fix that bug
+            // before re-enabling this feature.
+            // XXX: the effective benefit of partial writes is limited by doPages()
+            // buffering (up to SM_PAGE_SIZE).
+
             // write partial buffer for all remote hit readers to see
             writeBufToDisk(-1, false, false);
         }


### PR DESCRIPTION
These writes were re-enabled in 5296bb, which claimed that on-disk
collapsing should work. This collapsing (as well as the shared memory
collapsing) requires the 'read-while-writing' feature, that is
what StoreMap::startAppending() is responsible for.  However, it proved
to be that the ability to read from disk during writing has never been
fully implemented (it is known that just enabling it via
startAppending() is not sufficient). So, for performance sake,
it is better to disable (yet useless) partial writes.

Except this performance issue, there is another problem caused by
93bdc39. droppedEarlierRequest() method, added at that revision, is
incapable of dealing with partial writes, returning an error.  As a
result, the whole entry is marked for deletion, and already collapsed
entries are aborted. Obviously, disabling partial writes resolves
this problem as well.