### PR TITLE
Fix "BUG: Lost previously bumped from-Squid connection"

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1046,8 +1046,6 @@ FwdState::usePinned()
     }
 
     if (connManager->pinning.peerAccessDenied) {
-        // The peer selection policy denies access to pinned connection.
-        // Return an error page to the client.
         serverConn = nullptr;
         temp->close();
         fail(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al));

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1017,10 +1017,17 @@ FwdState::connectStart()
     AsyncJob::Start(cs);
 }
 
-Comm::ConnectionPointer
-FwdState::healthyPinnedConnection()
+/// send request on an existing connection dedicated to the requesting client
+void
+FwdState::usePinned()
 {
+    // we only handle pinned destinations; others are handled by connectStart()
+    assert(!serverDestinations.empty());
+    assert(!serverDestinations[0]);
+
     const auto connManager = request->pinnedConnection();
+    debugs(17, 7, "connection manager: " << connManager);
+
     // the client connection may close while we get here, nullifying connManager
     const auto temp = connManager ? connManager->borrowPinnedConnection(request) : nullptr;
     debugs(17, 5, "connection: " << temp);
@@ -1031,22 +1038,6 @@ FwdState::healthyPinnedConnection()
         serverConn = nullptr;
         const auto anErr = new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, request, al);
         fail(anErr);
-        return Comm::ConnectionPointer(nullptr);
-    }
-
-    return temp;
-}
-
-/// send request on an existing connection dedicated to the requesting client
-void
-FwdState::usePinned()
-{
-    // we only handle pinned destinations; others are handled by connectStart()
-    assert(!serverDestinations.empty());
-    assert(!serverDestinations[0]);
-
-    serverConn = healthyPinnedConnection();
-    if (!serverConn) {
         // Connection managers monitor their idle pinned to-server
         // connections and close from-client connections upon seeing
         // a to-server connection closure. Retrying here is futile.
@@ -1054,25 +1045,26 @@ FwdState::usePinned()
         return;
     }
 
-    const auto connManager = request->pinnedConnection();
     if (connManager->pinning.peerAccessDenied) {
         // The peer selection policy denies access to pinned connection.
         // Return an error page to the client.
+        serverConn = nullptr;
+        temp->close();
         fail(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al));
         stopAndDestroy("pinned connection access denied");
         return;
     }
 
+    serverConn = temp;
     flags.connected_okay = true;
     ++n_tries;
     request->flags.pinned = true;
 
-    debugs(17, 7, "connection manager: " << connManager);
     assert(connManager);
     if (connManager->pinnedAuth())
         request->flags.auth = true;
 
-    closeHandler = comm_add_close_handler(serverConn->fd,  fwdServerClosedWrapper, this);
+    closeHandler = comm_add_close_handler(temp->fd,  fwdServerClosedWrapper, this);
 
     syncWithServerConn(connManager->pinning.host);
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1028,6 +1028,8 @@ FwdState::usePinned()
     const auto connManager = request->pinnedConnection();
     debugs(17, 7, "connection manager: " << connManager);
 
+    const auto peerDenied = connManager && connManager->pinning.peerAccessDenied;
+
     // the client connection may close while we get here, nullifying connManager
     const auto temp = connManager ? connManager->borrowPinnedConnection(request) : nullptr;
     debugs(17, 5, "connection: " << temp);
@@ -1036,7 +1038,7 @@ FwdState::usePinned()
     if (!Comm::IsConnOpen(temp)) {
         syncHierNote(temp, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;
-        const auto errType = connManager && connManager->pinning.peerAccessDenied ? ERR_CANNOT_FORWARD : ERR_ZERO_SIZE_OBJECT;
+        const auto errType = peerDenied ? ERR_CANNOT_FORWARD : ERR_ZERO_SIZE_OBJECT;
         const auto anErr = new ErrorState(errType, Http::scServiceUnavailable, request, al);
         fail(anErr);
         // Connection managers monitor their idle pinned to-server

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1029,9 +1029,8 @@ FwdState::usePinned()
     debugs(17, 7, "connection manager: " << connManager);
 
     try {
-        const auto temp = ConnStateData::BorrowPinnedConnection(request, al);
-        debugs(17, 5, "connection: " << temp);
-        serverConn = temp;
+        serverConn = ConnStateData::BorrowPinnedConnection(request, al);
+        debugs(17, 5, "connection: " << serverConn);
     } catch (ErrorState * const anErr) {
         syncHierNote(nullptr, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1029,20 +1029,17 @@ FwdState::usePinned()
     debugs(17, 7, "connection manager: " << connManager);
 
     try {
-        const auto temp = ConnStateData::BorrowPinnedConnection(request);
+        const auto temp = ConnStateData::BorrowPinnedConnection(request, al);
         debugs(17, 5, "connection: " << temp);
         serverConn = temp;
-    } catch (const PinningException &ex) {
-        // the previously pinned idle peer connection may get closed (by the peer)
+    } catch (ErrorState * const anErr) {
         syncHierNote(nullptr, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;
-        const auto errType = (ex.errType == PinningException::errConnectionGone) ? ERR_ZERO_SIZE_OBJECT : ERR_CANNOT_FORWARD;
-        const auto anErr = new ErrorState(errType, Http::scServiceUnavailable, request, al);
         fail(anErr);
         // Connection managers monitor their idle pinned to-server
         // connections and close from-client connections upon seeing
         // a to-server connection closure. Retrying here is futile.
-        stopAndDestroy(ex.what());
+        stopAndDestroy("pinned connection failure");
         return;
     }
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1036,20 +1036,13 @@ FwdState::usePinned()
     if (!Comm::IsConnOpen(temp)) {
         syncHierNote(temp, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;
-        const auto anErr = new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, request, al);
+        const auto errType = connManager && connManager->pinning.peerAccessDenied ? ERR_CANNOT_FORWARD : ERR_ZERO_SIZE_OBJECT;
+        const auto anErr = new ErrorState(errType, Http::scServiceUnavailable, request, al);
         fail(anErr);
         // Connection managers monitor their idle pinned to-server
         // connections and close from-client connections upon seeing
         // a to-server connection closure. Retrying here is futile.
         stopAndDestroy("pinned connection failure");
-        return;
-    }
-
-    if (connManager->pinning.peerAccessDenied) {
-        serverConn = nullptr;
-        temp->close();
-        fail(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al));
-        stopAndDestroy("pinned connection access denied");
         return;
     }
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -964,28 +964,26 @@ FwdState::connectStart()
 
     request->hier.startPeerClock();
 
-    // Requests bumped at step2+ require their pinned connection. Since we
-    // failed to reuse the pinned connection, we now must terminate the
-    // bumped request. For client-first and step1 bumped requests, the
-    // from-client connection is already bumped, but the connection to the
-    // server is not established/pinned so they must be excluded. We can
-    // recognize step1 bumping by nil ConnStateData::serverBump().
-#if USE_OPENSSL
-    const auto clientFirstBump = request->clientConnectionManager.valid() &&
-                                 (request->clientConnectionManager->sslBumpMode == Ssl::bumpClientFirst ||
-                                  (request->clientConnectionManager->sslBumpMode == Ssl::bumpBump && !request->clientConnectionManager->serverBump())
-                                 );
-#else
-    const auto clientFirstBump = false;
-#endif /* USE_OPENSSL */
-    if (request->flags.sslBumped && !clientFirstBump) {
-        // TODO: Factor out/reuse as Occasionally(DBG_IMPORTANT, 2[, occurrences]).
-        static int occurrences = 0;
-        const auto level = (occurrences++ < 100) ? DBG_IMPORTANT : 2;
-        debugs(17, level, "BUG: Lost previously bumped from-Squid connection. Rejecting bumped request.");
-        fail(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al));
-        self = nullptr; // refcounted
-        return;
+    if (request->pinnedConnection()) {
+        // This is a previously pinned connection which not allowed to be used
+        // any more probably because of peer selection policy.
+
+        if (!healthyPinnedConnection()) {
+            // client connection is going to be closed soon.
+            stopAndDestroy("pinned connection is closing");
+            return;
+        }
+
+        // We have a pinned connection and we should check if reconnect/retry
+        // is allowed for this type of pinned connections.
+        if (!retriablePinned()) {
+            debugs(17, 2, "Deny to use non re-triable pinned connection. Rejecting request.");
+            fail(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al));
+            stopAndDestroy("non re-triable pinned connection");
+            return;
+        }
+
+        request->pinnedConnection()->unpinConnection(true);
     }
 
     // Use pconn to avoid opening a new connection.
@@ -1040,17 +1038,10 @@ FwdState::connectStart()
     AsyncJob::Start(cs);
 }
 
-/// send request on an existing connection dedicated to the requesting client
-void
-FwdState::usePinned()
+Comm::ConnectionPointer
+FwdState::healthyPinnedConnection()
 {
-    // we only handle pinned destinations; others are handled by connectStart()
-    assert(!serverDestinations.empty());
-    assert(!serverDestinations[0]);
-
     const auto connManager = request->pinnedConnection();
-    debugs(17, 7, "connection manager: " << connManager);
-
     // the client connection may close while we get here, nullifying connManager
     const auto temp = connManager ? connManager->borrowPinnedConnection(request) : nullptr;
     debugs(17, 5, "connection: " << temp);
@@ -1061,6 +1052,22 @@ FwdState::usePinned()
         serverConn = nullptr;
         const auto anErr = new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, request, al);
         fail(anErr);
+        return Comm::ConnectionPointer(nullptr);
+    }
+
+    return temp;
+}
+
+/// send request on an existing connection dedicated to the requesting client
+void
+FwdState::usePinned()
+{
+    // we only handle pinned destinations; others are handled by connectStart()
+    assert(!serverDestinations.empty());
+    assert(!serverDestinations[0]);
+
+    serverConn = healthyPinnedConnection();
+    if (!serverConn) {
         // Connection managers monitor their idle pinned to-server
         // connections and close from-client connections upon seeing
         // a to-server connection closure. Retrying here is futile.
@@ -1068,16 +1075,17 @@ FwdState::usePinned()
         return;
     }
 
-    serverConn = temp;
     flags.connected_okay = true;
     ++n_tries;
     request->flags.pinned = true;
 
+    const auto connManager = request->pinnedConnection();
+    debugs(17, 7, "connection manager: " << connManager);
     assert(connManager);
     if (connManager->pinnedAuth())
         request->flags.auth = true;
 
-    closeHandler = comm_add_close_handler(temp->fd,  fwdServerClosedWrapper, this);
+    closeHandler = comm_add_close_handler(serverConn->fd,  fwdServerClosedWrapper, this);
 
     syncWithServerConn(connManager->pinning.host);
 
@@ -1392,14 +1400,9 @@ FwdState::exhaustedTries() const
 }
 
 bool
-FwdState::pinnedCanRetry() const
+FwdState::retriablePinned() const
 {
     assert(request->flags.pinned);
-
-    // pconn race on pinned connection: Currently we do not have any mechanism
-    // to retry current pinned connection path.
-    if (pconnRace == raceHappened)
-        return false;
 
     // If a bumped connection was pinned, then the TLS client was given our peer
     // details. Do not retry because we do not ensure that those details stay
@@ -1411,6 +1414,19 @@ FwdState::pinnedCanRetry() const
     // The other pinned cases are FTP proxying and connection-based HTTP
     // authentication. TODO: Do these cases have restrictions?
     return true;
+}
+
+bool
+FwdState::pinnedCanRetry() const
+{
+    assert(request->flags.pinned);
+
+    // pconn race on pinned connection: Currently we do not have any mechanism
+    // to retry current pinned connection path.
+    if (pconnRace == raceHappened)
+        return false;
+
+    return retriablePinned();
 }
 
 time_t

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1028,27 +1028,24 @@ FwdState::usePinned()
     const auto connManager = request->pinnedConnection();
     debugs(17, 7, "connection manager: " << connManager);
 
-    const auto peerDenied = connManager && connManager->pinning.peerAccessDenied;
-
-    // the client connection may close while we get here, nullifying connManager
-    const auto temp = connManager ? connManager->borrowPinnedConnection(request) : nullptr;
-    debugs(17, 5, "connection: " << temp);
-
-    // the previously pinned idle peer connection may get closed (by the peer)
-    if (!Comm::IsConnOpen(temp)) {
-        syncHierNote(temp, connManager ? connManager->pinning.host : request->url.host());
+    try {
+        const auto temp = ConnStateData::BorrowPinnedConnection(request);
+        debugs(17, 5, "connection: " << temp);
+        serverConn = temp;
+    } catch (const PinningException &ex) {
+        // the previously pinned idle peer connection may get closed (by the peer)
+        syncHierNote(nullptr, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;
-        const auto errType = peerDenied ? ERR_CANNOT_FORWARD : ERR_ZERO_SIZE_OBJECT;
+        const auto errType = (ex.errType == PinningException::errConnectionGone) ? ERR_ZERO_SIZE_OBJECT : ERR_CANNOT_FORWARD;
         const auto anErr = new ErrorState(errType, Http::scServiceUnavailable, request, al);
         fail(anErr);
         // Connection managers monitor their idle pinned to-server
         // connections and close from-client connections upon seeing
         // a to-server connection closure. Retrying here is futile.
-        stopAndDestroy("pinned connection failure");
+        stopAndDestroy(ex.what());
         return;
     }
 
-    serverConn = temp;
     flags.connected_okay = true;
     ++n_tries;
     request->flags.pinned = true;
@@ -1057,7 +1054,7 @@ FwdState::usePinned()
     if (connManager->pinnedAuth())
         request->flags.auth = true;
 
-    closeHandler = comm_add_close_handler(temp->fd,  fwdServerClosedWrapper, this);
+    closeHandler = comm_add_close_handler(serverConn->fd,  fwdServerClosedWrapper, this);
 
     syncWithServerConn(connManager->pinning.host);
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1387,9 +1387,14 @@ FwdState::exhaustedTries() const
 }
 
 bool
-FwdState::retriablePinned() const
+FwdState::pinnedCanRetry() const
 {
     assert(request->flags.pinned);
+
+    // pconn race on pinned connection: Currently we do not have any mechanism
+    // to retry current pinned connection path.
+    if (pconnRace == raceHappened)
+        return false;
 
     // If a bumped connection was pinned, then the TLS client was given our peer
     // details. Do not retry because we do not ensure that those details stay
@@ -1401,19 +1406,6 @@ FwdState::retriablePinned() const
     // The other pinned cases are FTP proxying and connection-based HTTP
     // authentication. TODO: Do these cases have restrictions?
     return true;
-}
-
-bool
-FwdState::pinnedCanRetry() const
-{
-    assert(request->flags.pinned);
-
-    // pconn race on pinned connection: Currently we do not have any mechanism
-    // to retry current pinned connection path.
-    if (pconnRace == raceHappened)
-        return false;
-
-    return retriablePinned();
 }
 
 time_t

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -127,10 +127,6 @@ private:
 
     void usePinned();
 
-    /// If request use an existing pinned to-peer connection and this
-    /// connection is alive and healthy return the pinned connection.
-    Comm::ConnectionPointer healthyPinnedConnection();
-
     /// whether a pinned to-peer connection can be replaced with another one
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -131,11 +131,6 @@ private:
     /// connection is alive and healthy return the pinned connection.
     Comm::ConnectionPointer healthyPinnedConnection();
 
-    /// Whether the kind of pinned to-peer connection can be replaced with
-    /// another one. For example the bumped connections can not be retried,
-    /// but FTP proxying related pinned connections can retried.
-    bool retriablePinned() const;
-
     /// whether a pinned to-peer connection can be replaced with another one
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -127,6 +127,15 @@ private:
 
     void usePinned();
 
+    /// If request use an existing pinned to-peer connection and this
+    /// connection is alive and healthy return the pinned connection.
+    Comm::ConnectionPointer healthyPinnedConnection();
+
+    /// Whether the kind of pinned to-peer connection can be replaced with
+    /// another one. For example the bumped connections can not be retried,
+    /// but FTP proxying related pinned connections can retried.
+    bool retriablePinned() const;
+
     /// whether a pinned to-peer connection can be replaced with another one
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3886,8 +3886,8 @@ ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntry
 
     const auto pinningError = [&](const err_type type) {
         unpinConnection(true);
-        // TODO: Should we return NewForwarding() here instead?
-        return new ErrorState(type, Http::scServiceUnavailable, request, ale);
+        HttpRequestPointer requestPointer = request;
+        return ErrorState::NewForwarding(type, requestPointer, ale);
     };
 
     // XXX: Remove this change-minimization hack before the official commit:
@@ -3916,11 +3916,10 @@ ConnStateData::BorrowPinnedConnection(HttpRequest *request, const AccessLogEntry
     if (const auto connManager = request ? request->pinnedConnection() : nullptr)
         return connManager->borrowPinnedConnection(request, ale);
 
-    // TODO: Should we return NewForwarding() here instead?
-
     // ERR_CANNOT_FORWARD is somewhat misleading here; we can still forward, but
     // there is no point since the client connection is now gone
-    throw new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, ale);
+    HttpRequestPointer requestPointer = request;
+    throw ErrorState::NewForwarding(ERR_CANNOT_FORWARD, requestPointer, ale);
 }
 
 void

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3904,7 +3904,7 @@ ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntry
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
 
     if (pinning.peerAccessDenied)
-        throw pinningError(ERR_CANNOT_FORWARD);
+        throw pinningError(ERR_CANNOT_FORWARD); // TODO: Why not ERR_ACCESS_DENIED?
 
     stopPinnedConnectionMonitoring();
     return pinning.serverConnection;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3879,55 +3879,48 @@ ConnStateData::clientPinnedConnectionRead(const CommIoCbParams &io)
         clientConnection->close();
 }
 
-void
-ConnStateData::validatePinnedConnection(HttpRequest *request)
-{
-    debugs(33, 7, HERE << pinning.serverConnection);
-
-    PinningException::PinningErrorType errType = PinningException::errNone;
-    const char *error = nullptr;
-    if (!Comm::IsConnOpen(pinning.serverConnection)) {
-        error = "server connection closed";
-        errType = PinningException::errConnectionGone;
-    } else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0) {
-        error = "wrong destination";
-        errType = PinningException::errPolicy;
-    } else if (request && pinning.port != request->url.port()) {
-        error = "wrong destination port";
-        errType = PinningException::errPolicy;
-    } else if (pinning.peer && !cbdataReferenceValid(pinning.peer)) {
-        error = "cache peer is gone";
-        errType = PinningException::errConnectionGone;
-    } else if (pinning.peerAccessDenied) {
-        error = "peer access prohibited";
-        errType = PinningException::errPolicy;
-    }
-
-    if (error) {
-        /* The pinning info is not safe, remove any pinning info */
-        unpinConnection(true);
-        SBuf tmp("pinned connection failure: ");
-        tmp.append(error);
-        throw PinningException(errType, tmp.c_str());
-    }
-}
-
 Comm::ConnectionPointer
-ConnStateData::borrowPinnedConnection(HttpRequest *request)
+ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntryPointer &ale)
 {
     debugs(33, 7, pinning.serverConnection);
-    validatePinnedConnection(request); // throws on error
+
+    const auto pinningError = [&](const err_type type) {
+        unpinConnection(true);
+        // TODO: Should we return NewForwarding() here instead?
+        return new ErrorState(type, Http::scServiceUnavailable, request, ale);
+    };
+
+    // XXX: Remove this change-minimization hack before the official commit:
+    // 1. Remove "else"
+    // 2. Add empty lines between ifs
+    // 3. Replace request pointer with a request reference, simplifying ifs.
+    if (!Comm::IsConnOpen(pinning.serverConnection))
+        throw pinningError(ERR_ZERO_SIZE_OBJECT);
+    else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0)
+        throw pinningError(ERR_CANNOT_FORWARD);
+    else if (request && pinning.port != request->url.port())
+        throw pinningError(ERR_CANNOT_FORWARD);
+    else if (pinning.peer && !cbdataReferenceValid(pinning.peer))
+        throw pinningError(ERR_ZERO_SIZE_OBJECT);
+
+    if (pinning.peerAccessDenied)
+        throw pinningError(ERR_CANNOT_FORWARD);
+
     stopPinnedConnectionMonitoring();
     return pinning.serverConnection;
 }
 
 Comm::ConnectionPointer
-ConnStateData::BorrowPinnedConnection(HttpRequest *request)
+ConnStateData::BorrowPinnedConnection(HttpRequest *request, const AccessLogEntryPointer &ale)
 {
     if (const auto connManager = request ? request->pinnedConnection() : nullptr)
-        return connManager->borrowPinnedConnection(request);
+        return connManager->borrowPinnedConnection(request, ale);
 
-    throw PinningException(PinningException::errConnectionGone, "pinned connection failure: client connection gone");
+    // TODO: Should we return NewForwarding() here instead?
+
+    // ERR_CANNOT_FORWARD is somewhat misleading here; we can still forward, but
+    // there is no point since the client connection is now gone
+    throw new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, ale);
 }
 
 void

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2196,6 +2196,7 @@ ConnStateData::ConnStateData(const MasterXaction::Pointer &xact) :
     pinning.pinned = false;
     pinning.auth = false;
     pinning.zeroReply = false;
+    pinning.peerAccessDenied = false;
     pinning.peer = NULL;
 
     // store the details required for creating more MasterXaction objects as new requests come in
@@ -3936,6 +3937,7 @@ ConnStateData::unpinConnection(const bool andClose)
     safe_free(pinning.host);
 
     pinning.zeroReply = false;
+    pinning.peerAccessDenied = false;
 
     /* NOTE: pinning.pinned should be kept. This combined with fd == -1 at the end of a request indicates that the host
      * connection has gone away */

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3897,14 +3897,14 @@ ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntry
     if (!Comm::IsConnOpen(pinning.serverConnection))
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
     else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0)
-        throw pinningError(ERR_CANNOT_FORWARD);
+        throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_CONFLICT_HOST
     else if (request && pinning.port != request->url.port())
-        throw pinningError(ERR_CANNOT_FORWARD);
+        throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_CONFLICT_HOST
     else if (pinning.peer && !cbdataReferenceValid(pinning.peer))
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
 
     if (pinning.peerAccessDenied)
-        throw pinningError(ERR_CANNOT_FORWARD); // TODO: Why not ERR_ACCESS_DENIED?
+        throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_FORWARDING_DENIED
 
     stopPinnedConnectionMonitoring();
     return pinning.serverConnection;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3887,6 +3887,8 @@ ConnStateData::validatePinnedConnection(HttpRequest *request)
     bool valid = true;
     if (!Comm::IsConnOpen(pinning.serverConnection))
         valid = false;
+    else if (pinning.peerAccessDenied)
+        valid = false;
     else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0)
         valid = false;
     else if (request && pinning.port != request->url.port())

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3883,6 +3883,7 @@ Comm::ConnectionPointer
 ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntryPointer &ale)
 {
     debugs(33, 7, pinning.serverConnection);
+    Must(request);
 
     const auto pinningError = [&](const err_type type) {
         unpinConnection(true);
@@ -3890,17 +3891,16 @@ ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntry
         return ErrorState::NewForwarding(type, requestPointer, ale);
     };
 
-    // XXX: Remove this change-minimization hack before the official commit:
-    // 1. Remove "else"
-    // 2. Add empty lines between ifs
-    // 3. Replace request pointer with a request reference, simplifying ifs.
     if (!Comm::IsConnOpen(pinning.serverConnection))
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
-    else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0)
+
+    if (pinning.auth && pinning.host && strcasecmp(pinning.host, request->url.host()) != 0)
         throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_CONFLICT_HOST
-    else if (request && pinning.port != request->url.port())
+
+    if (pinning.port != request->url.port())
         throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_CONFLICT_HOST
-    else if (pinning.peer && !cbdataReferenceValid(pinning.peer))
+
+    if (pinning.peer && !cbdataReferenceValid(pinning.peer))
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
 
     if (pinning.peerAccessDenied)

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3879,39 +3879,55 @@ ConnStateData::clientPinnedConnectionRead(const CommIoCbParams &io)
         clientConnection->close();
 }
 
-const Comm::ConnectionPointer
+void
 ConnStateData::validatePinnedConnection(HttpRequest *request)
 {
     debugs(33, 7, HERE << pinning.serverConnection);
 
-    bool valid = true;
-    if (!Comm::IsConnOpen(pinning.serverConnection))
-        valid = false;
-    else if (pinning.peerAccessDenied)
-        valid = false;
-    else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0)
-        valid = false;
-    else if (request && pinning.port != request->url.port())
-        valid = false;
-    else if (pinning.peer && !cbdataReferenceValid(pinning.peer))
-        valid = false;
-
-    if (!valid) {
-        /* The pinning info is not safe, remove any pinning info */
-        unpinConnection(true);
+    PinningException::PinningErrorType errType = PinningException::errNone;
+    const char *error = nullptr;
+    if (!Comm::IsConnOpen(pinning.serverConnection)) {
+        error = "server connection closed";
+        errType = PinningException::errConnectionGone;
+    } else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0) {
+        error = "wrong destination";
+        errType = PinningException::errPolicy;
+    } else if (request && pinning.port != request->url.port()) {
+        error = "wrong destination port";
+        errType = PinningException::errPolicy;
+    } else if (pinning.peer && !cbdataReferenceValid(pinning.peer)) {
+        error = "cache peer is gone";
+        errType = PinningException::errConnectionGone;
+    } else if (pinning.peerAccessDenied) {
+        error = "peer access prohibited";
+        errType = PinningException::errPolicy;
     }
 
-    return pinning.serverConnection;
+    if (error) {
+        /* The pinning info is not safe, remove any pinning info */
+        unpinConnection(true);
+        SBuf tmp("pinned connection failure: ");
+        tmp.append(error);
+        throw PinningException(errType, tmp.c_str());
+    }
 }
 
 Comm::ConnectionPointer
 ConnStateData::borrowPinnedConnection(HttpRequest *request)
 {
     debugs(33, 7, pinning.serverConnection);
-    if (validatePinnedConnection(request) != nullptr)
-        stopPinnedConnectionMonitoring();
+    validatePinnedConnection(request); // throws on error
+    stopPinnedConnectionMonitoring();
+    return pinning.serverConnection;
+}
 
-    return pinning.serverConnection; // closed if validation failed
+Comm::ConnectionPointer
+ConnStateData::BorrowPinnedConnection(HttpRequest *request)
+{
+    if (const auto connManager = request ? request->pinnedConnection() : nullptr)
+        return connManager->borrowPinnedConnection(request);
+
+    throw PinningException(PinningException::errConnectionGone, "pinned connection failure: client connection gone");
 }
 
 void

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -139,6 +139,7 @@ public:
         bool auth;               /* pinned for www authentication */
         bool reading;   ///< we are monitoring for peer connection closure
         bool zeroReply; ///< server closed w/o response (ERR_ZERO_SIZE_OBJECT)
+        bool peerAccessDenied; ///< cache_peer_access acl rules denies the pinned connection use
         CachePeer *peer;             /* CachePeer the connection goes via */
         AsyncCall::Pointer readHandler; ///< detects serverConnection closure
         AsyncCall::Pointer closeHandler; /*The close handler for pinned server side connection*/

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -47,6 +47,22 @@ class ServerBump;
 }
 #endif
 
+/// An std::runtime_error with an error type description.
+class PinningException: public std::runtime_error
+{
+public:
+    enum PinningErrorType {
+        errNone,
+        errPolicy, //< pinning policy error, eg authentication failure
+        errConnectionGone //< one of the pinned connection sides is gone
+    };
+    PinningException(const PinningErrorType type, const char *descr):
+        std::runtime_error(descr),
+        errType(type)
+        {}
+    PinningErrorType errType;
+};
+
 /**
  * Legacy Server code managing a connection to a client.
  *
@@ -183,14 +199,20 @@ public:
     /// Undo pinConnection() and, optionally, close the pinned connection.
     void unpinConnection(const bool andClose);
     /// Returns validated pinnned server connection (and stops its monitoring).
+    /// Throws a PinningException on errors
     Comm::ConnectionPointer borrowPinnedConnection(HttpRequest *request);
+
+    /// A static borrowPinnedConnection variant which also check if the
+    /// HttpRequest object is linked with a valid ConnStateData object
+    /// Throws a PinningException on errors;
+    static Comm::ConnectionPointer BorrowPinnedConnection(HttpRequest *request);
     /**
-     * Checks if there is pinning info if it is valid. It can close the server side connection
+     * Checks if pinning info is valid. It can close the server side connection
      * if pinned info is not valid.
+     * It trows a PinningException if pinned info is not valid
      \param request   if it is not NULL also checks if the pinning info refers to the request client side HttpRequest
-     \return          The details of the server side connection (may be closed if failures were present).
      */
-    const Comm::ConnectionPointer validatePinnedConnection(HttpRequest *request);
+    void validatePinnedConnection(HttpRequest *request);
     /**
      * returts the pinned CachePeer if exists, NULL otherwise
      */

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -139,7 +139,7 @@ public:
         bool auth;               /* pinned for www authentication */
         bool reading;   ///< we are monitoring for peer connection closure
         bool zeroReply; ///< server closed w/o response (ERR_ZERO_SIZE_OBJECT)
-        bool peerAccessDenied; ///< cache_peer_access acl rules denies the pinned connection use
+        bool peerAccessDenied; ///< cache_peer_access denied pinned connection reuse
         CachePeer *peer;             /* CachePeer the connection goes via */
         AsyncCall::Pointer readHandler; ///< detects serverConnection closure
         AsyncCall::Pointer closeHandler; /*The close handler for pinned server side connection*/

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -183,12 +183,9 @@ public:
     void pinBusyConnection(const Comm::ConnectionPointer &pinServerConn, const HttpRequest::Pointer &request);
     /// Undo pinConnection() and, optionally, close the pinned connection.
     void unpinConnection(const bool andClose);
-    /// Returns validated pinnned server connection (and stops its monitoring).
-    /// \throws a pointer to ErrorState if validation fails
-    Comm::ConnectionPointer borrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &);
 
-    /// borrowPinnedConnection() for callers w/o direct access to ConnStateData
-    /// \throws a pointer to ErrorState
+    /// \returns validated pinned to-server connection, stopping its monitoring
+    /// \throws a newly allocated ErrorState if validation fails
     static Comm::ConnectionPointer BorrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &);
     /**
      * returts the pinned CachePeer if exists, NULL otherwise
@@ -327,6 +324,9 @@ protected:
     void finishDechunkingRequest(bool withSuccess);
     void abortChunkedRequestBody(const err_type error);
     err_type handleChunkedRequestBody();
+
+    /// ConnStateData-specific part of BorrowPinnedConnection()
+    Comm::ConnectionPointer borrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &);
 
     void startPinnedConnectionMonitoring();
     void clientPinnedConnectionRead(const CommIoCbParams &io);

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -568,8 +568,7 @@ PeerSelector::selectPinned()
     const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
     // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
-    if (!usePinned)
-        request->pinnedConnection()->pinning.peerAccessDenied = true;
+    request->pinnedConnection()->pinning.peerAccessDenied = !usePinned;
 
     addSelection(pear, PINNED);
     if (entry)

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -566,14 +566,14 @@ PeerSelector::selectPinned()
 
     const auto pear = request->pinnedConnection()->pinnedPeer();
     const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
-    if (usePinned) {
-        addSelection(pear, PINNED);
-        if (entry)
-            entry->ping_status = PING_DONE; // skip ICP
-    }
-
     // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
+    if (!usePinned)
+        request->pinnedConnection()->pinning.peerAccessDenied = true;
+
+    addSelection(pear, PINNED);
+    if (entry)
+        entry->ping_status = PING_DONE; // skip ICP
 }
 
 /**

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -564,16 +564,15 @@ PeerSelector::selectPinned()
     if (!request->pinnedConnection())
         return;
 
-    if (Comm::IsConnOpen(request->pinnedConnection()->validatePinnedConnection(request))) {
-        const auto pear = request->pinnedConnection()->pinnedPeer();
-        const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
-        if (usePinned) {
-            addSelection(pear, PINNED);
-            if (entry)
-                entry->ping_status = PING_DONE; // skip ICP
-        }
+    const auto pear = request->pinnedConnection()->pinnedPeer();
+    const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
+    if (usePinned) {
+        addSelection(pear, PINNED);
+        if (entry)
+            entry->ping_status = PING_DONE; // skip ICP
     }
-    // If the pinned connection is prohibited (for this request) or gone, then
+
+    // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
 }
 

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -564,13 +564,13 @@ PeerSelector::selectPinned()
     if (!request->pinnedConnection())
         return;
 
-    const auto pear = request->pinnedConnection()->pinnedPeer();
-    const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
+    const auto peer = request->pinnedConnection()->pinnedPeer();
+    const auto usePinned = peer ? peerAllowedToUse(peer, this) : (direct != DIRECT_NO);
     // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
     request->pinnedConnection()->pinning.peerAccessDenied = !usePinned;
 
-    addSelection(pear, PINNED);
+    addSelection(peer, PINNED);
     if (entry)
         entry->ping_status = PING_DONE; // skip ICP
 }

--- a/src/tests/stub_client_side.cc
+++ b/src/tests/stub_client_side.cc
@@ -34,7 +34,7 @@ bool ConnStateData::handleRequestBodyData() STUB_RETVAL(false)
 void ConnStateData::pinBusyConnection(const Comm::ConnectionPointer &, const HttpRequest::Pointer &) STUB
 void ConnStateData::notePinnedConnectionBecameIdle(PinnedIdleContext) STUB
 void ConnStateData::unpinConnection(const bool) STUB
-const Comm::ConnectionPointer ConnStateData::validatePinnedConnection(HttpRequest *) STUB_RETVAL(nullptr)
+Comm::ConnectionPointer ConnStateData::BorrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &) STUB_RETVAL(nullptr)
 void ConnStateData::clientPinnedConnectionClosed(const CommCloseCbParams &) STUB
 void ConnStateData::connStateClosed(const CommCloseCbParams &) STUB
 void ConnStateData::requestTimeout(const CommTimeoutCbParams &) STUB

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1133,9 +1133,6 @@ TunnelStateData::usePinned()
     if (!Comm::IsConnOpen(serverConn))
         fail = "pinned path failure";
 
-    if (request->pinnedConnection()->pinning.peerAccessDenied)
-        fail = "pinned path access denied";
-
     if (fail) {
         // a PINNED path failure is fatal; do not wait for more paths
         sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al),

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1116,14 +1116,14 @@ TunnelStateData::usePinned()
 {
     try {
         const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw(), al);
-        debugs(26,7, "pinned peer connection: " << serverConn);
-
+        debugs(26, 7, "pinned peer connection: " << serverConn);
         tunnelConnectDone(serverConn, Comm::OK, 0, (void *)this);
-    } catch (const PinningException &ex) {
+    } catch (ErrorState * const error) {
         // a PINNED path failure is fatal; do not wait for more paths
-        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al), ex.what());
+        sendError(error, "pinned path failure");
         return;
     }
+
 }
 
 CBDATA_CLASS_INIT(TunnelStateData);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1115,7 +1115,7 @@ void
 TunnelStateData::usePinned()
 {
     try {
-        const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw());
+        const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw(), al);
         debugs(26,7, "pinned peer connection: " << serverConn);
 
         tunnelConnectDone(serverConn, Comm::OK, 0, (void *)this);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1117,7 +1117,7 @@ TunnelStateData::usePinned()
     try {
         const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw(), al);
         debugs(26, 7, "pinned peer connection: " << serverConn);
-        tunnelConnectDone(serverConn, Comm::OK, 0, (void *)this);
+        tunnelConnectDone(serverConn, Comm::OK, 0, static_cast<void *>(this));
     } catch (ErrorState * const error) {
         // a PINNED path failure is fatal; do not wait for more paths
         sendError(error, "pinned path failure");

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1136,7 +1136,7 @@ TunnelStateData::usePinned()
     if (request->pinnedConnection()->pinning.peerAccessDenied)
         fail = "pinned path access denied";
 
-    if (fail){
+    if (fail) {
         // a PINNED path failure is fatal; do not wait for more paths
         sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al),
                   fail);


### PR DESCRIPTION
Fix "BUG: Lost previously bumped from-Squid connection"

FwdState assumed that PeerSelector always returns the connection pinned
by previous SslBump steps. That assumption was wrong in two cases:

  1. The previously pinned connection got closed.
  2. PeerSelector policies prevent pinned connection reuse. For example,
     connection destination is now denied by cache_peer_access rules.

PeerSelector now returns a PINNED selection even if a pinned connection
cannot or should not be used. The initiator is now fully responsible for
checking the returned connection usability, including the new
ConnStateData::pinning::peerAccessDenied flag. Unusable pinned
connection is now treated as any other fatal (for the transaction)
forwarding problem rather than an internal BUG.

The above changes do not change traffic on the wire but remove bogus
level-1 BUG messages from cache.log.

We also polished which error page is returned depending on the pinning
validation problem: ERR_ZERO_SIZE_OBJECT is returned when the validation
failed because of the peer disappearance or to-server connection
closure. Other cases use ERR_CANNOT_FORWARD. Eventually, these errors
can be detailed further to distinguish various problems. We may also
want to generalize ERR_CONFLICT_HOST and/or ERR_FORWARDING_DENIED to
make them applicable in this context.

This is a Measurement Factory project.