### PR TITLE
Reforward CONNECT after tls handshake failure with peer

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -691,12 +691,9 @@ FwdState::connectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, in
         fail(anErr);
 
         /* it might have been a timeout with a partially open link */
-        if (conn != NULL) {
-            if (conn->getPeer())
-                peerConnectFailed(conn->getPeer());
-
+        if (conn)
             conn->close();
-        }
+
         retryOrBail();
         return;
     }

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -101,7 +101,6 @@ PeerPoolMgr::handleOpenedConnection(const CommConnectCbParams &params)
         /* it might have been a timeout with a partially open link */
         if (params.conn != NULL)
             params.conn->close();
-        peerConnectFailed(peer);
         checkpoint("conn opening failure"); // may retry
         return;
     }

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -124,6 +124,11 @@ Comm::ConnOpener::sendAnswer(Comm::Flag errFlag, int xerrno, const char *why)
         }
     }
 
+    if (errFlag && conn_) {
+        if (const auto peer = conn_->getPeer())
+            peerConnectFailed(peer);
+    }
+
     if (callback_ != NULL) {
         // avoid scheduling cancelled callbacks, assuming they are common
         // enough to make this extra check an optimization
@@ -366,8 +371,6 @@ Comm::ConnOpener::doConnect()
         } else {
             // send ERROR back to the upper layer.
             debugs(5, 5, HERE << conn_ << ": * - ERR tried too many times already.");
-            if (auto peer = conn_->getPeer())
-                peerConnectFailed(peer);
             sendAnswer(Comm::ERR_CONNECT, xerrno, "Comm::ConnOpener::doConnect");
         }
     }

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -21,6 +21,7 @@
 #include "ip/QosConfig.h"
 #include "ip/tools.h"
 #include "ipcache.h"
+#include "neighbors.h"
 #include "SquidConfig.h"
 #include "SquidTime.h"
 
@@ -365,6 +366,8 @@ Comm::ConnOpener::doConnect()
         } else {
             // send ERROR back to the upper layer.
             debugs(5, 5, HERE << conn_ << ": * - ERR tried too many times already.");
+            if (auto peer = conn_->getPeer())
+                peerConnectFailed(peer);
             sendAnswer(Comm::ERR_CONNECT, xerrno, "Comm::ConnOpener::doConnect");
         }
     }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1180,13 +1180,12 @@ void
 TunnelStateData::connectedToPeer(Security::EncryptorAnswer &answer)
 {
     if (ErrorState *error = answer.error.get()) {
-        answer.error.clear();
         assert(!serverDestinations.empty());
-        auto failedDest = serverDestinations.front();
-        if (retry())
-            delete error;
-        else
+        const auto failedDest = serverDestinations.front();
+        if (!retry()) {
+            answer.error.clear(); // preserve error for errorSendComplete()
             sendError(0, error, failedDest);
+        }
         return;
     }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1064,9 +1064,9 @@ tunnelConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xe
     if (status != Comm::OK) {
         debugs(26, 4, HERE << conn << ", comm failure recovery.");
         assert(!tunnelState->serverDestinations.empty());
-        auto failedDest = tunnelState->serverDestinations.front();
+        const auto failedDest = tunnelState->serverDestinations.front();
         if (!tunnelState->retry()) {
-            auto error = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw());
+            const auto error = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw());
             error->xerrno = xerrno;
             tunnelState->sendError(error, failedDest);
         }


### PR DESCRIPTION
Why retry such TLS negotiation failures? Peer B may not have the same
misconfiguration that led to the negotiation failure when talking to
peer A. Admins may improve fault tolerance by using pools of different
peers or pools of identical peers that are reconfigured one by one. And
FwdState already does this – flags.connected_okay is not set until TLS
negotiation is successful.

Also handle failures to peers (peerConnectFailed()) from
Comm::ConnOpener job, thus eliminating code duplication in each caller.
Security::BlindPeerConnector already follows this approach.