### PR TITLE
Fixed rock disk entry contamination related to aborted swapouts

### DIFF
--- a/src/ClientRequestContext.h
+++ b/src/ClientRequestContext.h
@@ -37,13 +37,13 @@ public:
     void hostHeaderVerifyFailed(const char *A, const char *B);
     void clientAccessCheck();
     void clientAccessCheck2();
-    void clientAccessCheckDone(const allow_t &answer);
+    void clientAccessCheckDone(const Acl::Answer &answer);
     void clientRedirectStart();
     void clientRedirectDone(const Helper::Reply &reply);
     void clientStoreIdStart();
     void clientStoreIdDone(const Helper::Reply &reply);
     void checkNoCache();
-    void checkNoCacheDone(const allow_t &answer);
+    void checkNoCacheDone(const Acl::Answer &answer);
 #if USE_ADAPTATION
 
     void adaptationAccessCheck();
@@ -56,7 +56,7 @@ public:
      */
     bool sslBumpAccessCheck();
     /// The callback function for ssl-bump access check list
-    void sslBumpAccessCheckDone(const allow_t &answer);
+    void sslBumpAccessCheckDone(const Acl::Answer &answer);
 #endif
 
     ClientHttpRequest *http;

--- a/src/ExternalACLEntry.h
+++ b/src/ExternalACLEntry.h
@@ -31,7 +31,7 @@ class ExternalACLEntryData
 public:
     ExternalACLEntryData() : result(ACCESS_DUNNO) {}
 
-    allow_t result;
+    Acl::Answer result;
 
     /// list of all kv-pairs returned by the helper
     NotePairs notes;
@@ -61,7 +61,7 @@ public:
 
     void update(ExternalACLEntryData const &);
     dlink_node lru;
-    allow_t result;
+    Acl::Answer result;
     time_t date;
 
     /// list of all kv-pairs returned by the helper

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -104,8 +104,8 @@ protected:
 #endif
 
     int checkNetdbDirect();
-    void checkAlwaysDirectDone(const allow_t answer);
-    void checkNeverDirectDone(const allow_t answer);
+    void checkAlwaysDirectDone(const Acl::Answer answer);
+    void checkNeverDirectDone(const Acl::Answer answer);
 
     void selectSomeNeighbor();
     void selectSomeNeighborReplies();
@@ -124,8 +124,8 @@ protected:
     static EVH HandlePingTimeout;
 
 private:
-    allow_t always_direct;
-    allow_t never_direct;
+    Acl::Answer always_direct;
+    Acl::Answer never_direct;
     int direct;   // TODO: fold always_direct/never_direct/prefer_direct into this now that ACL can do a multi-state result.
     size_t foundPaths = 0; ///< number of unique destinations identified so far
     ErrorState *lastError;

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -109,14 +109,16 @@ typedef enum {
 } aclMatchCode;
 
 /// \ingroup ACLAPI
-/// ACL check answer; TODO: Rename to Acl::Answer
-class allow_t
+/// ACL check answer
+namespace Acl {
+
+class Answer
 {
 public:
-    // not explicit: allow "aclMatchCode to allow_t" conversions (for now)
-    allow_t(const aclMatchCode aCode, int aKind = 0): code(aCode), kind(aKind) {}
+    // not explicit: allow "aclMatchCode to Acl::Answer" conversions (for now)
+    Answer(const aclMatchCode aCode, int aKind = 0): code(aCode), kind(aKind) {}
 
-    allow_t(): code(ACCESS_DUNNO), kind(0) {}
+    Answer(): code(ACCESS_DUNNO), kind(0) {}
 
     bool operator ==(const aclMatchCode aCode) const {
         return code == aCode;
@@ -126,7 +128,7 @@ public:
         return !(*this == aCode);
     }
 
-    bool operator ==(const allow_t allow) const {
+    bool operator ==(const Answer allow) const {
         return code == allow.code && kind == allow.kind;
     }
 
@@ -153,8 +155,10 @@ public:
     int kind; ///< which custom access list verb matched
 };
 
+} // namespace Acl
+
 inline std::ostream &
-operator <<(std::ostream &o, const allow_t a)
+operator <<(std::ostream &o, const Acl::Answer a)
 {
     switch (a) {
     case ACCESS_DENIED:

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -55,12 +55,12 @@ ACLChecklist::completeNonBlocking()
 }
 
 void
-ACLChecklist::markFinished(const allow_t &finalAnswer, const char *reason)
+ACLChecklist::markFinished(const Acl::Answer &finalAnswer, const char *reason)
 {
     assert (!finished() && !asyncInProgress());
     finished_ = true;
-    allow_ = finalAnswer;
-    debugs(28, 3, HERE << this << " answer " << allow_ << " for " << reason);
+    answer_ = finalAnswer;
+    debugs(28, 3, HERE << this << " answer " << answer_ << " for " << reason);
 }
 
 /// Called first (and once) by all checks to initialize their state
@@ -156,7 +156,7 @@ ACLChecklist::goAsync(AsyncState *state)
 // ACLFilledChecklist overwrites this to unclock something before we
 // "delete this"
 void
-ACLChecklist::checkCallback(allow_t answer)
+ACLChecklist::checkCallback(Acl::Answer answer)
 {
     ACLCB *callback_;
     void *cbdata_;
@@ -181,7 +181,7 @@ ACLChecklist::ACLChecklist() :
     asyncCaller_(false),
     occupied_(false),
     finished_(false),
-    allow_(ACCESS_DENIED),
+    answer_(ACCESS_DENIED),
     asyncStage_(asyncNone),
     state_(NullState::Instance()),
     asyncLoopDepth_(0)
@@ -304,7 +304,7 @@ ACLChecklist::matchAndFinish()
         markFinished(accessList->winningAction(), "match");
 }
 
-allow_t const &
+Acl::Answer const &
 ACLChecklist::fastCheck(const Acl::Tree * list)
 {
     PROF_start(aclCheckFast);
@@ -332,7 +332,7 @@ ACLChecklist::fastCheck(const Acl::Tree * list)
 /* Warning: do not cbdata lock this here - it
  * may be static or on the stack
  */
-allow_t const &
+Acl::Answer const &
 ACLChecklist::fastCheck()
 {
     PROF_start(aclCheckFast);
@@ -370,13 +370,13 @@ ACLChecklist::fastCheck()
 void
 ACLChecklist::calcImplicitAnswer()
 {
-    const allow_t lastAction = (accessList && cbdataReferenceValid(accessList)) ?
-                               accessList->lastAction() : allow_t(ACCESS_DUNNO);
-    allow_t implicitRuleAnswer = ACCESS_DUNNO;
+    const auto lastAction = (accessList && cbdataReferenceValid(accessList)) ?
+                               accessList->lastAction() : Acl::Answer(ACCESS_DUNNO);
+    auto implicitRuleAnswer = Acl::Answer(ACCESS_DUNNO);
     if (lastAction == ACCESS_DENIED) // reverse last seen "deny"
-        implicitRuleAnswer = ACCESS_ALLOWED;
+        implicitRuleAnswer = Acl::Answer(ACCESS_ALLOWED);
     else if (lastAction == ACCESS_ALLOWED) // reverse last seen "allow"
-        implicitRuleAnswer = ACCESS_DENIED;
+        implicitRuleAnswer = Acl::Answer(ACCESS_DENIED);
     // else we saw no rules and will respond with ACCESS_DUNNO
 
     debugs(28, 3, HERE << this << " NO match found, last action " <<
@@ -391,7 +391,7 @@ ACLChecklist::callerGone()
 }
 
 bool
-ACLChecklist::bannedAction(const allow_t &action) const
+ACLChecklist::bannedAction(const Acl::Answer &action) const
 {
     const bool found = std::find(bannedActions_.begin(), bannedActions_.end(), action) != bannedActions_.end();
     debugs(28, 5, "Action '" << action << "/" << action.kind << (found ? "' is " : "' is not") << " banned");
@@ -399,7 +399,7 @@ ACLChecklist::bannedAction(const allow_t &action) const
 }
 
 void
-ACLChecklist::banAction(const allow_t &action)
+ACLChecklist::banAction(const Acl::Answer &action)
 {
     bannedActions_.push_back(action);
 }

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -16,7 +16,7 @@
 class HttpRequest;
 
 /// ACL checklist callback
-typedef void ACLCB(allow_t, void *);
+typedef void ACLCB(Acl::Answer, void *);
 
 /** \ingroup ACLAPI
     Base class for maintaining Squid and transaction state for access checks.
@@ -109,7 +109,7 @@ public:
      *
      * If there are no rules to check at all, the result becomes ACCESS_DUNNO.
      */
-    allow_t const & fastCheck();
+    Acl::Answer const & fastCheck();
 
     /**
      * Perform a blocking (immediate) check whether a list of ACLs matches.
@@ -132,7 +132,7 @@ public:
      *
      * If there are no ACLs to check at all, the result becomes ACCESS_ALLOWED.
      */
-    allow_t const & fastCheck(const Acl::Tree *list);
+    Acl::Answer const & fastCheck(const Acl::Tree *list);
 
     /// If slow lookups are allowed, switches into "async in progress" state.
     /// Otherwise, returns false; the caller is expected to handle the failure.
@@ -151,14 +151,14 @@ public:
     bool asyncInProgress() const { return asyncStage_ != asyncNone; }
     /// called when no more ACLs should be checked; sets the final answer and
     /// prints a debugging message explaining the reason for that answer
-    void markFinished(const allow_t &newAnswer, const char *reason);
+    void markFinished(const Acl::Answer &newAnswer, const char *reason);
 
-    const allow_t &currentAnswer() const { return allow_; }
+    const Acl::Answer &currentAnswer() const { return answer_; }
 
     /// whether the action is banned or not
-    bool bannedAction(const allow_t &action) const;
+    bool bannedAction(const Acl::Answer &action) const;
     /// add action to the list of banned actions
-    void banAction(const allow_t &action);
+    void banAction(const Acl::Answer &action);
 
     // XXX: ACLs that need request or reply have to use ACLFilledChecklist and
     // should do their own checks so that we do not have to povide these two
@@ -184,7 +184,7 @@ public:
 
 private:
     /// Calls non-blocking check callback with the answer and destroys self.
-    void checkCallback(allow_t answer);
+    void checkCallback(Acl::Answer answer);
 
     void matchAndFinish();
 
@@ -228,7 +228,7 @@ private: /* internal methods */
     bool asyncCaller_; ///< whether the caller supports async/slow ACLs
     bool occupied_; ///< whether a check (fast or non-blocking) is in progress
     bool finished_;
-    allow_t allow_;
+    Acl::Answer answer_;
 
     enum AsyncStage { asyncNone, asyncStarting, asyncRunning, asyncFailed };
     AsyncStage asyncStage_;
@@ -242,7 +242,7 @@ private: /* internal methods */
     /// suspended (due to an async lookup) matches() in the ACL tree
     std::stack<Breadcrumb> matchPath;
     /// the list of actions which must ignored during acl checks
-    std::vector<allow_t> bannedActions_;
+    std::vector<Acl::Answer> bannedActions_;
 };
 
 #endif /* SQUID_ACLCHECKLIST_H */

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -145,11 +145,11 @@ aclParseAccessLine(const char *directive, ConfigParser &, acl_access **treep)
         return;
     }
 
-    allow_t action = ACCESS_DUNNO;
+    auto action = Acl::Answer(ACCESS_DUNNO);
     if (!strcmp(t, "allow"))
-        action = ACCESS_ALLOWED;
+        action = Acl::Answer(ACCESS_ALLOWED);
     else if (!strcmp(t, "deny"))
-        action = ACCESS_DENIED;
+        action = Acl::Answer(ACCESS_DENIED);
     else {
         debugs(28, DBG_CRITICAL, "aclParseAccessLine: " << cfg_filename << " line " << config_lineno << ": " << config_input_line);
         debugs(28, DBG_CRITICAL, "aclParseAccessLine: expecting 'allow' or 'deny', got '" << t << "'.");

--- a/src/acl/Tree.cc
+++ b/src/acl/Tree.cc
@@ -13,13 +13,13 @@
 
 CBDATA_NAMESPACED_CLASS_INIT(Acl, Tree);
 
-allow_t
+Acl::Answer
 Acl::Tree::winningAction() const
 {
     return actionAt(lastMatch_ - nodes.begin());
 }
 
-allow_t
+Acl::Answer
 Acl::Tree::lastAction() const
 {
     if (actions.empty())
@@ -28,7 +28,7 @@ Acl::Tree::lastAction() const
 }
 
 /// computes action that corresponds to the position of the matched rule
-allow_t
+Acl::Answer
 Acl::Tree::actionAt(const Nodes::size_type pos) const
 {
     assert(pos < nodes.size());
@@ -41,7 +41,7 @@ Acl::Tree::actionAt(const Nodes::size_type pos) const
 }
 
 void
-Acl::Tree::add(ACL *rule, const allow_t &action)
+Acl::Tree::add(ACL *rule, const Acl::Answer &action)
 {
     // either all rules have actions or none
     assert(nodes.size() == actions.size());

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -30,27 +30,27 @@ public:
     SBufList treeDump(const char *name, ActionToStringConverter converter) const;
 
     /// Returns the corresponding action after a successful tree match.
-    allow_t winningAction() const;
+    Answer winningAction() const;
 
     /// what action to use if no nodes matched
-    allow_t lastAction() const;
+    Answer lastAction() const;
 
     /// appends and takes control over the rule with a given action
-    void add(ACL *rule, const allow_t &action);
+    void add(ACL *rule, const Answer &action);
     void add(ACL *rule); ///< same as InnerNode::add()
 
 protected:
     /// Acl::OrNode API
     virtual bool bannedAction(ACLChecklist *, Nodes::const_iterator) const override;
-    allow_t actionAt(const Nodes::size_type pos) const;
+    Answer actionAt(const Nodes::size_type pos) const;
 
     /// if not empty, contains actions corresponding to InnerNode::nodes
-    typedef std::vector<allow_t> Actions;
+    typedef std::vector<Answer> Actions;
     Actions actions;
 };
 
 inline const char *
-AllowOrDeny(const allow_t &action)
+AllowOrDeny(const Answer &action)
 {
     return action.allowed() ? "allow" : "deny";
 }

--- a/src/acl/forward.h
+++ b/src/acl/forward.h
@@ -23,6 +23,7 @@ namespace Acl
 {
 
 class Address;
+class Answer;
 class InnerNode;
 class NotNode;
 class AndNode;
@@ -34,8 +35,7 @@ void Init(void);
 
 } // namespace Acl
 
-class allow_t;
-typedef void ACLCB(allow_t, void *);
+typedef void ACLCB(Acl::Answer, void *);
 
 #define ACL_NAME_SZ 64
 

--- a/src/adaptation/AccessCheck.cc
+++ b/src/adaptation/AccessCheck.cc
@@ -149,7 +149,7 @@ Adaptation::AccessCheck::checkCandidates()
 }
 
 void
-Adaptation::AccessCheck::AccessCheckCallbackWrapper(allow_t answer, void *data)
+Adaptation::AccessCheck::AccessCheckCallbackWrapper(Acl::Answer answer, void *data)
 {
     debugs(93, 8, HERE << "callback answer=" << answer);
     AccessCheck *ac = (AccessCheck*)data;
@@ -160,7 +160,7 @@ Adaptation::AccessCheck::AccessCheckCallbackWrapper(allow_t answer, void *data)
      */
 
     // convert to async call to get async call protections and features
-    typedef UnaryMemFunT<AccessCheck, allow_t> MyDialer;
+    typedef UnaryMemFunT<AccessCheck, Acl::Answer> MyDialer;
     AsyncCall::Pointer call =
         asyncCall(93,7, "Adaptation::AccessCheck::noteAnswer",
                   MyDialer(ac, &Adaptation::AccessCheck::noteAnswer, answer));
@@ -170,7 +170,7 @@ Adaptation::AccessCheck::AccessCheckCallbackWrapper(allow_t answer, void *data)
 
 /// process the results of the ACL check
 void
-Adaptation::AccessCheck::noteAnswer(allow_t answer)
+Adaptation::AccessCheck::noteAnswer(Acl::Answer answer)
 {
     Must(!candidates.empty()); // the candidate we were checking must be there
     debugs(93,5, HERE << topCandidate() << " answer=" << answer);

--- a/src/adaptation/AccessCheck.h
+++ b/src/adaptation/AccessCheck.h
@@ -59,8 +59,8 @@ private:
 
 public:
     void checkCandidates();
-    static void AccessCheckCallbackWrapper(allow_t, void*);
-    void noteAnswer(allow_t answer);
+    static void AccessCheckCallbackWrapper(Acl::Answer, void*);
+    void noteAnswer(Acl::Answer answer);
 
 protected:
     // AsyncJob API

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -167,6 +167,30 @@ urlParseProtocol(const char *b)
     return AnyP::PROTO_NONE;
 }
 
+/**
+ * Appends configured append_domain to hostname, assuming
+ * the given buffer is at least SQUIDHOSTNAMELEN bytes long,
+ * and that the host FQDN is not a 'dotless' TLD.
+ *
+ * \returns false if and only if there is not enough space to append
+ */
+bool
+urlAppendDomain(char *host)
+{
+    /* For IPv4 addresses check for a dot */
+    /* For IPv6 addresses also check for a colon */
+    if (Config.appendDomain && !strchr(host, '.') && !strchr(host, ':')) {
+        const uint64_t dlen = strlen(host);
+        const uint64_t want = dlen + Config.appendDomainLen;
+        if (want > SQUIDHOSTNAMELEN - 1) {
+            debugs(23, 2, "URL domain too large (" << dlen << " bytes)");
+            return false;
+        }
+        strncat(host, Config.appendDomain, SQUIDHOSTNAMELEN - dlen - 1);
+    }
+    return true;
+}
+
 /*
  * Parse a URI/URL.
  *
@@ -376,9 +400,8 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const char *url)
         return false;
     }
 
-    /* For IPV6 addresses also check for a colon */
-    if (Config.appendDomain && !strchr(foundHost, '.') && !strchr(foundHost, ':'))
-        strncat(foundHost, Config.appendDomain, SQUIDHOSTNAMELEN - strlen(foundHost) - 1);
+    if (!urlAppendDomain(foundHost))
+        return false;
 
     /* remove trailing dots from hostnames */
     while ((l = strlen(foundHost)) > 0 && foundHost[--l] == '.')

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -193,6 +193,7 @@ bool urlIsRelative(const char *);
 char *urlMakeAbsolute(const HttpRequest *, const char *);
 char *urlRInternal(const char *host, unsigned short port, const char *dir, const char *name);
 char *urlInternal(const char *dir, const char *name);
+bool urlAppendDomain(char *host); ///< apply append_domain config to the given hostname
 
 enum MatchDomainNameFlags {
     mdnNone = 0,

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -24,7 +24,7 @@
  * \retval ACCESS_DENIED        user not authorized
  * \retval ACCESS_ALLOWED       user authenticated and authorized
  */
-allow_t
+Acl::Answer
 AuthenticateAcl(ACLChecklist *ch)
 {
     ACLFilledChecklist *checklist = Filled(ch);

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -19,7 +19,7 @@
 
 class ACLChecklist;
 /// \ingroup AuthAPI
-allow_t AuthenticateAcl(ACLChecklist *ch);
+Acl::Answer AuthenticateAcl(ACLChecklist *ch);
 
 #endif /* USE_AUTH */
 #endif /* SQUID_AUTH_ACL_H */

--- a/src/auth/AclMaxUserIp.cc
+++ b/src/auth/AclMaxUserIp.cc
@@ -122,7 +122,7 @@ int
 ACLMaxUserIP::match(ACLChecklist *cl)
 {
     ACLFilledChecklist *checklist = Filled(cl);
-    allow_t answer = AuthenticateAcl(checklist);
+    auto answer = AuthenticateAcl(checklist);
     int ti;
 
     // convert to tri-state ACL match 1,0,-1

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -65,7 +65,7 @@ ACLProxyAuth::parse()
 int
 ACLProxyAuth::match(ACLChecklist *checklist)
 {
-    allow_t answer = AuthenticateAcl(checklist);
+    auto answer = AuthenticateAcl(checklist);
 
     // convert to tri-state ACL match 1,0,-1
     switch (answer) {

--- a/src/auth/UserRequest.cc
+++ b/src/auth/UserRequest.cc
@@ -468,7 +468,7 @@ schemesConfig(HttpRequest *request, HttpReply *rep)
         ACLFilledChecklist ch(NULL, request, NULL);
         ch.reply = rep;
         HTTPMSGLOCK(ch.reply);
-        const allow_t answer = ch.fastCheck(Auth::TheConfig.schemeAccess);
+        const auto answer = ch.fastCheck(Auth::TheConfig.schemeAccess);
         if (answer.allowed())
             return Auth::TheConfig.schemeLists.at(answer.kind).authConfigs;
     }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -242,7 +242,7 @@ static void free_configuration_includes_quoted_values(bool *recognizeQuotedValue
 static void parse_on_unsupported_protocol(acl_access **access);
 static void dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *access);
 static void free_on_unsupported_protocol(acl_access **access);
-static void ParseAclWithAction(acl_access **access, const allow_t &action, const char *desc, ACL *acl = nullptr);
+static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, ACL *acl = nullptr);
 
 /*
  * LegacyParser is a parser for legacy code that uses the global
@@ -1884,7 +1884,7 @@ parse_AuthSchemes(acl_access **authSchemes)
         return;
     }
     Auth::TheConfig.schemeLists.emplace_back(tok, ConfigParser::LastTokenWasQuoted());
-    const allow_t action = allow_t(ACCESS_ALLOWED, Auth::TheConfig.schemeLists.size() - 1);
+    const auto action = Acl::Answer(ACCESS_ALLOWED, Auth::TheConfig.schemeLists.size() - 1);
     ParseAclWithAction(authSchemes, action, "auth_schemes");
 }
 
@@ -1899,7 +1899,7 @@ static void
 dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 {
     if (authSchemes)
-        dump_SBufList(entry, authSchemes->treeDump(name, [](const allow_t &action) {
+        dump_SBufList(entry, authSchemes->treeDump(name, [](const Acl::Answer &action) {
         return Auth::TheConfig.schemeLists.at(action.kind).rawSchemes;
     }));
 }
@@ -1907,7 +1907,7 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 #endif /* USE_AUTH */
 
 static void
-ParseAclWithAction(acl_access **access, const allow_t &action, const char *desc, ACL *acl)
+ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, ACL *acl)
 {
     assert(access);
     SBuf name;
@@ -4652,7 +4652,7 @@ static void parse_sslproxy_ssl_bump(acl_access **ssl_bump)
         sslBumpCfgRr::lastDeprecatedRule = Ssl::bumpEnd;
     }
 
-    allow_t action = allow_t(ACCESS_ALLOWED);
+    auto action = Acl::Answer(ACCESS_ALLOWED);
 
     if (strcmp(bm, Ssl::BumpModeStr[Ssl::bumpClientFirst]) == 0) {
         action.kind = Ssl::bumpClientFirst;
@@ -4715,7 +4715,7 @@ static void parse_sslproxy_ssl_bump(acl_access **ssl_bump)
 static void dump_sslproxy_ssl_bump(StoreEntry *entry, const char *name, acl_access *ssl_bump)
 {
     if (ssl_bump)
-        dump_SBufList(entry, ssl_bump->treeDump(name, [](const allow_t &action) {
+        dump_SBufList(entry, ssl_bump->treeDump(name, [](const Acl::Answer &action) {
         return Ssl::BumpModeStr.at(action.kind);
     }));
 }
@@ -4811,7 +4811,7 @@ static void free_note(Notes *notes)
 static bool FtpEspvDeprecated = false;
 static void parse_ftp_epsv(acl_access **ftp_epsv)
 {
-    allow_t ftpEpsvDeprecatedAction;
+    Acl::Answer ftpEpsvDeprecatedAction;
     bool ftpEpsvIsDeprecatedRule = false;
 
     char *t = ConfigParser::PeekAtToken();
@@ -4823,11 +4823,11 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
     if (!strcmp(t, "off")) {
         (void)ConfigParser::NextToken();
         ftpEpsvIsDeprecatedRule = true;
-        ftpEpsvDeprecatedAction = allow_t(ACCESS_DENIED);
+        ftpEpsvDeprecatedAction = Acl::Answer(ACCESS_DENIED);
     } else if (!strcmp(t, "on")) {
         (void)ConfigParser::NextToken();
         ftpEpsvIsDeprecatedRule = true;
-        ftpEpsvDeprecatedAction = allow_t(ACCESS_ALLOWED);
+        ftpEpsvDeprecatedAction = Acl::Answer(ACCESS_ALLOWED);
     }
 
     // Check for mixing "ftp_epsv on|off" and "ftp_epsv allow|deny .." rules:
@@ -4846,7 +4846,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         delete *ftp_epsv;
         *ftp_epsv = nullptr;
 
-        if (ftpEpsvDeprecatedAction == allow_t(ACCESS_DENIED)) {
+        if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
             if (ACL *a = ACL::FindByName("all"))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
@@ -4976,7 +4976,7 @@ parse_on_unsupported_protocol(acl_access **access)
         return;
     }
 
-    allow_t action = allow_t(ACCESS_ALLOWED);
+    auto action = Acl::Answer(ACCESS_ALLOWED);
     if (strcmp(tm, "tunnel") == 0)
         action.kind = 1;
     else if (strcmp(tm, "respond") == 0)
@@ -5000,7 +5000,7 @@ dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *ac
         "respond"
     };
     if (access) {
-        SBufList lines = access->treeDump(name, [](const allow_t &action) {
+        SBufList lines = access->treeDump(name, [](const Acl::Answer &action) {
             return onErrorTunnelMode.at(action.kind);
         });
         dump_SBufList(entry, lines);

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2139,6 +2139,7 @@ parse_peer(CachePeer ** head)
 
     CachePeer *p = new CachePeer;
     p->host = xstrdup(host_str);
+    Tolower(p->host);
     p->name = xstrdup(host_str);
     p->type = parseNeighborType(token);
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1566,7 +1566,7 @@ clientTunnelOnError(ConnStateData *conn, Http::StreamPointer &context, HttpReque
         ClientHttpRequest *http = context ? context->http : nullptr;
         const char *log_uri = http ? http->log_uri : nullptr;
         checklist.syncAle(request.getRaw(), log_uri);
-        allow_t answer = checklist.fastCheck();
+        auto answer = checklist.fastCheck();
         if (answer.allowed() && answer.kind == 1) {
             debugs(33, 3, "Request will be tunneled to server");
             if (context) {
@@ -2283,7 +2283,7 @@ ConnStateData::whenClientIpKnown()
             /* pools require explicit 'allow' to assign a client into them */
             if (pools[pool]->access) {
                 ch.changeAcl(pools[pool]->access);
-                allow_t answer = ch.fastCheck();
+                auto answer = ch.fastCheck();
                 if (answer.allowed()) {
 
                     /*  request client information from db after we did all checks
@@ -2544,7 +2544,7 @@ httpsEstablish(ConnStateData *connState, const Security::ContextPointer &ctx)
  * A callback function to use with the ACLFilledChecklist callback.
  */
 static void
-httpsSslBumpAccessCheckDone(allow_t answer, void *data)
+httpsSslBumpAccessCheckDone(Acl::Answer answer, void *data)
 {
     ConnStateData *connState = (ConnStateData *) data;
 
@@ -3023,7 +3023,7 @@ ConnStateData::parseTlsHandshake()
     }
 }
 
-void httpsSslBumpStep2AccessCheckDone(allow_t answer, void *data)
+void httpsSslBumpStep2AccessCheckDone(Acl::Answer answer, void *data)
 {
     ConnStateData *connState = (ConnStateData *) data;
 
@@ -3103,9 +3103,9 @@ ConnStateData::startPeekAndSplice()
         acl_checklist->al = http ? http->al : nullptr;
         //acl_checklist->src_addr = params.conn->remote;
         //acl_checklist->my_addr = s->s;
-        acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpNone));
-        acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpClientFirst));
-        acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpServerFirst));
+        acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpNone));
+        acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpClientFirst));
+        acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpServerFirst));
         const char *log_uri = http ? http->log_uri : nullptr;
         acl_checklist->syncAle(sslServerBump->request.getRaw(), log_uri);
         acl_checklist->nonBlockingCheck(httpsSslBumpStep2AccessCheckDone, this);

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2067,14 +2067,14 @@ clientReplyContext::processReplyAccess ()
 }
 
 void
-clientReplyContext::ProcessReplyAccessResult(allow_t rv, void *voidMe)
+clientReplyContext::ProcessReplyAccessResult(Acl::Answer rv, void *voidMe)
 {
     clientReplyContext *me = static_cast<clientReplyContext *>(voidMe);
     me->processReplyAccessResult(rv);
 }
 
 void
-clientReplyContext::processReplyAccessResult(const allow_t &accessAllowed)
+clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
 {
     debugs(88, 2, "The reply for " << http->request->method
            << ' ' << http->uri << " is " << accessAllowed << ", because it matched "

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -115,7 +115,7 @@ private:
     HttpReply *reply;
     void processReplyAccess();
     static ACLCB ProcessReplyAccessResult;
-    void processReplyAccessResult(const allow_t &accessAllowed);
+    void processReplyAccessResult(const Acl::Answer &accessAllowed);
     void cloneReply();
     void buildReplyHeader ();
     bool alwaysAllowResponse(Http::StatusCode sline) const;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -81,7 +81,7 @@
 static const char *const crlf = "\r\n";
 
 #if FOLLOW_X_FORWARDED_FOR
-static void clientFollowXForwardedForCheck(allow_t answer, void *data);
+static void clientFollowXForwardedForCheck(Acl::Answer answer, void *data);
 #endif /* FOLLOW_X_FORWARDED_FOR */
 
 ErrorState *clientBuildError(err_type, Http::StatusCode, char const *url, Ip::Address &, HttpRequest *, const AccessLogEntry::Pointer &);
@@ -90,15 +90,15 @@ CBDATA_CLASS_INIT(ClientRequestContext);
 
 /* Local functions */
 /* other */
-static void clientAccessCheckDoneWrapper(allow_t, void *);
+static void clientAccessCheckDoneWrapper(Acl::Answer, void *);
 #if USE_OPENSSL
-static void sslBumpAccessCheckDoneWrapper(allow_t, void *);
+static void sslBumpAccessCheckDoneWrapper(Acl::Answer, void *);
 #endif
 static int clientHierarchical(ClientHttpRequest * http);
 static void clientInterpretRequestHeaders(ClientHttpRequest * http);
 static HLPCB clientRedirectDoneWrapper;
 static HLPCB clientStoreIdDoneWrapper;
-static void checkNoCacheDoneWrapper(allow_t, void *);
+static void checkNoCacheDoneWrapper(Acl::Answer, void *);
 SQUIDCEXTERN CSR clientGetMoreData;
 SQUIDCEXTERN CSS clientReplyStatus;
 SQUIDCEXTERN CSD clientReplyDetach;
@@ -437,7 +437,7 @@ ClientRequestContext::httpStateIsValid()
  * ++ indirect_client_addr contains the remote direct client from the trusted peers viewpoint.
  */
 static void
-clientFollowXForwardedForCheck(allow_t answer, void *data)
+clientFollowXForwardedForCheck(Acl::Answer answer, void *data)
 {
     ClientRequestContext *calloutContext = (ClientRequestContext *) data;
 
@@ -727,7 +727,7 @@ ClientRequestContext::clientAccessCheck2()
 }
 
 void
-clientAccessCheckDoneWrapper(allow_t answer, void *data)
+clientAccessCheckDoneWrapper(Acl::Answer answer, void *data)
 {
     ClientRequestContext *calloutContext = (ClientRequestContext *) data;
 
@@ -738,7 +738,7 @@ clientAccessCheckDoneWrapper(allow_t answer, void *data)
 }
 
 void
-ClientRequestContext::clientAccessCheckDone(const allow_t &answer)
+ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
 {
     acl_checklist = NULL;
     err_type page_id;
@@ -860,7 +860,7 @@ ClientHttpRequest::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer g)
 #endif
 
 static void
-clientRedirectAccessCheckDone(allow_t answer, void *data)
+clientRedirectAccessCheckDone(Acl::Answer answer, void *data)
 {
     ClientRequestContext *context = (ClientRequestContext *)data;
     ClientHttpRequest *http = context->http;
@@ -891,7 +891,7 @@ ClientRequestContext::clientRedirectStart()
  * Will handle as "ERR" (no change) in a case Access is not allowed.
  */
 static void
-clientStoreIdAccessCheckDone(allow_t answer, void *data)
+clientStoreIdAccessCheckDone(Acl::Answer answer, void *data)
 {
     ClientRequestContext *context = static_cast<ClientRequestContext *>(data);
     ClientHttpRequest *http = context->http;
@@ -1375,7 +1375,7 @@ ClientRequestContext::checkNoCache()
 }
 
 static void
-checkNoCacheDoneWrapper(allow_t answer, void *data)
+checkNoCacheDoneWrapper(Acl::Answer answer, void *data)
 {
     ClientRequestContext *calloutContext = (ClientRequestContext *) data;
 
@@ -1386,7 +1386,7 @@ checkNoCacheDoneWrapper(allow_t answer, void *data)
 }
 
 void
-ClientRequestContext::checkNoCacheDone(const allow_t &answer)
+ClientRequestContext::checkNoCacheDone(const Acl::Answer &answer)
 {
     acl_checklist = NULL;
     if (answer.denied()) {
@@ -1473,7 +1473,7 @@ ClientRequestContext::sslBumpAccessCheck()
  * as ACLFilledChecklist callback
  */
 static void
-sslBumpAccessCheckDoneWrapper(allow_t answer, void *data)
+sslBumpAccessCheckDoneWrapper(Acl::Answer answer, void *data)
 {
     ClientRequestContext *calloutContext = static_cast<ClientRequestContext *>(data);
 
@@ -1483,7 +1483,7 @@ sslBumpAccessCheckDoneWrapper(allow_t answer, void *data)
 }
 
 void
-ClientRequestContext::sslBumpAccessCheckDone(const allow_t &answer)
+ClientRequestContext::sslBumpAccessCheckDone(const Acl::Answer &answer)
 {
     if (!httpStateIsValid())
         return;

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -84,7 +84,7 @@ public:
 
     void trimCache();
 
-    bool maybeCacheable(const allow_t &) const;
+    bool maybeCacheable(const Acl::Answer &) const;
 
     int ttl;
 
@@ -465,7 +465,7 @@ external_acl::trimCache()
 }
 
 bool
-external_acl::maybeCacheable(const allow_t &result) const
+external_acl::maybeCacheable(const Acl::Answer &result) const
 {
     if (cache_size <= 0)
         return false; // cache is disabled
@@ -594,7 +594,7 @@ copyResultsFromEntry(HttpRequest *req, const ExternalACLEntryPointer &entry)
     }
 }
 
-static allow_t
+static Acl::Answer
 aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
 {
     debugs(82, 9, HERE << "acl=\"" << acl->def->name << "\"");
@@ -631,7 +631,7 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
         if (acl->def->require_auth) {
             /* Make sure the user is authenticated */
             debugs(82, 3, HERE << acl->def->name << " check user authenticated.");
-            const allow_t ti = AuthenticateAcl(ch);
+            const auto ti = AuthenticateAcl(ch);
             if (!ti.allowed()) {
                 debugs(82, 2, HERE << acl->def->name << " user not authenticated (" << ti << ")");
                 return ti;
@@ -705,7 +705,7 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
 int
 ACLExternal::match(ACLChecklist *checklist)
 {
-    allow_t answer = aclMatchExternal(data, Filled(checklist));
+    auto answer = aclMatchExternal(data, Filled(checklist));
 
     // convert to tri-state ACL match 1,0,-1
     switch (answer) {

--- a/src/fs/rock/RockIoRequests.cc
+++ b/src/fs/rock/RockIoRequests.cc
@@ -17,7 +17,8 @@ CBDATA_NAMESPACED_CLASS_INIT(Rock, WriteRequest);
 Rock::ReadRequest::ReadRequest(const ::ReadRequest &base,
                                const IoState::Pointer &anSio):
     ::ReadRequest(base),
-     sio(anSio)
+     sio(anSio),
+     id(0)
 {
 }
 
@@ -25,8 +26,9 @@ Rock::WriteRequest::WriteRequest(const ::WriteRequest &base,
                                  const IoState::Pointer &anSio):
     ::WriteRequest(base),
      sio(anSio),
+     sidPrevious(-1),
      sidCurrent(-1),
-     sidNext(-1),
+     id(0),
      eof(false)
 {
 }

--- a/src/fs/rock/RockIoRequests.h
+++ b/src/fs/rock/RockIoRequests.h
@@ -11,6 +11,7 @@
 
 #include "DiskIO/ReadRequest.h"
 #include "DiskIO/WriteRequest.h"
+#include "fs/rock/forward.h"
 #include "fs/rock/RockIoState.h"
 
 class DiskFile;
@@ -25,6 +26,9 @@ class ReadRequest: public ::ReadRequest
 public:
     ReadRequest(const ::ReadRequest &base, const IoState::Pointer &anSio);
     IoState::Pointer sio;
+
+    /// identifies this read transaction for the requesting IoState
+    IoXactionId id;
 };
 
 class WriteRequest: public ::WriteRequest
@@ -35,11 +39,16 @@ public:
     WriteRequest(const ::WriteRequest &base, const IoState::Pointer &anSio);
     IoState::Pointer sio;
 
+    /* We own these two reserved slots until SwapDir links them into the map. */
+
+    /// slot that will point to sidCurrent in the cache_dir map
+    SlotId sidPrevious;
+
     /// slot being written using this write request
     SlotId sidCurrent;
 
-    /// allocated next slot (negative if we are writing the last slot)
-    SlotId sidNext;
+    /// identifies this write transaction for the requesting IoState
+    IoXactionId id;
 
     /// whether this is the last request for the entry
     bool eof;

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -210,9 +210,15 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
             const auto sidNext = dir->reserveSlotForWriting(); // throws
             assert(sidNext >= 0);
             writeToDisk(sidNext);
-        } else if (Store::Root().transientReaders(*e)) {
-            // write partial buffer for all remote hit readers to see
-            writeBufToDisk(-1, false, false);
+            // } else if (Store::Root().transientReaders(*e)) {
+            // XXX: Partial writes cannot be read -- no map->startAppending()!
+            // XXX: Partial writes confuse SwapDir::droppedEarlierRequest(),
+            // resulting in released entries and, hence, misses and CF retries.
+            // XXX: The effective benefit of partial writes is reduced by
+            // doPages() buffering SM_PAGE_SIZE*n leftovers.
+
+            // // write partial buffer for all remote hit readers to see
+            // writeBufToDisk(-1, false, false);
         }
     }
 

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -35,7 +35,12 @@ Rock::IoState::IoState(Rock::SwapDir::Pointer &aDir,
     dir(aDir),
     slotSize(dir->slotSize),
     objOffset(0),
+    sidFirst(-1),
+    sidPrevious(-1),
     sidCurrent(-1),
+    sidNext(-1),
+    requestsSent(0),
+    repliesReceived(0),
     theBuf(dir->slotSize)
 {
     e = anEntry;
@@ -101,7 +106,8 @@ Rock::IoState::read_(char *buf, size_t len, off_t coreOff, STRCB *cb, void *data
     // if we are dealing with the first read or
     // if the offset went backwords, start searching from the beginning
     if (sidCurrent < 0 || coreOff < objOffset) {
-        sidCurrent = readAnchor().start;
+        // readers do not need sidFirst but set it for consistency/triage sake
+        sidCurrent = sidFirst = readAnchor().start;
         objOffset = 0;
     }
 
@@ -126,14 +132,32 @@ Rock::IoState::read_(char *buf, size_t len, off_t coreOff, STRCB *cb, void *data
     len = min(len,
               static_cast<size_t>(objOffset + currentReadableSlice().size - coreOff));
     const uint64_t diskOffset = dir->diskOffset(sidCurrent);
-    theFile->read(new ReadRequest(::ReadRequest(buf,
-                                  diskOffset + sizeof(DbCellHeader) + coreOff - objOffset, len), this));
+    const auto start = diskOffset + sizeof(DbCellHeader) + coreOff - objOffset;
+    const auto request = new ReadRequest(::ReadRequest(buf, start, len), this);
+    request->id = ++requestsSent;
+    theFile->read(request);
 }
 
 void
+Rock::IoState::handleReadCompletion(Rock::ReadRequest &request, const int rlen, const int errFlag)
+{
+    if (errFlag != DISK_OK || rlen < 0) {
+        debugs(79, 3, errFlag << " failure for " << *e);
+        return callReaderBack(request.buf, -1);
+    }
+
+    if (!expectedReply(request.id))
+        return callReaderBack(request.buf, -1);
+
+    debugs(79, 5, '#' << request.id << " read " << rlen << " bytes at " << offset_ << " for " << *e);
+    offset_ += rlen;
+    callReaderBack(request.buf, rlen);
+}
+
+/// report (already sanitized/checked) I/O results to the read initiator
+void
 Rock::IoState::callReaderBack(const char *buf, int rlen)
 {
-    debugs(79, 5, rlen << " bytes for " << *e);
     splicingPoint = rlen >= 0 ? sidCurrent : -1;
     if (splicingPoint < 0)
         staleSplicingPointNext = -1;
@@ -181,44 +205,30 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
 {
     debugs(79, 7, swap_filen << " writes " << size << " more");
 
-    // either this is the first write or append; we do not support write gaps
+    // either this is the first write or append
+    // we do not support write gaps or rewrites
     assert(!coreOff || coreOff == -1);
+    assert(!coreOff == !offset_);
 
     // throw if an accepted unknown-size entry grew too big or max-size changed
     Must(static_cast<uint64_t>(offset_ + size) <= static_cast<uint64_t>(dir->maxObjectSize()));
 
-    // allocate the first slice during the first write
-    if (!coreOff) {
-        assert(sidCurrent < 0);
-        sidCurrent = dir->reserveSlotForWriting(); // throws on failures
-        assert(sidCurrent >= 0);
-        writeAnchor().start = sidCurrent;
-    }
-
     // buffer incoming data in slot buffer and write overflowing or final slots
     // quit when no data left or we stopped writing on reentrant error
     while (size > 0 && theFile != NULL) {
-        assert(sidCurrent >= 0);
         const size_t processed = writeToBuffer(buf, size);
         buf += processed;
         size -= processed;
         const bool overflow = size > 0;
 
         // We do not write a full buffer without overflow because
-        // we would not yet know what to set the nextSlot to.
+        // we do not want to risk writing a payload-free slot on EOF.
         if (overflow) {
-            const auto sidNext = dir->reserveSlotForWriting(); // throws
+            Must(sidNext < 0);
+            sidNext = dir->reserveSlotForWriting();
             assert(sidNext >= 0);
-            writeToDisk(sidNext);
-            // } else if (Store::Root().transientReaders(*e)) {
-            // XXX: Partial writes cannot be read -- no map->startAppending()!
-            // XXX: Partial writes confuse SwapDir::droppedEarlierRequest(),
-            // resulting in released entries and, hence, misses and CF retries.
-            // XXX: The effective benefit of partial writes is reduced by
-            // doPages() buffering SM_PAGE_SIZE*n leftovers.
-
-            // // write partial buffer for all remote hit readers to see
-            // writeBufToDisk(-1, false, false);
+            writeToDisk();
+            Must(sidNext < 0); // short sidNext lifetime simplifies code logic
         }
     }
 
@@ -234,7 +244,7 @@ Rock::IoState::writeToBuffer(char const *buf, size_t size)
         return 0;
 
     if (!theBuf.size) {
-        // will fill the header in writeToDisk when the next slot is known
+        // writeToDisk() will eventually fill this header space
         theBuf.appended(sizeof(DbCellHeader));
     }
 
@@ -245,44 +255,38 @@ Rock::IoState::writeToBuffer(char const *buf, size_t size)
 }
 
 /// write what was buffered during write() calls
-/// negative sidNext means this is the last write request for this entry
 void
-Rock::IoState::writeToDisk(const SlotId sidNextProposal)
+Rock::IoState::writeToDisk()
 {
     assert(theFile != NULL);
     assert(theBuf.size >= sizeof(DbCellHeader));
 
-    const bool lastWrite = sidNextProposal < 0;
+    assert((sidFirst < 0) == (sidCurrent < 0));
+    if (sidFirst < 0) // this is the first disk write
+        sidCurrent = sidFirst = dir->reserveSlotForWriting();
+
+    // negative sidNext means this is the last write request for this entry
+    const bool lastWrite = sidNext < 0;
+    // here, eof means that we are writing the right-most entry slot
     const bool eof = lastWrite &&
                      // either not updating or the updating reader has loaded everything
                      (touchingStoreEntry() || staleSplicingPointNext < 0);
-    // approve sidNextProposal unless _updating_ the last slot
-    const SlotId sidNext = (!touchingStoreEntry() && lastWrite) ?
-                           staleSplicingPointNext : sidNextProposal;
-    debugs(79, 5, "sidNext:" << sidNextProposal << "=>" << sidNext << " eof=" << eof);
+    debugs(79, 5, "sidCurrent=" << sidCurrent << " sidNext=" << sidNext << " eof=" << eof);
 
     // TODO: if DiskIO module is mmap-based, we should be writing whole pages
     // to avoid triggering read-page;new_head+old_tail;write-page overheads
 
-    writeBufToDisk(sidNext, eof, lastWrite);
-    theBuf.clear();
-
-    sidCurrent = sidNext;
-}
-
-/// creates and submits a request to write current slot buffer to disk
-/// eof is true if and only this is the last slot
-void
-Rock::IoState::writeBufToDisk(const SlotId sidNext, const bool eof, const bool lastWrite)
-{
-    // no slots after the last/eof slot (but partial slots may have a nil next)
-    assert(!eof || sidNext < 0);
+    assert(eof == (sidNext < 0)); // no slots after eof
 
     // finalize db cell header
     DbCellHeader header;
     memcpy(header.key, e->key, sizeof(header.key));
-    header.firstSlot = writeAnchor().start;
-    header.nextSlot = sidNext;
+    header.firstSlot = sidFirst;
+
+    const auto updatingTheLastSlot = !touchingStoreEntry() && lastWrite;
+    assert(!updatingTheLastSlot || sidNext < 0);
+    header.nextSlot = updatingTheLastSlot ? staleSplicingPointNext : sidNext;
+
     header.payloadSize = theBuf.size - sizeof(DbCellHeader);
     header.entrySize = eof ? offset_ : 0; // storeSwapOutFileClosed sets swap_file_sz after write
     header.version = writeAnchor().basics.timestamp;
@@ -305,16 +309,48 @@ Rock::IoState::writeBufToDisk(const SlotId sidNext, const bool eof, const bool l
         ::WriteRequest(static_cast<char*>(wBuf), diskOffset, theBuf.size,
                        memFreeBufFunc(wBufCap)), this);
     r->sidCurrent = sidCurrent;
-    r->sidNext = sidNext;
+    r->sidPrevious = sidPrevious;
+    r->id = ++requestsSent;
     r->eof = lastWrite;
+
+    sidPrevious = sidCurrent;
+    sidCurrent = sidNext; // sidNext may be cleared/negative already
+    sidNext = -1;
+
+    theBuf.clear();
 
     // theFile->write may call writeCompleted immediatelly
     theFile->write(r);
 }
 
+bool
+Rock::IoState::expectedReply(const IoXactionId receivedId)
+{
+    Must(requestsSent); // paranoid: we sent some requests
+    Must(receivedId); // paranoid: the request was sent by some sio
+    Must(receivedId <= requestsSent); // paranoid: within our range
+    ++repliesReceived;
+    const auto expectedId = repliesReceived;
+    if (receivedId == expectedId)
+        return true;
+
+    debugs(79, 3, "no; expected reply #" << expectedId <<
+           ", but got #" << receivedId);
+    return false;
+}
+
 void
 Rock::IoState::finishedWriting(const int errFlag)
 {
+    if (sidCurrent >= 0) {
+        dir->noteFreeMapSlice(sidCurrent);
+        sidCurrent = -1;
+    }
+    if (sidNext >= 0) {
+        dir->noteFreeMapSlice(sidNext);
+        sidNext = -1;
+    }
+
     // we incremented offset_ while accumulating data in write()
     // we do not reset writeableAnchor_ here because we still keep the lock
     if (touchingStoreEntry())
@@ -326,7 +362,9 @@ void
 Rock::IoState::close(int how)
 {
     debugs(79, 3, swap_filen << " offset: " << offset_ << " how: " << how <<
-           " buf: " << theBuf.size << " callback: " << callback);
+           " leftovers: " << theBuf.size <<
+           " after " << requestsSent << '/' << repliesReceived <<
+           " callback: " << callback);
 
     if (!theFile) {
         debugs(79, 3, "I/O already canceled");
@@ -339,7 +377,7 @@ Rock::IoState::close(int how)
     switch (how) {
     case wroteAll:
         assert(theBuf.size > 0); // we never flush last bytes on our own
-        writeToDisk(-1); // flush last, yet unwritten slot to disk
+        writeToDisk(); // flush last, yet unwritten slot to disk
         return; // writeCompleted() will callBack()
 
     case writerGone:

--- a/src/fs/rock/RockIoState.h
+++ b/src/fs/rock/RockIoState.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_FS_ROCK_IO_STATE_H
 #define SQUID_FS_ROCK_IO_STATE_H
 
+#include "fs/rock/forward.h"
 #include "fs/rock/RockSwapDir.h"
 #include "sbuf/MemBlob.h"
 
@@ -41,11 +42,15 @@ public:
     /// whether we are still waiting for the I/O results (i.e., not closed)
     bool stillWaiting() const { return theFile != NULL; }
 
-    /// forwards read data to the reader that initiated this I/O
-    void callReaderBack(const char *buf, int rlen);
+    /// forwards read data (or an error) to the reader that initiated this I/O
+    void handleReadCompletion(Rock::ReadRequest &request, const int rlen, const int errFlag);
 
     /// called by SwapDir::writeCompleted() after the last write and on error
     void finishedWriting(const int errFlag);
+
+    /// notes that the disker has satisfied the given I/O request
+    /// \returns whether all earlier I/O requests have been already satisfied
+    bool expectedReply(const IoXactionId receivedId);
 
     /* one and only one of these will be set and locked; access via *Anchor() */
     const Ipc::StoreMapAnchor *readableAnchor_; ///< starting point for reading
@@ -64,15 +69,36 @@ private:
 
     void tryWrite(char const *buf, size_t size, off_t offset);
     size_t writeToBuffer(char const *buf, size_t size);
-    void writeToDisk(const SlotId nextSlot);
-    void writeBufToDisk(const SlotId nextSlot, const bool eof, const bool lastWrite);
+    void writeToDisk();
 
+    void callReaderBack(const char *buf, int rlen);
     void callBack(int errflag);
 
     Rock::SwapDir::Pointer dir; ///< swap dir that initiated I/O
     const size_t slotSize; ///< db cell size
     int64_t objOffset; ///< object offset for current db slot
-    SlotId sidCurrent; ///< ID of the db slot currently being read or written
+
+    /// The very first entry slot. Usually the same as anchor.first,
+    /// but writers set anchor.first only after the first write is done.
+    SlotId sidFirst;
+
+    /// Unused by readers.
+    /// For writers, the slot pointing (via .next) to sidCurrent.
+    SlotId sidPrevious;
+
+    /// For readers, the db slot currently being read from disk.
+    /// For writers, the reserved db slot that will be filled and written next.
+    SlotId sidCurrent;
+
+    /// Unused by readers.
+    /// For writers, the reserved db slot that sidCurrent.next will point to.
+    SlotId sidNext;
+
+    /// the number of read or write requests we sent to theFile
+    uint64_t requestsSent;
+
+    /// the number of successful responses we received from theFile
+    uint64_t repliesReceived;
 
     RefCount<DiskFile> theFile; // "file" responsible for this I/O
     MemBlob theBuf; // use for write content accumulation only

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -845,16 +845,15 @@ Rock::SwapDir::readCompleted(const char *, int rlen, int errflag, RefCount< ::Re
     ReadRequest *request = dynamic_cast<Rock::ReadRequest*>(r.getRaw());
     assert(request);
     IoState::Pointer sio = request->sio;
-
-    if (errflag == DISK_OK && rlen > 0)
-        sio->offset_ += rlen;
-
-    sio->callReaderBack(r->buf, rlen);
+    sio->handleReadCompletion(*request, rlen, errflag);
 }
 
 void
 Rock::SwapDir::writeCompleted(int errflag, size_t, RefCount< ::WriteRequest> r)
 {
+    // TODO: Move details into IoState::handleWriteCompletion() after figuring
+    // out how to deal with map access. See readCompleted().
+
     Rock::WriteRequest *request = dynamic_cast<Rock::WriteRequest*>(r.getRaw());
     assert(request);
     assert(request->sio !=  NULL);
@@ -863,7 +862,7 @@ Rock::SwapDir::writeCompleted(int errflag, size_t, RefCount< ::WriteRequest> r)
     // quit if somebody called IoState::close() while we were waiting
     if (!sio.stillWaiting()) {
         debugs(79, 3, "ignoring closed entry " << sio.swap_filen);
-        noteFreeMapSlice(request->sidNext);
+        noteFreeMapSlice(request->sidCurrent);
         return;
     }
 
@@ -871,7 +870,7 @@ Rock::SwapDir::writeCompleted(int errflag, size_t, RefCount< ::WriteRequest> r)
 
     if (errflag != DISK_OK)
         handleWriteCompletionProblem(errflag, *request);
-    else if (droppedEarlierRequest(*request))
+    else if (!sio.expectedReply(request->id))
         handleWriteCompletionProblem(DISK_ERROR, *request);
     else
         handleWriteCompletionSuccess(*request);
@@ -888,15 +887,24 @@ Rock::SwapDir::handleWriteCompletionSuccess(const WriteRequest &request)
     sio.splicingPoint = request.sidCurrent;
     // do not increment sio.offset_ because we do it in sio->write()
 
+    assert(sio.writeableAnchor_);
+    if (sio.writeableAnchor_->start < 0) { // wrote the first slot
+        Must(request.sidPrevious < 0);
+        sio.writeableAnchor_->start = request.sidCurrent;
+    } else {
+        Must(request.sidPrevious >= 0);
+        map->writeableSlice(sio.swap_filen, request.sidPrevious).next = request.sidCurrent;
+    }
+
     // finalize the shared slice info after writing slice contents to disk
+    // once done, the chain gets possession of the slice we were writing
     Ipc::StoreMap::Slice &slice =
         map->writeableSlice(sio.swap_filen, request.sidCurrent);
     slice.size = request.len - sizeof(DbCellHeader);
-    slice.next = request.sidNext;
+    Must(slice.next < 0);
 
     if (request.eof) {
         assert(sio.e);
-        assert(sio.writeableAnchor_);
         if (sio.touchingStoreEntry()) {
             sio.e->swap_file_sz = sio.writeableAnchor_->basics.swap_file_sz =
                                       sio.offset_;
@@ -915,7 +923,7 @@ Rock::SwapDir::handleWriteCompletionProblem(const int errflag, const WriteReques
 {
     auto &sio = *request.sio;
 
-    noteFreeMapSlice(request.sidNext);
+    noteFreeMapSlice(request.sidCurrent);
 
     writeError(sio);
     sio.finishedWriting(errflag);
@@ -934,23 +942,6 @@ Rock::SwapDir::writeError(StoreIOState &sio)
     // else noop: a fresh entry update error does not affect stale entry readers
 
     // All callers must also call IoState callback, to propagate the error.
-}
-
-/// whether the disk has dropped at least one of the previous write requests
-bool
-Rock::SwapDir::droppedEarlierRequest(const WriteRequest &request) const
-{
-    const auto &sio = *request.sio;
-    assert(sio.writeableAnchor_);
-    const Ipc::StoreMapSliceId expectedSliceId = sio.splicingPoint < 0 ?
-            sio.writeableAnchor_->start :
-            map->writeableSlice(sio.swap_filen, sio.splicingPoint).next;
-    if (expectedSliceId != request.sidCurrent) {
-        debugs(79, 3, "yes; expected " << expectedSliceId << ", but got " << request.sidCurrent);
-        return true;
-    }
-
-    return false;
 }
 
 void

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -140,7 +140,6 @@ private:
     void createError(const char *const msg);
     void handleWriteCompletionSuccess(const WriteRequest &request);
     void handleWriteCompletionProblem(const int errflag, const WriteRequest &request);
-    bool droppedEarlierRequest(const WriteRequest &request) const;
 
     DiskIOStrategy *io;
     RefCount<DiskFile> theFile; ///< cache storage for this cache_dir

--- a/src/fs/rock/forward.h
+++ b/src/fs/rock/forward.h
@@ -32,6 +32,9 @@ class SwapDir;
 /// db cell number, starting with cell 0 (always occupied by the db header)
 typedef sfileno SlotId;
 
+/// unique (within a given IoState object scope) I/O transaction identifier
+typedef uint64_t IoXactionId;
+
 class Rebuild;
 
 class IoState;
@@ -39,6 +42,8 @@ class IoState;
 class HeaderUpdater;
 
 class DbCellHeader;
+
+class ReadRequest;
 
 class WriteRequest;
 

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -295,7 +295,7 @@ Http::Stream::sendStartOfMessage(HttpReply *rep, StoreIOBuffer bodyData)
             std::unique_ptr<ACLFilledChecklist> chl(clientAclChecklistCreate(pool->access, http));
             chl->reply = rep;
             HTTPMSGLOCK(chl->reply);
-            const allow_t answer = chl->fastCheck();
+            const auto answer = chl->fastCheck();
             if (answer.allowed()) {
                 writeQuotaHandler = pool->createBucket();
                 fd_table[clientConnection->fd].writeQuotaHandler = writeQuotaHandler;

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -99,13 +99,9 @@ internalRemoteUri(bool encrypt, const char *host, unsigned short port, const cha
 
     /*
      * append the domain in order to mirror the requests with appended
-     * domains
+     * domains. If that fails, just use the hostname anyway.
      */
-
-    /* For IPv6 addresses also check for a colon */
-    if (Config.appendDomain && !strchr(lc_host, '.') && !strchr(lc_host, ':'))
-        strncat(lc_host, Config.appendDomain, SQUIDHOSTNAMELEN -
-                strlen(lc_host) - 1);
+    (void)urlAppendDomain(lc_host);
 
     /* build URI */
     AnyP::Uri tmp(AnyP::PROTO_HTTP);

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -198,7 +198,7 @@ PeerSelectionInitiator::startSelectingDestinations(HttpRequest *request, const A
 }
 
 void
-PeerSelector::checkNeverDirectDone(const allow_t answer)
+PeerSelector::checkNeverDirectDone(const Acl::Answer answer)
 {
     acl_checklist = nullptr;
     debugs(44, 3, answer);
@@ -220,13 +220,13 @@ PeerSelector::checkNeverDirectDone(const allow_t answer)
 }
 
 void
-PeerSelector::CheckNeverDirectDone(allow_t answer, void *data)
+PeerSelector::CheckNeverDirectDone(Acl::Answer answer, void *data)
 {
     static_cast<PeerSelector*>(data)->checkNeverDirectDone(answer);
 }
 
 void
-PeerSelector::checkAlwaysDirectDone(const allow_t answer)
+PeerSelector::checkAlwaysDirectDone(const Acl::Answer answer)
 {
     acl_checklist = nullptr;
     debugs(44, 3, answer);
@@ -248,7 +248,7 @@ PeerSelector::checkAlwaysDirectDone(const allow_t answer)
 }
 
 void
-PeerSelector::CheckAlwaysDirectDone(allow_t answer, void *data)
+PeerSelector::CheckAlwaysDirectDone(Acl::Answer answer, void *data)
 {
     static_cast<PeerSelector*>(data)->checkAlwaysDirectDone(answer);
 }

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -119,14 +119,15 @@ Security::KeyData::loadX509ChainFromFile()
             }
 #endif
             // checks that the chained certs are actually part of a chain for validating cert
-            if (X509_check_issued(ca, latestCert.get()) == X509_V_OK) {
+            const auto checkCode = X509_check_issued(ca, latestCert.get());
+            if (checkCode == X509_V_OK) {
                 debugs(83, DBG_PARSE_NOTE(3), "Adding issuer CA: " << nameStr);
                 // OpenSSL API requires that we order certificates such that the
                 // chain can be appended directly into the on-wire traffic.
                 latestCert = CertPointer(ca);
                 chain.emplace_front(latestCert);
             } else {
-                debugs(83, DBG_PARSE_NOTE(2), "Ignoring non-issuer CA from " << certFile << ": " << nameStr);
+                debugs(83, DBG_PARSE_NOTE(2), certFile << ": Ignoring non-issuer CA " << nameStr << ": " << X509_verify_cert_error_string(checkCode) << " (" << checkCode << ")");
             }
             OPENSSL_free(nameStr);
         }

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -115,7 +115,7 @@ protected:
 #elif USE_GNUTLS
         debugs(83, 5, "gnutls_certificate_credentials construct, this=" << (void*)ctx);
         return Security::ContextPointer(ctx, [](gnutls_certificate_credentials_t p) {
-            debugs(83, 0, "gnutls_certificate_credentials destruct this=" << (void*)p);
+            debugs(83, 5, "gnutls_certificate_credentials destruct, this=" << (void*)p);
             gnutls_certificate_free_credentials(p);
         });
 #else

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -26,7 +26,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Ssl, PeekingPeerConnector);
 void switchToTunnel(HttpRequest *request, Comm::ConnectionPointer & clientConn, Comm::ConnectionPointer &srvConn);
 
 void
-Ssl::PeekingPeerConnector::cbCheckForPeekAndSpliceDone(allow_t answer, void *data)
+Ssl::PeekingPeerConnector::cbCheckForPeekAndSpliceDone(Acl::Answer answer, void *data)
 {
     Ssl::PeekingPeerConnector *peerConnect = (Ssl::PeekingPeerConnector *) data;
     // Use job calls to add done() checks and other job logic/protections.
@@ -34,7 +34,7 @@ Ssl::PeekingPeerConnector::cbCheckForPeekAndSpliceDone(allow_t answer, void *dat
 }
 
 void
-Ssl::PeekingPeerConnector::checkForPeekAndSpliceDone(allow_t answer)
+Ssl::PeekingPeerConnector::checkForPeekAndSpliceDone(Acl::Answer answer)
 {
     const Ssl::BumpMode finalAction = answer.allowed() ?
                                       static_cast<Ssl::BumpMode>(answer.kind):
@@ -58,18 +58,18 @@ Ssl::PeekingPeerConnector::checkForPeekAndSplice()
         ::Config.accessList.ssl_bump,
         request.getRaw(), NULL);
     acl_checklist->al = al;
-    acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpNone));
-    acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpPeek));
-    acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpStare));
-    acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpClientFirst));
-    acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpServerFirst));
+    acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpNone));
+    acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpPeek));
+    acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpStare));
+    acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpClientFirst));
+    acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpServerFirst));
     Security::SessionPointer session(fd_table[serverConn->fd].ssl);
     BIO *b = SSL_get_rbio(session.get());
     Ssl::ServerBio *srvBio = static_cast<Ssl::ServerBio *>(BIO_get_data(b));
     if (!srvBio->canSplice())
-        acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpSplice));
+        acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpSplice));
     if (!srvBio->canBump())
-        acl_checklist->banAction(allow_t(ACCESS_ALLOWED, Ssl::bumpBump));
+        acl_checklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpBump));
     acl_checklist->syncAle(request.getRaw(), nullptr);
     acl_checklist->nonBlockingCheck(Ssl::PeekingPeerConnector::cbCheckForPeekAndSpliceDone, this);
 }

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -52,7 +52,7 @@ public:
     void checkForPeekAndSplice();
 
     /// Callback function for ssl_bump acl check in step3  SSL bump step.
-    void checkForPeekAndSpliceDone(allow_t answer);
+    void checkForPeekAndSpliceDone(Acl::Answer answer);
 
     /// Handles the final bumping decision.
     void checkForPeekAndSpliceMatched(const Ssl::BumpMode finalMode);
@@ -65,7 +65,7 @@ public:
     void serverCertificateVerified();
 
     /// A wrapper function for checkForPeekAndSpliceDone for use with acl
-    static void cbCheckForPeekAndSpliceDone(allow_t answer, void *data);
+    static void cbCheckForPeekAndSpliceDone(Acl::Answer answer, void *data);
 
 private:
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -506,6 +506,9 @@ store_client::readBody(const char *, ssize_t len)
     assert(_callback.pending());
     debugs(90, 3, "storeClientReadBody: len " << len << "");
 
+    if (len < 0)
+        return fail();
+
     if (copyInto.offset == 0 && len > 0 && entry->getReply()->sline.status() == Http::scNone) {
         /* Our structure ! */
         HttpReply *rep = (HttpReply *) entry->getReply(); // bypass const
@@ -567,13 +570,8 @@ storeClientReadBody(void *data, const char *buf, ssize_t len, StoreIOState::Poin
 bool
 store_client::unpackHeader(char const *buf, ssize_t len)
 {
-    int xerrno = errno; // FIXME: where does errno come from?
     debugs(90, 3, "store_client::unpackHeader: len " << len << "");
-
-    if (len < 0) {
-        debugs(90, 3, "WARNING: unpack error: " << xstrerr(xerrno));
-        return false;
-    }
+    assert(len >= 0);
 
     int swap_hdr_sz = 0;
     tlv *tlv_list = nullptr;
@@ -622,6 +620,9 @@ store_client::readHeader(char const *buf, ssize_t len)
     // abort if we fail()'d earlier
     if (!object_ok)
         return;
+
+    if (len < 0)
+        return fail();
 
     if (!unpackHeader(buf, len)) {
         fail();

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -12,10 +12,10 @@
 #include "STUB.h"
 
 #if USE_AUTH
-#include "acl/Acl.h" /* for allow_t */
+#include "acl/Acl.h" /* for Acl::Answer */
 
 #include "auth/Acl.h"
-allow_t AuthenticateAcl(ACLChecklist *) STUB_RETVAL(ACCESS_DENIED)
+Acl::Answer AuthenticateAcl(ACLChecklist *) STUB_RETVAL(ACCESS_DENIED)
 
 #include "auth/AclMaxUserIp.h"
 ACL * ACLMaxUserIP::clone() const STUB_RETVAL(NULL)


### PR DESCRIPTION
Also probably fixed sent response corruption related to aborted rock
swapins.

The following disk entry contamination sequence was observed in detailed
cache logs during high-load Polygraph tests. Some of the observed
level-1 errors matched those in real-world deployments.

1. Worker A schedules AX – a request to write a piece of entry A to disk
   slot X. The disker is busy writing and reading other slots for worker
   A and other workers so AX stays in the A-to-Disker queue for a while.
2. Entry A aborts swapout (for any reason, including network errors
   while receiving the being-stored response). Squid makes disk slot X
   available for other entries to use. AX stays queued.
3. Another worker B picks up disk slot X (from the shared free disk slot
   pool) and schedules BX, a request to write a piece of entry B to disk
   slot X. BX gets queued in an B-to-Disker queue. AX stays queued.
4. The disker satisfies write request BX. Disk slot X contains entry B
   contents now. AX stays queued.
5. The disker satisfies write request AX. Disk slot X is a part of entry
   B slot chain but contains former entry A contents now! HTTP requests
   for entry B now read entry A leftovers from disk and complain about
   metadata mismatches (at best) or get wrong response contents (at
   worst).

To prevent premature disk slot reuse, we now keep disk slots reserved
while they are in the disk queue, even if the corresponding cache entry
is long gone: Individual disk write requests now "own" the slot they are
writing. The Rock::IoState object owns reserved but not yet used slots
so that they can be freed when the object is gone. The disk entry owns
the (successfully written) slots added to its chain in the map.

The new slot ownership scheme required changes in what metadata the
writing code has to maintain. For example, we now keep the address of
the previous slot in the entry chain so that we can update its .next
field after a successful disk write. Also, the old code detecting
dropped write requests could no longer rely on the now-empty .next field
in the previous map entry. The rewritten code numbers I/O transactions
so that out-of-order replies can be detected without using the map.

I tried to simplify the metadata maintenance code by shortening
reservation lifetimes and using just-in-time [first] slot reservations.
The new code may also leak fewer slots when facing C++ exceptions.

As for reading, I realized that we had no protection from dropped rock
read requests. If the first read request is dropped, the metadata
decoding would probably fail but if subsequent reads are skipped, the
client may be fed with data that is missing those skipped blocks. I did
not try to reproduce these problems, but they are not fixed using the
same I/O transaction numbering mechanism that the writing code now uses.

I also removed commented out "partial writing" code because IoState
class member changes should expose any dangerous merge problems.