### PR TITLE
Add a new GeneratingCONNECT value for the existing at_step ACL

### DIFF
--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -165,7 +165,7 @@ Acl::Init()
     RegisterMaker("user_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509UserAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509CAAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509Fingerprint, "-sha1", true), new ACLServerCertificateStrategy, name); });
-    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<int>(new ACLAtStepData, new ACLAtStepStrategy, name); });
+    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<XactionSteps>(new ACLAtStepData, new ACLAtStepStrategy, name); });
     RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLServerNameData, new ACLServerNameStrategy, name); });
     RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLRegexData, new ACLServerNameStrategy, name); });
 #endif

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -165,7 +165,7 @@ Acl::Init()
     RegisterMaker("user_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509UserAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509CAAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509Fingerprint, "-sha1", true), new ACLServerCertificateStrategy, name); });
-    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<Ssl::BumpStep>(new ACLAtStepData, new ACLAtStepStrategy, name); });
+    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<int>(new ACLAtStepData, new ACLAtStepStrategy, name); });
     RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLServerNameData, new ACLServerNameStrategy, name); });
     RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLRegexData, new ACLServerNameStrategy, name); });
 #endif

--- a/src/MasterXaction.h
+++ b/src/MasterXaction.h
@@ -55,6 +55,10 @@ public:
     /// the initiator of this transaction
     XactionInitiator initiator;
 
+    /// It is true while squid is generating a CONNECT request to a peer
+    /// to serve the transaction
+    bool generatingConnect = false;
+
     // TODO: add state from other Jobs in the transaction
 };
 

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -16,24 +16,19 @@
 #include "ssl/ServerBump.h"
 
 int
-ACLAtStepStrategy::match (ACLData<int> * &data, ACLFilledChecklist *checklist)
+ACLAtStepStrategy::match (ACLData<XactionSteps> * &data, ACLFilledChecklist *checklist)
 {
     Must(checklist->request);
     Must(checklist->request->masterXaction);
-    if (checklist->request->masterXaction->generatingConnect && data->match(ACLAtStepData::atStepGeneratingConnect))
+    if (checklist->request->masterXaction->generatingConnect && data->match(xaStepGeneratingConnect))
         return 1;
 
 #if USE_OPENSSL
-    static std::map<Ssl::BumpStep, ACLAtStepData::AtStepValues> BumpAtStepMap= {
-        {Ssl::bumpStep1, ACLAtStepData::atStepSslBump1},
-        {Ssl::bumpStep2, ACLAtStepData::atStepSslBump2},
-        {Ssl::bumpStep3, ACLAtStepData::atStepSslBump3}
-    };
     Ssl::ServerBump *bump = NULL;
     if (checklist->conn() != NULL && (bump = checklist->conn()->serverBump()))
-        return data->match(BumpAtStepMap[bump->step]);
+        return data->match(bump->step);
     else
-        return data->match(BumpAtStepMap[Ssl::bumpStep1]);
+        return data->match(xaStepTlsBump1);
 #endif
     return 0;
 }

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -13,7 +13,9 @@
 #include "acl/FilledChecklist.h"
 #include "client_side.h"
 #include "http/Stream.h"
+#if USE_OPENSSL
 #include "ssl/ServerBump.h"
+#endif
 
 int
 ACLAtStepStrategy::match (ACLData<XactionSteps> * &data, ACLFilledChecklist *checklist)

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -8,8 +8,6 @@
 
 #include "squid.h"
 
-#if USE_OPENSSL
-
 #include "acl/AtStep.h"
 #include "acl/AtStepData.h"
 #include "acl/FilledChecklist.h"
@@ -18,15 +16,24 @@
 #include "ssl/ServerBump.h"
 
 int
-ACLAtStepStrategy::match (ACLData<Ssl::BumpStep> * &data, ACLFilledChecklist *checklist)
+ACLAtStepStrategy::match (ACLData<int> * &data, ACLFilledChecklist *checklist)
 {
+    Must(checklist->request);
+    Must(checklist->request->masterXaction);
+    if (checklist->request->masterXaction->generatingConnect && data->match(ACLAtStepData::atStepGeneratingConnect))
+        return 1;
+
+#if USE_OPENSSL
+    static std::map<Ssl::BumpStep, ACLAtStepData::AtStepValues> BumpAtStepMap= {
+        {Ssl::bumpStep1, ACLAtStepData::atStepSslBump1},
+        {Ssl::bumpStep2, ACLAtStepData::atStepSslBump2},
+        {Ssl::bumpStep3, ACLAtStepData::atStepSslBump3}
+    };
     Ssl::ServerBump *bump = NULL;
     if (checklist->conn() != NULL && (bump = checklist->conn()->serverBump()))
-        return data->match(bump->step);
+        return data->match(BumpAtStepMap[bump->step]);
     else
-        return data->match(Ssl::bumpStep1);
+        return data->match(BumpAtStepMap[Ssl::bumpStep1]);
+#endif
     return 0;
 }
-
-#endif /* USE_OPENSSL */
-

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -10,9 +10,10 @@
 #define SQUID_ACLATSTEP_H
 
 #include "acl/Strategy.h"
+#include "enums.h"
 
 /// \ingroup ACLAPI
-class ACLAtStepStrategy : public ACLStrategy<int>
+class ACLAtStepStrategy : public ACLStrategy<XactionSteps>
 {
 
 public:

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -9,20 +9,16 @@
 #ifndef SQUID_ACLATSTEP_H
 #define SQUID_ACLATSTEP_H
 
-#if USE_OPENSSL
-
 #include "acl/Strategy.h"
-#include "ssl/support.h"
 
 /// \ingroup ACLAPI
-class ACLAtStepStrategy : public ACLStrategy<Ssl::BumpStep>
+class ACLAtStepStrategy : public ACLStrategy<int>
 {
 
 public:
     virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
-#endif /* USE_OPENSSL */
 
 #endif /* SQUID_ACLATSTEP_H */
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -37,7 +37,7 @@ ACLAtStepData::~ACLAtStepData()
 }
 
 bool
-ACLAtStepData::match(int toFind)
+ACLAtStepData::match(XactionSteps toFind)
 {
     for (auto it = values.cbegin(); it != values.cend(); ++it) {
         if (*it == toFind)
@@ -61,7 +61,7 @@ ACLAtStepData::parse()
 {
     while (const char *t = ConfigParser::strtokFile()) {
         const auto at = AtStep(t);
-        if (at == atStepValuesEnd) {
+        if (at == xaStepValuesEnd) {
             debugs(28, DBG_CRITICAL, "FATAL: invalid AtStep step: " << t);
             self_destruct();
         }
@@ -82,21 +82,21 @@ ACLAtStepData::clone() const
 }
 
 const char *
-ACLAtStepData::AtStepStr(int at)
+ACLAtStepData::AtStepStr(XactionSteps at)
 {
-    if (at >=0 && at < atStepValuesEnd)
+    if (at >=0 && at < xaStepValuesEnd)
         return AtStepValuesStr[at];
     else
         return "-";
 }
 
-int
+XactionSteps
 ACLAtStepData::AtStep(const char *atStr)
 {
-    for (auto at = 0; at < atStepValuesEnd; ++at)
+    for (auto at = 0; at < xaStepValuesEnd; ++at)
         if (strcasecmp(atStr, AtStepValuesStr[at]) == 0)
-            return at;
+            return static_cast<XactionSteps>(at);
 
-    return atStepValuesEnd;
+    return xaStepValuesEnd;
 }
 

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -11,37 +11,28 @@
 
 #include "acl/Acl.h"
 #include "acl/Data.h"
+#include "enums.h"
 #include <list>
 
-class ACLAtStepData : public ACLData<int>
+class ACLAtStepData : public ACLData<XactionSteps>
 {
     MEMPROXY_CLASS(ACLAtStepData);
 
 public:
-    enum AtStepValues {
-#if USE_OPENSSL
-        atStepSslBump1,
-        atStepSslBump2,
-        atStepSslBump3,
-#endif
-        atStepGeneratingConnect,
-        atStepValuesEnd
-    };
-
     ACLAtStepData();
     ACLAtStepData(ACLAtStepData const &);
     ACLAtStepData &operator= (ACLAtStepData const &);
     virtual ~ACLAtStepData();
-    bool match(int);
+    bool match(XactionSteps);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
     virtual ACLAtStepData *clone() const;
 
-    static const char *AtStepStr(int);
-    static int AtStep(const char *);
+    static const char *AtStepStr(XactionSteps);
+    static XactionSteps AtStep(const char *);
 
-    std::list<int> values;
+    std::list<XactionSteps> values;
 
 private:
     static const char *AtStepValuesStr[];

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -9,33 +9,43 @@
 #ifndef SQUID_ACLATSTEPDATA_H
 #define SQUID_ACLATSTEPDATA_H
 
-#if USE_OPENSSL
-
 #include "acl/Acl.h"
 #include "acl/Data.h"
-#include "ssl/support.h"
-
 #include <list>
 
-class ACLAtStepData : public ACLData<Ssl::BumpStep>
+class ACLAtStepData : public ACLData<int>
 {
     MEMPROXY_CLASS(ACLAtStepData);
 
 public:
+    enum AtStepValues {
+#if USE_OPENSSL
+        atStepSslBump1,
+        atStepSslBump2,
+        atStepSslBump3,
+#endif
+        atStepGeneratingConnect,
+        atStepValuesEnd
+    };
+
     ACLAtStepData();
     ACLAtStepData(ACLAtStepData const &);
     ACLAtStepData &operator= (ACLAtStepData const &);
     virtual ~ACLAtStepData();
-    bool match(Ssl::BumpStep);
+    bool match(int);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
     virtual ACLAtStepData *clone() const;
 
-    std::list<Ssl::BumpStep> values;
-};
+    static const char *AtStepStr(int);
+    static int AtStep(const char *);
 
-#endif /* USE_OPENSSL */
+    std::list<int> values;
+
+private:
+    static const char *AtStepValuesStr[];
+};
 
 #endif /* SQUID_ACLSSL_ERRORDATA_H */
 

--- a/src/acl/Makefile.am
+++ b/src/acl/Makefile.am
@@ -59,6 +59,10 @@ libacls_la_SOURCES = \
 	AnyOf.h \
 	Asn.cc \
 	Asn.h \
+	AtStep.cc \
+	AtStep.h \
+	AtStepData.cc \
+	AtStepData.h \
 	ConnectionsEncrypted.cc \
 	ConnectionsEncrypted.h \
 	ConnMark.cc \
@@ -154,10 +158,6 @@ libacls_la_SOURCES = \
 EXTRA_libacls_la_SOURCES =
 
 SSL_ACLS = \
-	AtStep.cc \
-	AtStep.h \
-	AtStepData.cc \
-	AtStepData.h \
         CertificateData.cc \
         CertificateData.h  \
         Certificate.cc \

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1350,6 +1350,24 @@ endif
 	  #  acl hasWhatMyLoggingDaemonNeeds has request
 	  #  acl hasWhatMyLoggingDaemonNeeds has response
 
+acl aclname at_step step
+	  # match against various request processing steps [fast]
+	  # Valid steps are:
+	  #   GeneratingCONNECT: While generates and process CONNECT request
+	  #                      to a peer
+IF USE_OPENSSL
+	  # The following steps can also be used to match against the
+	  # current step during ssl_bump evaluation.
+	  # Never matches and should not be used outside the ssl_bump context.
+	  #
+	  # At each SslBump step, Squid evaluates ssl_bump directives to find
+	  # the next bumping action (e.g., peek or splice). Valid SslBump step
+	  # values and the corresponding ssl_bump evaluation moments are:
+	  #   SslBump1: After getting TCP-level and HTTP CONNECT info.
+	  #   SslBump2: After getting SSL Client Hello info.
+	  #   SslBump3: After getting SSL Server Hello info.
+ENDIF
+
 IF USE_OPENSSL
 	acl aclname ssl_error errorname
 	  # match against SSL certificate validation error [fast]
@@ -1380,17 +1398,6 @@ IF USE_OPENSSL
 	  # Optional argument specifies the digest algorithm to use.
 	  # The SHA1 digest algorithm is the default and is currently
 	  # the only algorithm supported (-sha1).
-
-	acl aclname at_step step
-	  # match against the current step during ssl_bump evaluation [fast]
-	  # Never matches and should not be used outside the ssl_bump context.
-	  #
-	  # At each SslBump step, Squid evaluates ssl_bump directives to find
-	  # the next bumping action (e.g., peek or splice). Valid SslBump step
-	  # values and the corresponding ssl_bump evaluation moments are:
-	  #   SslBump1: After getting TCP-level and HTTP CONNECT info.
-	  #   SslBump2: After getting SSL Client Hello info.
-	  #   SslBump3: After getting SSL Server Hello info.
 
 	acl aclname ssl::server_name [option] .foo.com ...
 	  # matches server name obtained from various sources [fast]

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1353,8 +1353,7 @@ endif
 acl aclname at_step step
 	  # match against various request processing steps [fast]
 	  # Valid steps are:
-	  #   GeneratingCONNECT: While generates and process CONNECT request
-	  #                      to a peer
+	  #   GeneratingCONNECT: While generates CONNECT request to a peer
 IF USE_OPENSSL
 	  # The following steps can also be used to match against the
 	  # current step during ssl_bump evaluation.

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3277,8 +3277,8 @@ ConnStateData::startPeekAndSplice()
     Http::StreamPointer context = pipeline.front();
     ClientHttpRequest *http = context ? context->http : nullptr;
 
-    if (sslServerBump->step == Ssl::bumpStep1) {
-        sslServerBump->step = Ssl::bumpStep2;
+    if (sslServerBump->step == xaStepTlsBump1) {
+        sslServerBump->step = xaStepTlsBump2;
         // Run a accessList check to check if want to splice or continue bumping
 
         ACLFilledChecklist *acl_checklist = new ACLFilledChecklist(Config.accessList.ssl_bump, sslServerBump->request.getRaw(), nullptr);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -130,6 +130,9 @@ Http::Tunneler::writeRequest()
     HttpHeader hdr_out(hoRequest);
     Http::StateFlags flags;
     flags.peering = true;
+
+    Must(request->masterXaction);
+    request->masterXaction->generatingConnect = true;
     // flags.tunneling = false; // the CONNECT request itself is not tunneled
     // flags.toOrigin = false; // the next HTTP hop is a non-originserver peer
     MemBuf mb;
@@ -337,6 +340,9 @@ void
 Http::Tunneler::callBack()
 {
     debugs(83, 5, connection << status());
+    Must(request);
+    Must(request->masterXaction);
+    request->masterXaction->generatingConnect = false;
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -149,6 +149,7 @@ Http::Tunneler::writeRequest()
 
     debugs(11, 2, "Tunnel Server REQUEST: " << connection <<
            ":\n----------\n" << mb.buf << "\n----------");
+    request->masterXaction->generatingConnect = false;
     fd_note(connection->fd, "Tunnel Server CONNECT");
 
     typedef CommCbMemFunT<Http::Tunneler, CommIoCbParams> Dialer;
@@ -342,7 +343,6 @@ Http::Tunneler::callBack()
     debugs(83, 5, connection << status());
     Must(request);
     Must(request->masterXaction);
-    request->masterXaction->generatingConnect = false;
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/enums.h
+++ b/src/enums.h
@@ -245,5 +245,15 @@ typedef enum {
 } htcp_clr_reason;
 #endif /* USE_HTCP */
 
+typedef enum {
+#if USE_OPENSSL
+    xaStepTlsBump1,
+    xaStepTlsBump2,
+    xaStepTlsBump3,
+#endif
+    xaStepGeneratingConnect,
+    xaStepValuesEnd
+} XactionSteps;
+
 #endif /* SQUID_ENUMS_H */
 

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -48,7 +48,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSplice()
     // Mark Step3 of bumping
     if (request->clientConnectionManager.valid()) {
         if (Ssl::ServerBump *serverBump = request->clientConnectionManager->serverBump()) {
-            serverBump->step = Ssl::bumpStep3;
+            serverBump->step = xaStepTlsBump3;
         }
     }
 
@@ -166,7 +166,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
         if (hostName)
             SSL_set_ex_data(serverSession.get(), ssl_ex_index_server, (void*)hostName);
 
-        Must(!csd->serverBump() || csd->serverBump()->step <= Ssl::bumpStep2);
+        Must(!csd->serverBump() || csd->serverBump()->step <= xaStepTlsBump2);
         if (csd->sslBumpMode == Ssl::bumpPeek || csd->sslBumpMode == Ssl::bumpStare) {
             auto clientSession = fd_table[clientConn->fd].ssl.get();
             Must(clientSession);

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -21,7 +21,7 @@
 CBDATA_NAMESPACED_CLASS_INIT(Ssl, ServerBump);
 
 Ssl::ServerBump::ServerBump(ClientHttpRequest *http, StoreEntry *e, Ssl::BumpMode md):
-    step(bumpStep1)
+    step(xaStepTlsBump1)
 {
     assert(http->request);
     request = http->request;

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -12,6 +12,7 @@
 #include "base/AsyncJob.h"
 #include "base/CbcPointer.h"
 #include "comm/forward.h"
+#include "enums.h"
 #include "HttpRequest.h"
 #include "ip/Address.h"
 #include "security/forward.h"
@@ -51,7 +52,7 @@ public:
         Ssl::BumpMode step2; ///< The SSL bump mode at step2
         Ssl::BumpMode step3; ///< The SSL bump mode at step3
     } act; ///< bumping actions at various bumping steps
-    Ssl::BumpStep step; ///< The SSL bumping step
+    XactionSteps step; ///< The TLS bumping step
 
 private:
     Security::SessionPointer serverSession; ///< The TLS session object on server side.

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -100,7 +100,7 @@ public:
             return false;
 #if USE_OPENSSL
         // We are bumping and we had already send "OK CONNECTED"
-        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->step > Ssl::bumpStep1)
+        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->step > xaStepTlsBump1)
             return false;
 #endif
         return !(request != NULL &&


### PR DESCRIPTION
Its purpose is to distinguish CONNECT-generation from GET forwarding
requests, for example "GET https://.." requests comming from a
client-first bumped connection.

It matches while squid generated a CONNECT request to a peer.

This is a Measurement Factory project