### PR TITLE
Fix server_cert_fingerprint on cert. validator-reported errors

### DIFF
--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -89,7 +89,10 @@ public:
 
     /// SSL [certificate validation] errors, in undefined order
     const Security::CertErrors *sslErrors;
-    /// The peer certificate
+
+    /// Peer certificate being checked by ssl_verify_cb() and by
+    /// Security::PeerConnector class. In other contexts, the peer
+    /// certificate is retrieved via ALE or ConnStateData::serverBump.
     Security::CertPointer serverCert;
 
     AccessLogEntry::Pointer al; ///< info for the future access.log, and external ACL

--- a/src/acl/ServerCertificate.cc
+++ b/src/acl/ServerCertificate.cc
@@ -25,7 +25,7 @@ ACLServerCertificateStrategy::match(ACLData<MatchType> * &data, ACLFilledCheckli
     if (checklist->serverCert)
         cert = checklist->serverCert;
     else if (checklist->al && Comm::IsConnOpen(checklist->al->hier.tcpServer)) {
-        auto ssl = fd_table[checklist->al->hier.tcpServer->fd].ssl.get();
+        const auto ssl = fd_table[checklist->al->hier.tcpServer->fd].ssl.get();
         cert.resetWithoutLocking(SSL_get_peer_certificate(ssl));
     } else if (checklist->conn() != NULL && checklist->conn()->serverBump())
         cert = checklist->conn()->serverBump()->serverCert;

--- a/src/acl/ServerCertificate.cc
+++ b/src/acl/ServerCertificate.cc
@@ -27,7 +27,7 @@ ACLServerCertificateStrategy::match(ACLData<MatchType> * &data, ACLFilledCheckli
     else if (checklist->al && Comm::IsConnOpen(checklist->al->hier.tcpServer)) {
         const auto ssl = fd_table[checklist->al->hier.tcpServer->fd].ssl.get();
         cert.resetWithoutLocking(SSL_get_peer_certificate(ssl));
-    } else if (checklist->conn() != NULL && checklist->conn()->serverBump())
+    } else if (checklist->conn() && checklist->conn()->serverBump())
         cert = checklist->conn()->serverBump()->serverCert;
 
     if (!cert)

--- a/src/acl/ServerCertificate.cc
+++ b/src/acl/ServerCertificate.cc
@@ -24,7 +24,10 @@ ACLServerCertificateStrategy::match(ACLData<MatchType> * &data, ACLFilledCheckli
     Security::CertPointer cert;
     if (checklist->serverCert)
         cert = checklist->serverCert;
-    else if (checklist->conn() != NULL && checklist->conn()->serverBump())
+    else if (checklist->al && Comm::IsConnOpen(checklist->al->hier.tcpServer)) {
+        auto ssl = fd_table[checklist->al->hier.tcpServer->fd].ssl.get();
+        cert.resetWithoutLocking(SSL_get_peer_certificate(ssl));
+    } else if (checklist->conn() != NULL && checklist->conn()->serverBump())
         cert = checklist->conn()->serverBump()->serverCert;
 
     if (!cert)


### PR DESCRIPTION
The server_cert_fingerprint ACL mismatched when sslproxy_cert_error
directive was applied to validation errors reported by the certificate
validator because the ACL could not find the server certificate.

This is a Measurement Factory project.
