### PR TITLE
Re-enabled updates of stored headers on HTTP 304 responses

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -511,7 +511,7 @@ FwdState::unregister(int fd)
 void
 FwdState::complete()
 {
-    const auto replyStatus = entry->baseReply().sline.status();
+    const auto replyStatus = entry->mem().baseReply().sline.status();
     debugs(17, 3, *entry << " status " << replyStatus << ' ' << entry->url());
 #if URL_CHECKSUM_DEBUG
 
@@ -1226,7 +1226,7 @@ FwdState::reforward()
         return 0;
     }
 
-    const auto s = entry->baseReply().sline.status();
+    const auto s = entry->mem().baseReply().sline.status();
     debugs(17, 3, HERE << "status " << s);
     return reforwardableStatus(s);
 }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -511,16 +511,17 @@ FwdState::unregister(int fd)
 void
 FwdState::complete()
 {
-    debugs(17, 3, HERE << entry->url() << "\n\tstatus " << entry->getReply()->sline.status());
+    const auto replyStatus = entry->replyStatus();
+    debugs(17, 3, *entry << " status " << replyStatus << ' ' << entry->url());
 #if URL_CHECKSUM_DEBUG
 
     entry->mem_obj->checkUrlChecksum();
 #endif
 
-    logReplyStatus(n_tries, entry->getReply()->sline.status());
+    logReplyStatus(n_tries, replyStatus);
 
     if (reforward()) {
-        debugs(17, 3, HERE << "re-forwarding " << entry->getReply()->sline.status() << " " << entry->url());
+        debugs(17, 3, "re-forwarding " << replyStatus << " " << entry->url());
 
         if (Comm::IsConnOpen(serverConn))
             unregister(serverConn);
@@ -531,9 +532,9 @@ FwdState::complete()
 
     } else {
         if (Comm::IsConnOpen(serverConn))
-            debugs(17, 3, HERE << "server FD " << serverConnection()->fd << " not re-forwarding status " << entry->getReply()->sline.status());
+            debugs(17, 3, "server FD " << serverConnection()->fd << " not re-forwarding status " << replyStatus);
         else
-            debugs(17, 3, HERE << "server (FD closed) not re-forwarding status " << entry->getReply()->sline.status());
+            debugs(17, 3, "server (FD closed) not re-forwarding status " << replyStatus);
         entry->complete();
 
         if (!Comm::IsConnOpen(serverConn))
@@ -1225,7 +1226,7 @@ FwdState::reforward()
         return 0;
     }
 
-    const Http::StatusCode s = e->getReply()->sline.status();
+    const auto s = entry->replyStatus();
     debugs(17, 3, HERE << "status " << s);
     return reforwardableStatus(s);
 }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -511,7 +511,7 @@ FwdState::unregister(int fd)
 void
 FwdState::complete()
 {
-    const auto replyStatus = entry->replyStatus();
+    const auto replyStatus = entry->stableReply().sline.status();
     debugs(17, 3, *entry << " status " << replyStatus << ' ' << entry->url());
 #if URL_CHECKSUM_DEBUG
 
@@ -1226,7 +1226,7 @@ FwdState::reforward()
         return 0;
     }
 
-    const auto s = entry->replyStatus();
+    const auto s = entry->stableReply().sline.status();
     debugs(17, 3, HERE << "status " << s);
     return reforwardableStatus(s);
 }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -511,7 +511,7 @@ FwdState::unregister(int fd)
 void
 FwdState::complete()
 {
-    const auto replyStatus = entry->stableReply().sline.status();
+    const auto replyStatus = entry->baseReply().sline.status();
     debugs(17, 3, *entry << " status " << replyStatus << ' ' << entry->url());
 #if URL_CHECKSUM_DEBUG
 
@@ -1226,7 +1226,7 @@ FwdState::reforward()
         return 0;
     }
 
-    const auto s = entry->stableReply().sline.status();
+    const auto s = entry->baseReply().sline.status();
     debugs(17, 3, HERE << "status " << s);
     return reforwardableStatus(s);
 }

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -82,7 +82,12 @@ public:
     /* Interface functions */
     void clean();
     void append(const HttpHeader * src);
-    bool update(HttpHeader const *fresh);
+    /// replaces fields with matching names and adds fresh fields with new names
+    /// also updates Http::HdrType::WARNINGs, assuming `fresh` is a 304 reply
+    /// TODO: Refactor most callers to avoid special handling of WARNINGs.
+    void update(const HttpHeader *fresh);
+    /// \returns whether calling update(fresh) would change our set of fields
+    bool needUpdate(const HttpHeader *fresh) const;
     void compact();
     int parse(const char *header_start, size_t len, Http::ContentLengthInterpreter &interpreter);
     /// Parses headers stored in a buffer.
@@ -172,7 +177,6 @@ protected:
     /// *blk_end points to the first header delimiter character (CR or LF in CR?LF).
     /// If block starts where it ends, then there are no fields in the header.
     static bool Isolate(const char **parse_start, size_t l, const char **blk_start, const char **blk_end);
-    bool needUpdate(const HttpHeader *fresh) const;
     bool skipUpdateHeader(const Http::HdrType id) const;
     void updateWarnings();
 

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -252,23 +252,19 @@ HttpReply::validatorsMatch(HttpReply const * otherRep) const
     return 1;
 }
 
-bool
-HttpReply::updateOnNotModified(HttpReply const * freshRep)
+HttpReply::Pointer
+HttpReply::updateOnNotModified(const HttpReply &reply304) const
 {
-    assert(freshRep);
+    // Optimization: Storing a reply is a lot more expensive than this check.
+    if (!header.needUpdate(&reply304.header))
+        return nullptr;
 
-    /* update raw headers */
-    if (!header.update(&freshRep->header))
-        return false;
-
-    /* clean cache */
-    hdrCacheClean();
-
-    header.compact();
-    /* init cache */
-    hdrCacheInit();
-
-    return true;
+    const Pointer cloned = clone();
+    cloned->header.update(&reply304.header);
+    cloned->hdrCacheClean();
+    cloned->header.compact();
+    cloned->hdrCacheInit();
+    return cloned;
 }
 
 /* internal routines */

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -253,7 +253,7 @@ HttpReply::validatorsMatch(HttpReply const * otherRep) const
 }
 
 HttpReply::Pointer
-HttpReply::updateOnNotModified(const HttpReply &reply304) const
+HttpReply::recreateOnNotModified(const HttpReply &reply304) const
 {
     // Optimization: Storing a reply is a lot more expensive than this check.
     if (!header.needUpdate(&reply304.header))

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -255,7 +255,8 @@ HttpReply::validatorsMatch(HttpReply const * otherRep) const
 HttpReply::Pointer
 HttpReply::recreateOnNotModified(const HttpReply &reply304) const
 {
-    // Optimization: Storing a reply is a lot more expensive than this check.
+    // If enough 304s do not update, then this expensive checking is cheaper
+    // than blindly storing reply prefix identical to the already stored one.
     if (!header.needUpdate(&reply304.header))
         return nullptr;
 

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -74,7 +74,7 @@ public:
 
     /// \returns nil (if no updates are necessary)
     /// \returns a new reply combining this reply with 304 updates (otherwise)
-    Pointer updateOnNotModified(const HttpReply &reply304) const;
+    Pointer recreateOnNotModified(const HttpReply &reply304) const;
 
     /** set commonly used info with one call */
     void setHeaders(Http::StatusCode status,

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -72,7 +72,9 @@ public:
 
     virtual bool inheritProperties(const Http::Message *);
 
-    bool updateOnNotModified(HttpReply const *other);
+    /// \returns nil (if no updates are necessary)
+    /// \returns a new reply combining this reply with 304 updates (otherwise)
+    Pointer updateOnNotModified(const HttpReply &reply304) const;
 
     /** set commonly used info with one call */
     void setHeaders(Http::StatusCode status,

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -264,6 +264,8 @@ MemObject::reset()
     /* Should we check for clients? */
     if (reply_)
         reply_->reset();
+    updatedReply_ = nullptr;
+    appliedUpdates = false;
 }
 
 int64_t

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -133,6 +133,13 @@ MemObject::~MemObject()
 }
 
 void
+MemObject::replaceBaseReply(const HttpReplyPointer &r)
+{
+    assert(r);
+    reply_ = r;
+}
+
+void
 MemObject::write(const StoreIOBuffer &writeBuffer)
 {
     PROF_start(MemObject_write);

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -132,6 +132,13 @@ MemObject::~MemObject()
     ctx_exit(ctx);              /* must exit before we free mem->url */
 }
 
+HttpReply &
+MemObject::adjustableBaseReply()
+{
+    assert(!updatedReply_);
+    return *reply_;
+}
+
 void
 MemObject::replaceBaseReply(const HttpReplyPointer &r)
 {

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -161,6 +161,8 @@ MemObject::dump() const
     debugs(20, DBG_IMPORTANT, "MemObject->inmem_lo: " << inmem_lo);
     debugs(20, DBG_IMPORTANT, "MemObject->nclients: " << nclients);
     debugs(20, DBG_IMPORTANT, "MemObject->reply: " << reply_);
+    debugs(20, DBG_IMPORTANT, "MemObject->updatedReply: " << updatedReply_);
+    debugs(20, DBG_IMPORTANT, "MemObject->appliedUpdates: " << appliedUpdates);
     debugs(20, DBG_IMPORTANT, "MemObject->request: " << request);
     debugs(20, DBG_IMPORTANT, "MemObject->logUri: " << logUri_);
     debugs(20, DBG_IMPORTANT, "MemObject->storeId: " << storeId_);

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -144,6 +144,7 @@ MemObject::replaceBaseReply(const HttpReplyPointer &r)
 {
     assert(r);
     reply_ = r;
+    updatedReply_ = nullptr;
 }
 
 void

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -54,8 +54,19 @@ public:
 
     void write(const StoreIOBuffer &buf);
     void unlinkRequest() { request = nullptr; }
+
+    /// Deprecated. Use either receivedReply() or updatedReply().
     const HttpReplyPointer &getReply() const { return reply_; }
-    void replaceReply(const HttpReplyPointer &r) { reply_ = r; }
+    /// (re)sets received reply, usually just replacing the initial/empty object
+    void replaceBaseReply(const HttpReplyPointer &r) { baseReply_ = r; }
+
+    /* XXX: Move and provide a getter/setter? */
+    /// response that corresponds to our StoreEntry; immune to 304 updates
+    /// always exists but starts as a dummy empty object until replaceBaseReply()
+    HttpReplyPointer &baseReply_ = reply_;
+    /// baseReply_ after 304 update(s); nil if no 304 updates since baseReply_
+    HttpReplyPointer updatedReply_;
+
     void stat (MemBuf * mb) const;
     int64_t endOffset () const;
     void markEndOfReplyHeaders(); ///< sets reply_->hdr_sz to endOffset()

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -55,10 +55,6 @@ public:
     void write(const StoreIOBuffer &buf);
     void unlinkRequest() { request = nullptr; }
 
-    /// Deprecated. Use either baseReply() or updatedReply().
-    /// \returns baseReply() (but legacy callers do not know the difference)
-    const HttpReplyPointer &getReply() const { return reply_; }
-
     /// response that corresponds to our StoreEntry; immune to 304 updates
     /// always exists but starts as a dummy empty object until replaceBaseReply()
     const HttpReply &baseReply() const { return *reply_; }

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -68,6 +68,7 @@ public:
     const HttpReplyPointer &updatedReply() const { return updatedReply_; }
 
     /// (re)sets base reply, usually just replacing the initial/empty object
+    /// also forgets the updated reply (if any)
     void replaceBaseReply(const HttpReplyPointer &r);
 
     /// (re)sets updated reply; \see updatedReply()

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -68,7 +68,7 @@ public:
     const HttpReplyPointer &updatedReply() const { return updatedReply_; }
 
     /// (re)sets base reply, usually just replacing the initial/empty object
-    void replaceBaseReply(const HttpReplyPointer &r) { reply_ = r; }
+    void replaceBaseReply(const HttpReplyPointer &r);
 
     /// (re)sets updated reply; \see updatedReply()
     void updateReply(const HttpReply &r) { updatedReply_ = &r; }

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -63,6 +63,16 @@ public:
     /// \returns combination of baseReply() and 304 updates -- after updates
     const HttpReplyPointer &updatedReply() const { return updatedReply_; }
 
+    /// \returns the updated-by-304(s) response (if it exists)
+    /// \returns baseReply() (otherwise)
+    /// Requires mem_obj.
+    const HttpReply &freshestReply() const {
+        if (updatedReply_)
+            return *updatedReply_;
+        else
+            return baseReply();
+    }
+
     /// \returns writable base reply for parsing and other initial modifications
     /// Base modifications can only be done when forming/loading the entry.
     /// After that, use replaceBaseReply() to reset all of the replies.

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -150,8 +150,6 @@ public:
     };
     MemCache memCache; ///< current [shared] memory caching state for the entry
 
-    /* Read only - this reply must be preserved by store clients */
-    /* The original reply. possibly with updated metadata. */
     HttpRequestPointer request;
 
     struct timeval start_ping;

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -55,12 +55,12 @@ public:
     void write(const StoreIOBuffer &buf);
     void unlinkRequest() { request = nullptr; }
 
-    /// response that corresponds to our StoreEntry; immune to 304 updates
-    /// starts empty until replaceBaseReply() or adjustableBaseReply()
+    /// HTTP response before 304 (Not Modified) updates
+    /// starts "empty"; modified via replaceBaseReply() or adjustableBaseReply()
     const HttpReply &baseReply() const { return *reply_; }
 
-    /// \returns nil if no 304 updates since replaceBaseReply()
-    /// \returns a combination of baseReply() and 304 updates (after updates)
+    /// \returns nil -- if no 304 updates since replaceBaseReply()
+    /// \returns combination of baseReply() and 304 updates -- after updates
     const HttpReplyPointer &updatedReply() const { return updatedReply_; }
 
     /// \returns writable base reply for parsing and other initial modifications
@@ -82,10 +82,14 @@ public:
 
     void stat (MemBuf * mb) const;
     int64_t endOffset () const;
-    void markEndOfReplyHeaders(); ///< sets reply_->hdr_sz to endOffset()
+
+    /// sets baseReply().hdr_sz (i.e. written reply headers size) to endOffset()
+    void markEndOfReplyHeaders();
+
     /// negative if unknown; otherwise, expected object_sz, expected endOffset
     /// maximum, and stored reply headers+body size (all three are the same)
     int64_t expectedReplySize() const;
+
     int64_t size() const;
     void reset();
     int64_t lowestMemReaderOffset() const;

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -99,7 +99,6 @@ public:
     /// negative if unknown; otherwise, expected object_sz, expected endOffset
     /// maximum, and stored reply headers+body size (all three are the same)
     int64_t expectedReplySize() const;
-
     int64_t size() const;
     void reset();
     int64_t lowestMemReaderOffset() const;
@@ -213,8 +212,8 @@ public:
     void kickReads();
 
 private:
-    HttpReplyPointer reply_; ///< \copydoc baseReply()
-    HttpReplyPointer updatedReply_; ///< \copydoc updatedReply()
+    HttpReplyPointer reply_; ///< \see baseReply()
+    HttpReplyPointer updatedReply_; ///< \see updatedReply()
 
     mutable String storeId_; ///< StoreId for our entry (usually request URI)
     mutable String logUri_;  ///< URI used for logging (usually request URI)

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -56,12 +56,17 @@ public:
     void unlinkRequest() { request = nullptr; }
 
     /// response that corresponds to our StoreEntry; immune to 304 updates
-    /// always exists but starts as a dummy empty object until replaceBaseReply()
+    /// starts empty until replaceBaseReply() or adjustableBaseReply()
     const HttpReply &baseReply() const { return *reply_; }
 
     /// \returns nil if no 304 updates since replaceBaseReply()
     /// \returns a combination of baseReply() and 304 updates (after updates)
     const HttpReplyPointer &updatedReply() const { return updatedReply_; }
+
+    /// \returns writable base reply for parsing and other initial modifications
+    /// Base modifications can only be done when forming/loading the entry.
+    /// After that, use replaceBaseReply() to reset all of the replies.
+    HttpReply &adjustableBaseReply();
 
     /// (re)sets base reply, usually just replacing the initial/empty object
     /// also forgets the updated reply (if any)

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -66,6 +66,10 @@ public:
     HttpReplyPointer &baseReply_ = reply_;
     /// baseReply_ after 304 update(s); nil if no 304 updates since baseReply_
     HttpReplyPointer updatedReply_;
+    /// reflects past Controller::updateOnNotModified(old, e304) calls:
+    /// for HTTP 304 entries: whether our entry was used as "e304"
+    /// for other entries: whether our entry was updated as "old"
+    bool appliedUpdates = false;
 
     void stat (MemBuf * mb) const;
     int64_t endOffset () const;

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -544,7 +544,7 @@ MemStore::copyFromShmSlice(StoreEntry &e, const StoreIOBuffer &buf, bool eof)
 
     // from store_client::readBody()
     // parse headers if needed; they might span multiple slices!
-    HttpReply *rep = (HttpReply *)e.getReply();
+    const auto rep = &e.adjustableBaseReply();
     if (rep->pstate < Http::Message::psParsed) {
         // XXX: have to copy because httpMsgParseStep() requires 0-termination
         MemBuf mb;

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -544,7 +544,7 @@ MemStore::copyFromShmSlice(StoreEntry &e, const StoreIOBuffer &buf, bool eof)
 
     // from store_client::readBody()
     // parse headers if needed; they might span multiple slices!
-    const auto rep = &e.adjustableBaseReply();
+    const auto rep = &e.mem().adjustableBaseReply();
     if (rep->pstate < Http::Message::psParsed) {
         // XXX: have to copy because httpMsgParseStep() requires 0-termination
         MemBuf mb;

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -360,7 +360,7 @@ MemStore::updateHeadersOrThrow(Ipc::StoreMapUpdate &update)
     // our +/- hdr_sz math below does not work if the chains differ [in size]
     Must(update.stale.anchor->basics.swap_file_sz == update.fresh.anchor->basics.swap_file_sz);
 
-    const auto &reply = update.entry->baseReply();
+    const auto &reply = update.entry->mem().baseReply();
     const uint64_t staleHdrSz = reply.hdr_sz;
     debugs(20, 7, "stale hdr_sz: " << staleHdrSz);
 

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -360,9 +360,7 @@ MemStore::updateHeadersOrThrow(Ipc::StoreMapUpdate &update)
     // our +/- hdr_sz math below does not work if the chains differ [in size]
     Must(update.stale.anchor->basics.swap_file_sz == update.fresh.anchor->basics.swap_file_sz);
 
-    const HttpReply *rawReply = update.entry->getReply();
-    Must(rawReply);
-    const HttpReply &reply = *rawReply;
+    const auto &reply = update.entry->baseReply();
     const uint64_t staleHdrSz = reply.hdr_sz;
     debugs(20, 7, "stale hdr_sz: " << staleHdrSz);
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -58,7 +58,7 @@ public:
     /// \throws exception if StoreEntry lacks mem_obj
     const HttpReply &freshestReply() const;
 
-    /// \returns the address of freshest reply (if it exists)
+    /// \returns the address of freshest reply (if mem_obj exists)
     /// \returns nil (otherwise)
     const HttpReply *hasFreshestReply() const { return mem_obj ? &freshestReply() : nullptr; }
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -50,12 +50,12 @@ public:
     virtual ~StoreEntry();
 
     /// \returns base response; \see MemObject::baseReply()
-    /// \throws exception if StoreEntry lacks mem_obj
+    /// Requires mem_obj.
     const HttpReply &baseReply() const;
 
     /// \returns the updated-by-304(s) response (if it exists)
     /// \returns baseReply() (otherwise)
-    /// \throws exception if StoreEntry lacks mem_obj
+    /// Requires mem_obj.
     const HttpReply &freshestReply() const;
 
     /// \returns the address of freshest reply (if mem_obj exists)
@@ -65,7 +65,7 @@ public:
     /// \returns writable base reply for parsing and other initial modifications
     /// Base modifications can only be done when forming/loading the entry.
     /// After that, use replaceBaseReply() to reset all of the replies.
-    /// \throws exception if StoreEntry lacks mem_obj
+    /// Requires mem_obj.
     HttpReply &adjustableBaseReply();
 
     void write(StoreIOBuffer);

--- a/src/Store.h
+++ b/src/Store.h
@@ -49,14 +49,10 @@ public:
     StoreEntry();
     virtual ~StoreEntry();
 
-    /// \returns the updated-by-304(s) response (if it exists)
-    /// \returns baseReply() (otherwise)
-    /// Requires mem_obj.
-    const HttpReply &freshestReply() const;
-
     /// \returns the address of freshest reply (if mem_obj exists)
     /// \returns nil (otherwise)
-    const HttpReply *hasFreshestReply() const { return mem_obj ? &freshestReply() : nullptr; }
+    /// \see MemObject::freshestReply()
+    const HttpReply *hasFreshestReply() const { return mem_obj ? &mem_obj->freshestReply() : nullptr; }
 
     MemObject &mem() { assert(mem_obj); return *mem_obj; }
     const MemObject &mem() const { assert(mem_obj); return *mem_obj; }

--- a/src/Store.h
+++ b/src/Store.h
@@ -49,10 +49,6 @@ public:
     StoreEntry();
     virtual ~StoreEntry();
 
-    /// \returns base response; \see MemObject::baseReply()
-    /// Requires mem_obj.
-    const HttpReply &baseReply() const;
-
     /// \returns the updated-by-304(s) response (if it exists)
     /// \returns baseReply() (otherwise)
     /// Requires mem_obj.

--- a/src/Store.h
+++ b/src/Store.h
@@ -51,8 +51,12 @@ public:
 
     /// \returns the updated-by-304(s) response (if it exists)
     /// \returns the received response (otherwise)
-    const HttpReply &latestReply() const;
+    /// \throws exception if StoreEntry lacks mem_obj
+    const HttpReply &freshestReply() const;
+
+    /// Deprecated. Use either receivedReply() or freshestReply() instead.
     HttpReply const *getReply() const;
+
     void write(StoreIOBuffer);
 
     /** Check if the Store entry is empty
@@ -176,6 +180,11 @@ public:
     bool hasIfNoneMatchEtag(const HttpRequest &request) const;
     /// whether this entry has an ETag; if yes, puts ETag value into parameter
     bool hasEtag(ETag &etag) const;
+
+    /// Updates easily-accessible non-Store-specific parts of the entry.
+    /// Use Controller::updateOnNotModified() instead of this helper.
+    /// \returns whether anything was actually updated
+    bool updateOnNotModified(const StoreEntry &e304);
 
     /// the disk this entry is [being] cached on; asserts for entries w/o a disk
     Store::Disk &disk() const;

--- a/src/Store.h
+++ b/src/Store.h
@@ -49,13 +49,13 @@ public:
     StoreEntry();
     virtual ~StoreEntry();
 
+    MemObject &mem() { assert(mem_obj); return *mem_obj; }
+    const MemObject &mem() const { assert(mem_obj); return *mem_obj; }
+
     /// \returns the address of freshest reply (if mem_obj exists)
     /// \returns nil (otherwise)
     /// \see MemObject::freshestReply()
     const HttpReply *hasFreshestReply() const { return mem_obj ? &mem_obj->freshestReply() : nullptr; }
-
-    MemObject &mem() { assert(mem_obj); return *mem_obj; }
-    const MemObject &mem() const { assert(mem_obj); return *mem_obj; }
 
     void write(StoreIOBuffer);
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -68,8 +68,11 @@ public:
     /// \throws exception if StoreEntry lacks mem_obj
     HttpReply &adjustableBaseReply();
 
-    /// Deprecated. Use baseReply(), freshestReply(), or hasFreshestReply() instead.
-    HttpReply const *getReply() const;
+    /// \returns the associated HTTP reply status code
+    /// Exists to avoid making the decision which reply to query -- both base
+    /// and freshest replies have the same status code.
+    /// \throws exception if StoreEntry lacks mem_obj
+    Http::StatusCode replyStatus() const { return baseReply().sline.status(); }
 
     void write(StoreIOBuffer);
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -49,12 +49,20 @@ public:
     StoreEntry();
     virtual ~StoreEntry();
 
+    /// \returns base response; \see MemObject::baseReply()
+    /// \throws exception if StoreEntry lacks mem_obj
+    const HttpReply &baseReply() const;
+
     /// \returns the updated-by-304(s) response (if it exists)
-    /// \returns the received response (otherwise)
+    /// \returns baseReply() (otherwise)
     /// \throws exception if StoreEntry lacks mem_obj
     const HttpReply &freshestReply() const;
 
-    /// Deprecated. Use either receivedReply() or freshestReply() instead.
+    /// \returns the address of freshest reply (if it exists)
+    /// \returns nil (otherwise)
+    const HttpReply *hasFreshestReply() const { return mem_obj ? &freshestReply() : nullptr; }
+
+    /// Deprecated. Use baseReply(), freshestReply(), or hasFreshestReply() instead.
     HttpReply const *getReply() const;
 
     void write(StoreIOBuffer);

--- a/src/Store.h
+++ b/src/Store.h
@@ -62,11 +62,8 @@ public:
     /// \returns nil (otherwise)
     const HttpReply *hasFreshestReply() const { return mem_obj ? &freshestReply() : nullptr; }
 
-    /// \returns writable base reply for parsing and other initial modifications
-    /// Base modifications can only be done when forming/loading the entry.
-    /// After that, use replaceBaseReply() to reset all of the replies.
-    /// Requires mem_obj.
-    HttpReply &adjustableBaseReply();
+    MemObject &mem() { assert(mem_obj); return *mem_obj; }
+    const MemObject &mem() const { assert(mem_obj); return *mem_obj; }
 
     void write(StoreIOBuffer);
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -62,6 +62,12 @@ public:
     /// \returns nil (otherwise)
     const HttpReply *hasFreshestReply() const { return mem_obj ? &freshestReply() : nullptr; }
 
+    /// \returns writable base reply for parsing and other initial modifications
+    /// Base modifications can only be done when forming/loading the entry.
+    /// After that, use replaceBaseReply() to reset all of the replies.
+    /// \throws exception if StoreEntry lacks mem_obj
+    HttpReply &adjustableBaseReply();
+
     /// Deprecated. Use baseReply(), freshestReply(), or hasFreshestReply() instead.
     HttpReply const *getReply() const;
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -68,12 +68,6 @@ public:
     /// \throws exception if StoreEntry lacks mem_obj
     HttpReply &adjustableBaseReply();
 
-    /// \returns base response; \see MemObject::baseReply()
-    /// Exists exclusively for callers that want to access response properties
-    /// that are not supposed to change across successful 304 updates.
-    /// \throws exception if StoreEntry lacks mem_obj
-    const HttpReply &stableReply() const { return baseReply(); }
-
     void write(StoreIOBuffer);
 
     /** Check if the Store entry is empty

--- a/src/Store.h
+++ b/src/Store.h
@@ -68,11 +68,11 @@ public:
     /// \throws exception if StoreEntry lacks mem_obj
     HttpReply &adjustableBaseReply();
 
-    /// \returns the associated HTTP reply status code
-    /// Exists to avoid making the decision which reply to query -- both base
-    /// and freshest replies have the same status code.
+    /// \returns base response; \see MemObject::baseReply()
+    /// Exists exclusively for callers that want to access response properties
+    /// that are not supposed to change across successful 304 updates.
     /// \throws exception if StoreEntry lacks mem_obj
-    Http::StatusCode replyStatus() const { return baseReply().sline.status(); }
+    const HttpReply &stableReply() const { return baseReply(); }
 
     void write(StoreIOBuffer);
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -49,6 +49,9 @@ public:
     StoreEntry();
     virtual ~StoreEntry();
 
+    /// \returns the updated-by-304(s) response (if it exists)
+    /// \returns the received response (otherwise)
+    const HttpReply &latestReply() const;
     HttpReply const *getReply() const;
     void write(StoreIOBuffer);
 
@@ -67,7 +70,8 @@ public:
     void lengthWentBad(const char *reason);
     void complete();
     store_client_t storeClientType() const;
-    char const *getSerialisedMetaData();
+    /// \returns a malloc()ed buffer containing a length-long packed swap header
+    const char *getSerialisedMetaData(size_t &length) const;
     /// Store a prepared error response. MemObject locks the reply object.
     void storeErrorResponse(HttpReply *reply);
     void replaceHttpReply(HttpReply *, bool andStartWriting = true);

--- a/src/StoreMeta.h
+++ b/src/StoreMeta.h
@@ -137,7 +137,7 @@ public:
 /// \ingroup SwapStoreAPI
 char *storeSwapMetaPack(tlv * tlv_list, int *length);
 /// \ingroup SwapStoreAPI
-tlv *storeSwapMetaBuild(StoreEntry * e);
+tlv *storeSwapMetaBuild(const StoreEntry *);
 /// \ingroup SwapStoreAPI
 void storeSwapTLVFree(tlv * n);
 

--- a/src/StoreMetaUnpacker.h
+++ b/src/StoreMetaUnpacker.h
@@ -41,14 +41,5 @@ private:
     StoreMeta **tail;
 };
 
-/*
- * store_swapmeta.c
- */
-char *storeSwapMetaPack(StoreMeta * tlv_list, int *length);
-StoreMeta *storeSwapMetaBuild(StoreEntry * e);
-StoreMeta *storeSwapMetaUnpack(const char *buf, int *hdrlen);
-void storeSwapTLVFree(StoreMeta * n);
-StoreMeta ** storeSwapTLVAdd(int type, const void *ptr, size_t len, StoreMeta ** tail);
-
 #endif /* SQUID_TYPELENGTHVALUEUNPACKER_H */
 

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -290,7 +290,7 @@ asHandleReply(void *data, StoreIOBuffer result)
         debugs(53, DBG_IMPORTANT, "asHandleReply: Called with Error set and size=" << (unsigned int) result.length);
         delete asState;
         return;
-    } else if (e->stableReply().sline.status() != Http::scOkay) {
+    } else if (e->baseReply().sline.status() != Http::scOkay) {
         debugs(53, DBG_IMPORTANT, "WARNING: AS " << asState->as_number << " whois request failed");
         delete asState;
         return;

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -290,7 +290,7 @@ asHandleReply(void *data, StoreIOBuffer result)
         debugs(53, DBG_IMPORTANT, "asHandleReply: Called with Error set and size=" << (unsigned int) result.length);
         delete asState;
         return;
-    } else if (e->replyStatus() != Http::scOkay) {
+    } else if (e->stableReply().sline.status() != Http::scOkay) {
         debugs(53, DBG_IMPORTANT, "WARNING: AS " << asState->as_number << " whois request failed");
         delete asState;
         return;

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -290,7 +290,7 @@ asHandleReply(void *data, StoreIOBuffer result)
         debugs(53, DBG_IMPORTANT, "asHandleReply: Called with Error set and size=" << (unsigned int) result.length);
         delete asState;
         return;
-    } else if (e->baseReply().sline.status() != Http::scOkay) {
+    } else if (e->mem().baseReply().sline.status() != Http::scOkay) {
         debugs(53, DBG_IMPORTANT, "WARNING: AS " << asState->as_number << " whois request failed");
         delete asState;
         return;

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -290,7 +290,7 @@ asHandleReply(void *data, StoreIOBuffer result)
         debugs(53, DBG_IMPORTANT, "asHandleReply: Called with Error set and size=" << (unsigned int) result.length);
         delete asState;
         return;
-    } else if (e->getReply()->sline.status() != Http::scOkay) {
+    } else if (e->replyStatus() != Http::scOkay) {
         debugs(53, DBG_IMPORTANT, "WARNING: AS " << asState->as_number << " whois request failed");
         delete asState;
         return;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -745,7 +745,7 @@ ClientHttpRequest::mRangeCLen()
     while (pos != request->range->end()) {
         /* account for headers for this range */
         mb.reset();
-        clientPackRangeHdr(memObject()->getReply(),
+        clientPackRangeHdr(&storeEntry()->freshestReply(),
                            *pos, range_iter.boundary, &mb);
         clen += mb.size;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3513,11 +3513,12 @@ int
 varyEvaluateMatch(StoreEntry * entry, HttpRequest * request)
 {
     SBuf vary(request->vary_headers);
-    int has_vary = entry->getReply()->header.has(Http::HdrType::VARY);
+    const auto &reply = entry->freshestReply();
+    auto has_vary = reply.header.has(Http::HdrType::VARY);
 #if X_ACCELERATOR_VARY
 
     has_vary |=
-        entry->getReply()->header.has(Http::HdrType::HDR_X_ACCELERATOR_VARY);
+        reply.header.has(Http::HdrType::HDR_X_ACCELERATOR_VARY);
 #endif
 
     if (!has_vary || entry->mem_obj->vary_headers.isEmpty()) {
@@ -3537,7 +3538,7 @@ varyEvaluateMatch(StoreEntry * entry, HttpRequest * request)
         /* virtual "vary" object found. Calculate the vary key and
          * continue the search
          */
-        vary = httpMakeVaryMark(request, entry->getReply());
+        vary = httpMakeVaryMark(request, &reply);
 
         if (!vary.isEmpty()) {
             request->vary_headers = vary;
@@ -3549,7 +3550,7 @@ varyEvaluateMatch(StoreEntry * entry, HttpRequest * request)
         }
     } else {
         if (vary.isEmpty()) {
-            vary = httpMakeVaryMark(request, entry->getReply());
+            vary = httpMakeVaryMark(request, &reply);
 
             if (!vary.isEmpty())
                 request->vary_headers = vary;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -745,7 +745,7 @@ ClientHttpRequest::mRangeCLen()
     while (pos != request->range->end()) {
         /* account for headers for this range */
         mb.reset();
-        clientPackRangeHdr(&storeEntry()->freshestReply(),
+        clientPackRangeHdr(&storeEntry()->mem().freshestReply(),
                            *pos, range_iter.boundary, &mb);
         clen += mb.size;
 
@@ -3513,7 +3513,7 @@ int
 varyEvaluateMatch(StoreEntry * entry, HttpRequest * request)
 {
     SBuf vary(request->vary_headers);
-    const auto &reply = entry->freshestReply();
+    const auto &reply = entry->mem().freshestReply();
     auto has_vary = reply.header.has(Http::HdrType::VARY);
 #if X_ACCELERATOR_VARY
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -442,7 +442,6 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
     /* update size of the request */
     reqsize = result.length + reqofs;
 
-
     // request to origin was aborted
     if (EBIT_TEST(http->storeEntry()->flags, ENTRY_ABORTED)) {
         debugs(88, 3, "request to origin aborted '" << http->storeEntry()->url() << "', sending old entry to client");

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -458,7 +458,8 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
         http->logType.update(LOG_TCP_REFRESH_UNMODIFIED);
         http->request->flags.staleIfHit = false; // old_entry is no longer stale
 
-        // update headers on existing entry
+        // TODO: The update may not be instantaneous. Should we wait for its
+        // completion to avoid spawning too much client-disassociated work?
         Store::Root().updateOnNotModified(old_entry, *http->storeEntry());
 
         // if client sent IMS
@@ -1646,7 +1647,7 @@ clientReplyContext::cloneReply()
 {
     assert(reply == NULL);
 
-    reply = http->storeEntry()->latestReply().clone();
+    reply = http->storeEntry()->freshestReply().clone();
     HTTPMSGLOCK(reply);
 
     if (reply->sline.protocol == AnyP::PROTO_HTTP) {

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -821,8 +821,9 @@ clientReplyContext::processConditional(StoreIOBuffer &result)
 {
     StoreEntry *const e = http->storeEntry();
 
-    if (e->getReply()->sline.status() != Http::scOkay) {
-        debugs(88, 4, "Reply code " << e->getReply()->sline.status() << " != 200");
+    const auto replyStatus = e->replyStatus();
+    if (replyStatus != Http::scOkay) {
+        debugs(88, 4, "miss because " << replyStatus << " != 200");
         http->logType.update(LOG_TCP_MISS);
         processMiss();
         return true;

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -821,7 +821,7 @@ clientReplyContext::processConditional(StoreIOBuffer &result)
 {
     StoreEntry *const e = http->storeEntry();
 
-    const auto replyStatusCode = e->stableReply().sline.status();
+    const auto replyStatusCode = e->baseReply().sline.status();
     if (replyStatusCode != Http::scOkay) {
         debugs(88, 4, "miss because " << replyStatusCode << " != 200");
         http->logType.update(LOG_TCP_MISS);
@@ -1208,7 +1208,7 @@ clientReplyContext::storeNotOKTransferDone() const
         return 0;
 
     // TODO: Use MemObject::expectedReplySize(method) after resolving XXX below.
-    const auto expectedBodySize = http->storeEntry()->stableReply().content_length;
+    const auto expectedBodySize = http->storeEntry()->baseReply().content_length;
 
     // XXX: The code below talks about sending data, and checks stats about
     // bytes written to the client connection, but this method must determine

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1646,7 +1646,7 @@ clientReplyContext::cloneReply()
 {
     assert(reply == NULL);
 
-    reply = http->storeEntry()->getReply()->clone();
+    reply = http->storeEntry()->latestReply().clone();
     HTTPMSGLOCK(reply);
 
     if (reply->sline.protocol == AnyP::PROTO_HTTP) {

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -821,9 +821,9 @@ clientReplyContext::processConditional(StoreIOBuffer &result)
 {
     StoreEntry *const e = http->storeEntry();
 
-    const auto replyStatus = e->replyStatus();
-    if (replyStatus != Http::scOkay) {
-        debugs(88, 4, "miss because " << replyStatus << " != 200");
+    const auto replyStatusCode = e->stableReply().sline.status();
+    if (replyStatusCode != Http::scOkay) {
+        debugs(88, 4, "miss because " << replyStatusCode << " != 200");
         http->logType.update(LOG_TCP_MISS);
         processMiss();
         return true;
@@ -1207,9 +1207,8 @@ clientReplyContext::storeNotOKTransferDone() const
         /* haven't found end of headers yet */
         return 0;
 
-    // Use base reply here -- it determines the body bytes we receive from Core.
     // TODO: Use MemObject::expectedReplySize(method) after resolving XXX below.
-    const auto expectedBodySize = mem->baseReply().content_length;
+    const auto expectedBodySize = http->storeEntry()->stableReply().content_length;
 
     // XXX: The code below talks about sending data, and checks stats about
     // bytes written to the client connection, but this method must determine

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -821,7 +821,7 @@ clientReplyContext::processConditional(StoreIOBuffer &result)
 {
     StoreEntry *const e = http->storeEntry();
 
-    const auto replyStatusCode = e->baseReply().sline.status();
+    const auto replyStatusCode = e->mem().baseReply().sline.status();
     if (replyStatusCode != Http::scOkay) {
         debugs(88, 4, "miss because " << replyStatusCode << " != 200");
         http->logType.update(LOG_TCP_MISS);
@@ -1208,7 +1208,7 @@ clientReplyContext::storeNotOKTransferDone() const
         return 0;
 
     // TODO: Use MemObject::expectedReplySize(method) after resolving XXX below.
-    const auto expectedBodySize = http->storeEntry()->baseReply().content_length;
+    const auto expectedBodySize = mem->baseReply().content_length;
 
     // XXX: The code below talks about sending data, and checks stats about
     // bytes written to the client connection, but this method must determine
@@ -1322,7 +1322,7 @@ clientReplyContext::replyStatus()
 
         // TODO: See also (and unify with) storeNotOKTransferDone() checks.
         const int64_t expectedBodySize =
-            http->storeEntry()->baseReply().bodySize(http->request->method);
+            http->storeEntry()->mem().baseReply().bodySize(http->request->method);
         if (expectedBodySize >= 0 && !http->gotEnough()) {
             debugs(88, 5, "clientReplyStatus: client didn't get all it expected");
             return STREAM_UNPLANNED_COMPLETE;

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -113,6 +113,7 @@ private:
     clientStreamNode * next() const;
     StoreIOBuffer holdingBuffer;
     HttpReply *reply;
+    HttpReplyPointer updatedReply; ///< cached reply updated with a 304 response
     void processReplyAccess();
     static ACLCB ProcessReplyAccessResult;
     void processReplyAccessResult(const Acl::Answer &accessAllowed);

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -80,6 +80,9 @@ public:
     virtual LogTags *loggingTags();
 
     ClientHttpRequest *http;
+    /// Base reply header bytes received from Core.
+    /// Compatible with ClientHttpRequest::Out::offset.
+    /// Not to be confused with ClientHttpRequest::Out::headers_sz.
     int headers_sz;
     store_client *sc;       /* The store_client we're using */
     StoreIOBuffer tempBuffer;   /* For use in validating requests via IMS */

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -116,7 +116,6 @@ private:
     clientStreamNode * next() const;
     StoreIOBuffer holdingBuffer;
     HttpReply *reply;
-    HttpReplyPointer updatedReply; ///< cached reply updated with a 304 response
     void processReplyAccess();
     static ACLCB ProcessReplyAccessResult;
     void processReplyAccessResult(const Acl::Answer &accessAllowed);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1627,9 +1627,9 @@ ClientHttpRequest::sslBumpStart()
 bool
 ClientHttpRequest::gotEnough() const
 {
-    /** TODO: should be querying the stream. */
+    // TODO: See also (and unify with) clientReplyContext::storeNotOKTransferDone()
     int64_t contentLength =
-        memObject()->getReply()->bodySize(request->method);
+        memObject()->baseReply().bodySize(request->method);
     assert(contentLength >= 0);
 
     if (out.offset < contentLength)

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -109,8 +109,15 @@ public:
     struct Out {
         Out() : offset(0), size(0), headers_sz(0) {}
 
+        /// Body bytes received from Core. Often looks like (is abused as) body
+        /// bytes written to the client connection. The two values are often
+        /// the same, but code like Http::Stream::packRange() may increment
+        /// offset to skip (unwanted by the client) bytes received from Core.
         int64_t offset;
+        /// Header and body bytes written to the client connection.
         uint64_t size;
+        /// Header bytes written to the client connection.
+        /// Not to be confused with clientReplyContext::headers_sz.
         size_t headers_sz;
     } out;
 

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -109,14 +109,15 @@ public:
     struct Out {
         Out() : offset(0), size(0), headers_sz(0) {}
 
-        /// Body bytes received from Core. Often looks like (is abused as) body
-        /// bytes written to the client connection. The two values are often
-        /// the same, but code like Http::Stream::packRange() may increment
-        /// offset to skip (unwanted by the client) bytes received from Core.
+        /// Roughly speaking, this offset points to the next body byte we want
+        /// to receive from Core. Without Ranges (and I/O errors), we should
+        /// have received (and written to the client) all the previous bytes.
+        /// XXX: The offset is updated by various receive-write steps, making
+        /// its exact meaning illusive. Its Out class placement is confusing.
         int64_t offset;
-        /// Header and body bytes written to the client connection.
+        /// Response header and body bytes written to the client connection.
         uint64_t size;
-        /// Header bytes written to the client connection.
+        /// Response header bytes written to the client connection.
         /// Not to be confused with clientReplyContext::headers_sz.
         size_t headers_sz;
     } out;

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -521,7 +521,7 @@ Client::blockCaching()
         // This relatively expensive check is not in StoreEntry::checkCachable:
         // That method lacks HttpRequest and may be called too many times.
         ACLFilledChecklist ch(acl, originalRequest().getRaw());
-        ch.reply = const_cast<HttpReply*>(entry->getReply()); // ACLFilledChecklist API bug
+        ch.reply = const_cast<HttpReply*>(&entry->freshestReply()); // ACLFilledChecklist API bug
         HTTPMSGLOCK(ch.reply);
         if (!ch.fastCheck().allowed()) { // when in doubt, block
             debugs(20, 3, "store_miss prohibits caching");

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -521,7 +521,7 @@ Client::blockCaching()
         // This relatively expensive check is not in StoreEntry::checkCachable:
         // That method lacks HttpRequest and may be called too many times.
         ACLFilledChecklist ch(acl, originalRequest().getRaw());
-        ch.reply = const_cast<HttpReply*>(&entry->freshestReply()); // ACLFilledChecklist API bug
+        ch.reply = const_cast<HttpReply*>(&entry->mem().freshestReply()); // ACLFilledChecklist API bug
         HTTPMSGLOCK(ch.reply);
         if (!ch.fastCheck().allowed()) { // when in doubt, block
             debugs(20, 3, "store_miss prohibits caching");

--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -218,7 +218,7 @@ Rock::HeaderUpdater::startWriting()
     debugs(20, 7, "wrote " << offset <<
            "; swap_file_sz delta: -" << stalePrefixSz << " +" << freshPrefixSz);
 
-    // Optimistic update OK: Our write lock prevents early swap_file_sz access.
+    // Optimistic early update OK: Our write lock blocks access to swap_file_sz.
     auto &swap_file_sz = update.fresh.anchor->basics.swap_file_sz;
     Must(swap_file_sz >= stalePrefixSz);
     swap_file_sz -= stalePrefixSz;

--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -182,13 +182,15 @@ Rock::HeaderUpdater::startWriting()
 
     off_t offset = 0; // current writing offset (for debugging)
 
+    const auto &mem = update.entry->mem();
+
     {
         debugs(20, 7, "fresh store meta for " << *update.entry);
         size_t freshSwapHeaderSize = 0;
         const auto freshSwapHeader = update.entry->getSerialisedMetaData(freshSwapHeaderSize);
         Must(freshSwapHeader);
         writer->write(freshSwapHeader, freshSwapHeaderSize, 0, nullptr);
-        stalePrefixSz += update.entry->mem_obj->swap_hdr_sz;
+        stalePrefixSz += mem.swap_hdr_sz;
         freshPrefixSz += freshSwapHeaderSize;
         offset += freshSwapHeaderSize;
         xfree(freshSwapHeader);
@@ -196,10 +198,9 @@ Rock::HeaderUpdater::startWriting()
 
     {
         debugs(20, 7, "fresh HTTP header @ " << offset);
-        const auto httpHeader = update.entry->freshestReply().pack();
+        const auto httpHeader = mem.freshestReply().pack();
         writer->write(httpHeader->content(), httpHeader->contentSize(), -1, nullptr);
-        Must(update.entry->mem_obj);
-        const auto &staleReply = update.entry->mem_obj->baseReply();
+        const auto &staleReply = mem.baseReply();
         Must(staleReply.hdr_sz >= 0); // for int-to-uint64_t conversion below
         Must(staleReply.hdr_sz > 0); // already initialized
         stalePrefixSz += staleReply.hdr_sz;

--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -216,11 +216,14 @@ Rock::HeaderUpdater::startWriting()
         exchangeBuffer.clear();
     }
 
-    debugs(20, 7, "wrote " << offset);
-    // TODO: Move these updates into StoreMap::closeForUpdating()?
-    Must(update.fresh.anchor->basics.swap_file_sz >= stalePrefixSz);
-    update.fresh.anchor->basics.swap_file_sz -= stalePrefixSz;
-    update.fresh.anchor->basics.swap_file_sz += freshPrefixSz;
+    debugs(20, 7, "wrote " << offset <<
+           "; swap_file_sz delta: -" << stalePrefixSz << " +" << freshPrefixSz);
+
+    // Optimistic update OK: Our write lock prevents early swap_file_sz access.
+    auto &swap_file_sz = update.fresh.anchor->basics.swap_file_sz;
+    Must(swap_file_sz >= stalePrefixSz);
+    swap_file_sz -= stalePrefixSz;
+    swap_file_sz += freshPrefixSz;
 
     writer->close(StoreIOState::wroteAll); // should call noteDoneWriting()
 }

--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -196,11 +196,10 @@ Rock::HeaderUpdater::startWriting()
 
     {
         debugs(20, 7, "fresh HTTP header @ " << offset);
-        const auto httpHeader = update.entry->latestReply().pack();
+        const auto httpHeader = update.entry->freshestReply().pack();
         writer->write(httpHeader->content(), httpHeader->contentSize(), -1, nullptr);
         Must(update.entry->mem_obj);
-        Must(update.entry->mem_obj->baseReply_);
-        const auto &staleReply = *update.entry->mem_obj->baseReply_;
+        const auto &staleReply = update.entry->mem_obj->baseReply();
         Must(staleReply.hdr_sz >= 0); // for int-to-uint64_t conversion below
         Must(staleReply.hdr_sz > 0); // already initialized
         stalePrefixSz += staleReply.hdr_sz;

--- a/src/http.cc
+++ b/src/http.cc
@@ -858,7 +858,7 @@ HttpStateData::peerSupportsConnectionPinning() const
     if (!_peer->connection_auth)
         return false;
 
-    const auto &rep = entry->freshestReply();
+    const auto &rep = entry->mem().freshestReply();
 
     /*The peer supports connection pinning and the http reply status
       is not unauthorized, so the related connection can be pinned

--- a/src/http.cc
+++ b/src/http.cc
@@ -858,12 +858,12 @@ HttpStateData::peerSupportsConnectionPinning() const
     if (!_peer->connection_auth)
         return false;
 
-    const HttpReplyPointer rep(entry->mem_obj->getReply());
+    const auto &rep = entry->freshestReply();
 
     /*The peer supports connection pinning and the http reply status
       is not unauthorized, so the related connection can be pinned
      */
-    if (rep->sline.status() != Http::scUnauthorized)
+    if (rep.sline.status() != Http::scUnauthorized)
         return true;
 
     /*The server respond with Http::scUnauthorized and the peer configured
@@ -892,7 +892,7 @@ HttpStateData::peerSupportsConnectionPinning() const
       reply and has in its list the "Session-Based-Authentication"
       which means that the peer supports connection pinning.
      */
-    if (rep->header.hasListMember(Http::HdrType::PROXY_SUPPORT, "Session-Based-Authentication", ','))
+    if (rep.header.hasListMember(Http::HdrType::PROXY_SUPPORT, "Session-Based-Authentication", ','))
         return true;
 
     return false;
@@ -916,7 +916,7 @@ HttpStateData::haveParsedReplyHeaders()
 
     if (StoreEntry *oldEntry = findPreviouslyCachedEntry(entry)) {
         oldEntry->lock("HttpStateData::haveParsedReplyHeaders");
-        sawDateGoBack = rep->olderThan(oldEntry->getReply());
+        sawDateGoBack = rep->olderThan(oldEntry->hasFreshestReply());
         oldEntry->unlock("HttpStateData::haveParsedReplyHeaders");
     }
 

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -439,7 +439,7 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
     }
     else if (rep->content_length < 0)
         range_err = "unknown length";
-    else if (rep->content_length != http->storeEntry()->baseReply().content_length)
+    else if (rep->content_length != http->storeEntry()->stableReply().content_length)
         range_err = "INCONSISTENT length";  /* a bug? */
 
     /* hits only - upstream CachePeer determines correct behaviour on misses,

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -439,7 +439,7 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
     }
     else if (rep->content_length < 0)
         range_err = "unknown length";
-    else if (rep->content_length != http->memObject()->getReply()->content_length)
+    else if (rep->content_length != http->storeEntry()->baseReply().content_length)
         range_err = "INCONSISTENT length";  /* a bug? */
 
     /* hits only - upstream CachePeer determines correct behaviour on misses,
@@ -648,7 +648,7 @@ Http::Stream::packRange(StoreIOBuffer const &source, MemBuf *mb)
             if (http->multipartRangeRequest() && i->debt() == i->currentSpec()->length) {
                 assert(http->memObject());
                 clientPackRangeHdr(
-                    http->memObject()->getReply(),  /* original reply */
+                    &http->storeEntry()->freshestReply(),  /* original reply */
                     i->currentSpec(),       /* current range */
                     i->boundary,    /* boundary, the same for all */
                     mb);

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -646,9 +646,8 @@ Http::Stream::packRange(StoreIOBuffer const &source, MemBuf *mb)
              * multi-range
              */
             if (http->multipartRangeRequest() && i->debt() == i->currentSpec()->length) {
-                assert(http->memObject());
                 clientPackRangeHdr(
-                    &http->storeEntry()->freshestReply(),  /* original reply */
+                    &http->storeEntry()->mem().freshestReply(),
                     i->currentSpec(),       /* current range */
                     i->boundary,    /* boundary, the same for all */
                     mb);

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -439,7 +439,7 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
     }
     else if (rep->content_length < 0)
         range_err = "unknown length";
-    else if (rep->content_length != http->storeEntry()->baseReply().content_length)
+    else if (rep->content_length != http->storeEntry()->mem().baseReply().content_length)
         range_err = "INCONSISTENT length";  /* a bug? */
 
     /* hits only - upstream CachePeer determines correct behaviour on misses,

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -439,7 +439,7 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
     }
     else if (rep->content_length < 0)
         range_err = "unknown length";
-    else if (rep->content_length != http->storeEntry()->stableReply().content_length)
+    else if (rep->content_length != http->storeEntry()->baseReply().content_length)
         range_err = "INCONSISTENT length";  /* a bug? */
 
     /* hits only - upstream CachePeer determines correct behaviour on misses,

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -696,7 +696,6 @@ netdbExchangeHandleReply(void *data, StoreIOBuffer receivedData)
     double hops;
     char *p;
     int j;
-    HttpReply const *rep;
     size_t hdr_sz;
     int nused = 0;
     int size;
@@ -738,11 +737,11 @@ netdbExchangeHandleReply(void *data, StoreIOBuffer receivedData)
 
         if ((hdr_sz = headersEnd(p, ex->buf_ofs))) {
             debugs(38, 5, "netdbExchangeHandleReply: hdr_sz = " << hdr_sz);
-            rep = ex->e->getReply();
-            assert(rep->sline.status() != Http::scNone);
-            debugs(38, 3, "netdbExchangeHandleReply: reply status " << rep->sline.status());
+            const auto scode = ex->e->freshestReply().sline.status();
+            assert(scode != Http::scNone);
+            debugs(38, 3, "netdbExchangeHandleReply: reply status " << scode);
 
-            if (rep->sline.status() != Http::scOkay) {
+            if (scode != Http::scOkay) {
                 delete ex;
                 return;
             }

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -737,7 +737,7 @@ netdbExchangeHandleReply(void *data, StoreIOBuffer receivedData)
 
         if ((hdr_sz = headersEnd(p, ex->buf_ofs))) {
             debugs(38, 5, "netdbExchangeHandleReply: hdr_sz = " << hdr_sz);
-            const auto scode = ex->e->freshestReply().sline.status();
+            const auto scode = ex->e->mem().freshestReply().sline.status();
             assert(scode != Http::scNone);
             debugs(38, 3, "netdbExchangeHandleReply: reply status " << scode);
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -582,7 +582,10 @@ Ipc::StoreMap::closeForUpdating(Update &update)
     update.stale.anchor->splicingPoint = update.stale.splicingPoint;
     freeEntry(update.stale.fileNo);
 
-    // make the stale anchor/chain reusable, reachable via its new location
+    // Make the stale anchor/chain reusable, reachable via update.fresh.name. If
+    // update.entry->swap_filen is still update.stale.fileNo, and the entry is
+    // using store, then the entry must have a lock on update.stale.fileNo,
+    // preventing its premature reuse by others.
     relocate(update.fresh.name, update.stale.fileNo);
 
     const Update updateSaved = update; // for post-close debugging below

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -186,8 +186,8 @@ public:
     StoreMapUpdate &operator =(const StoreMapUpdate &other) = delete;
 
     StoreEntry *entry; ///< the store entry being updated
-    Edition stale; ///< old anchor and chain being updated
-    Edition fresh; ///< new anchor and updated chain prefix
+    Edition stale; ///< old anchor and chain
+    Edition fresh; ///< new anchor and the updated chain prefix
 };
 
 class StoreMapCleaner;

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -520,7 +520,7 @@ peerDigestFetchReply(void *data, char *buf, ssize_t size)
         return -1;
 
     if ((hdr_size = headersEnd(buf, size))) {
-        const auto &reply = fetch->entry->freshestReply();
+        const auto &reply = fetch->entry->mem().freshestReply();
         const auto status = reply.sline.status();
         assert(status != Http::scNone);
         debugs(72, 3, "peerDigestFetchReply: " << pd->host << " status: " << status <<
@@ -603,7 +603,7 @@ peerDigestSwapInHeaders(void *data, char *buf, ssize_t size)
     assert(!fetch->offset);
 
     if ((hdr_size = headersEnd(buf, size))) {
-        const auto &reply = fetch->entry->freshestReply();
+        const auto &reply = fetch->entry->mem().freshestReply();
         const auto status = reply.sline.status();
         assert(status != Http::scNone);
 

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -520,13 +520,12 @@ peerDigestFetchReply(void *data, char *buf, ssize_t size)
         return -1;
 
     if ((hdr_size = headersEnd(buf, size))) {
-        HttpReply const *reply = fetch->entry->getReply();
-        assert(reply);
-        assert(reply->sline.status() != Http::scNone);
-        const Http::StatusCode status = reply->sline.status();
+        const auto &reply = fetch->entry->freshestReply();
+        const auto status = reply.sline.status();
+        assert(status != Http::scNone);
         debugs(72, 3, "peerDigestFetchReply: " << pd->host << " status: " << status <<
-               ", expires: " << (long int) reply->expires << " (" << std::showpos <<
-               (int) (reply->expires - squid_curtime) << ")");
+               ", expires: " << (long int) reply.expires << " (" << std::showpos <<
+               (int) (reply.expires - squid_curtime) << ")");
 
         /* this "if" is based on clientHandleIMSReply() */
 
@@ -565,7 +564,7 @@ peerDigestFetchReply(void *data, char *buf, ssize_t size)
             }
         } else {
             /* some kind of a bug */
-            peerDigestFetchAbort(fetch, buf, reply->sline.reason());
+            peerDigestFetchAbort(fetch, buf, reply.sline.reason());
             return -1;      /* XXX -1 will abort stuff in ReadReply! */
         }
 
@@ -604,13 +603,13 @@ peerDigestSwapInHeaders(void *data, char *buf, ssize_t size)
     assert(!fetch->offset);
 
     if ((hdr_size = headersEnd(buf, size))) {
-        assert(fetch->entry->getReply());
-        assert(fetch->entry->getReply()->sline.status() != Http::scNone);
+        const auto &reply = fetch->entry->freshestReply();
+        const auto status = reply.sline.status();
+        assert(status != Http::scNone);
 
-        if (fetch->entry->getReply()->sline.status() != Http::scOkay) {
+        if (status != Http::scOkay) {
             debugs(72, DBG_IMPORTANT, "peerDigestSwapInHeaders: " << fetch->pd->host <<
-                   " status " << fetch->entry->getReply()->sline.status() <<
-                   " got cached!");
+                   " status " << status << " got cached!");
 
             peerDigestFetchAbort(fetch, buf, "internal status error");
             return -1;
@@ -642,7 +641,8 @@ peerDigestSwapInCBlock(void *data, char *buf, ssize_t size)
     if (size >= (ssize_t)StoreDigestCBlockSize) {
         PeerDigest *pd = fetch->pd;
 
-        assert(pd && fetch->entry->getReply());
+        assert(pd);
+        assert(fetch->entry->mem_obj);
 
         if (peerDigestSetCBlock(pd, buf)) {
             /* XXX: soon we will have variable header size */

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -550,7 +550,7 @@ refreshIsCachable(const StoreEntry * entry)
         /* no mem_obj? */
         return true;
 
-    if (entry->stableReply().content_length == 0)
+    if (entry->baseReply().content_length == 0)
         /* No use refreshing (caching?) 0 byte objects */
         return false;
 

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -326,7 +326,7 @@ refreshCheck(const StoreEntry * entry, HttpRequest * request, time_t delta)
 
     debugs(22, 3, "Staleness = " << staleness);
 
-    const HttpReplyPointer reply(entry->mem_obj ? &entry->freshestReply() : nullptr);
+    const auto reply = entry->hasFreshestReply(); // may be nil
 
     // stale-if-error requires any failure be passed thru when its period is over.
     int staleIfError = -1;

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -550,11 +550,7 @@ refreshIsCachable(const StoreEntry * entry)
         /* no mem_obj? */
         return true;
 
-    if (entry->getReply() == NULL)
-        /* no reply? */
-        return true;
-
-    if (entry->getReply()->content_length == 0)
+    if (entry->freshestReply().content_length == 0)
         /* No use refreshing (caching?) 0 byte objects */
         return false;
 

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -550,7 +550,7 @@ refreshIsCachable(const StoreEntry * entry)
         /* no mem_obj? */
         return true;
 
-    if (entry->freshestReply().content_length == 0)
+    if (entry->stableReply().content_length == 0)
         /* No use refreshing (caching?) 0 byte objects */
         return false;
 

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -550,7 +550,7 @@ refreshIsCachable(const StoreEntry * entry)
         /* no mem_obj? */
         return true;
 
-    if (entry->baseReply().content_length == 0)
+    if (entry->mem_obj->baseReply().content_length == 0)
         /* No use refreshing (caching?) 0 byte objects */
         return false;
 

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -326,7 +326,7 @@ refreshCheck(const StoreEntry * entry, HttpRequest * request, time_t delta)
 
     debugs(22, 3, "Staleness = " << staleness);
 
-    const HttpReplyPointer reply(entry->mem_obj && entry->mem_obj->getReply() ? entry->mem_obj->getReply() : nullptr);
+    const HttpReplyPointer reply(entry->mem_obj ? &entry->freshestReply() : nullptr);
 
     // stale-if-error requires any failure be passed thru when its period is over.
     int staleIfError = -1;

--- a/src/store.cc
+++ b/src/store.cc
@@ -1713,13 +1713,6 @@ StoreEntry::freshestReply() const
     return mem_obj->baseReply();
 }
 
-HttpReply &
-StoreEntry::adjustableBaseReply()
-{
-    assert(mem_obj);
-    return mem_obj->adjustableBaseReply();
-}
-
 void
 StoreEntry::reset()
 {

--- a/src/store.cc
+++ b/src/store.cc
@@ -935,7 +935,7 @@ StoreEntry::checkTooSmall()
         if (mem_obj->object_sz >= 0 &&
                 mem_obj->object_sz < Config.Store.minObjectSize)
             return 1;
-    const auto clen = freshestReply().content_length;
+    const auto clen = stableReply().content_length;
     if (clen >= 0 && clen < Config.Store.minObjectSize)
         return 1;
     return 0;
@@ -947,7 +947,7 @@ StoreEntry::checkTooBig() const
     if (mem_obj->endOffset() > store_maxobjsize)
         return true;
 
-    const auto clen = freshestReply().content_length;
+    const auto clen = stableReply().content_length;
     return (clen >= 0 && clen > store_maxobjsize);
 }
 
@@ -1274,7 +1274,7 @@ StoreEntry::validLength() const
 {
     int64_t diff;
     assert(mem_obj != NULL);
-    const auto reply = &mem_obj->baseReply();
+    const auto reply = &stableReply();
     debugs(20, 3, "storeEntryValidLength: Checking '" << getMD5Text() << "'");
     debugs(20, 5, "storeEntryValidLength:     object_len = " <<
            objectLen());

--- a/src/store.cc
+++ b/src/store.cc
@@ -935,6 +935,7 @@ StoreEntry::checkTooSmall()
         if (mem_obj->object_sz >= 0 &&
                 mem_obj->object_sz < Config.Store.minObjectSize)
             return 1;
+
     const auto clen = baseReply().content_length;
     if (clen >= 0 && clen < Config.Store.minObjectSize)
         return 1;
@@ -1076,9 +1077,6 @@ StoreEntry::complete()
         return;
     }
 
-    /* This is suspect: mem obj offsets include the headers. do we adjust for that
-     * in use of object_sz?
-     */
     mem_obj->object_sz = mem_obj->endOffset();
 
     store_status = STORE_OK;
@@ -1462,7 +1460,7 @@ StoreEntry::timestampsSet()
     debugs(20, 7, *this << " had " << describeTimestamps());
 
     // TODO: Remove change-reducing "&" before the official commit.
-    const auto * const reply = &(freshestReply());
+    const auto * const reply = &freshestReply();
 
     time_t served_date = reply->date;
     int age = reply->header.getInt(Http::HdrType::AGE);

--- a/src/store.cc
+++ b/src/store.cc
@@ -1721,6 +1721,13 @@ StoreEntry::freshestReply() const
     return mem_obj->baseReply();
 }
 
+HttpReply &
+StoreEntry::adjustableBaseReply()
+{
+    assert(mem_obj);
+    return mem_obj->adjustableBaseReply();
+}
+
 void
 StoreEntry::reset()
 {

--- a/src/store.cc
+++ b/src/store.cc
@@ -935,7 +935,7 @@ StoreEntry::checkTooSmall()
         if (mem_obj->object_sz >= 0 &&
                 mem_obj->object_sz < Config.Store.minObjectSize)
             return 1;
-    const auto clen = stableReply().content_length;
+    const auto clen = baseReply().content_length;
     if (clen >= 0 && clen < Config.Store.minObjectSize)
         return 1;
     return 0;
@@ -947,7 +947,7 @@ StoreEntry::checkTooBig() const
     if (mem_obj->endOffset() > store_maxobjsize)
         return true;
 
-    const auto clen = stableReply().content_length;
+    const auto clen = baseReply().content_length;
     return (clen >= 0 && clen > store_maxobjsize);
 }
 
@@ -1274,7 +1274,7 @@ StoreEntry::validLength() const
 {
     int64_t diff;
     assert(mem_obj != NULL);
-    const auto reply = &stableReply();
+    const auto reply = &baseReply();
     debugs(20, 3, "storeEntryValidLength: Checking '" << getMD5Text() << "'");
     debugs(20, 5, "storeEntryValidLength:     object_len = " <<
            objectLen());

--- a/src/store.cc
+++ b/src/store.cc
@@ -1460,7 +1460,7 @@ StoreEntry::timestampsSet()
     debugs(20, 7, *this << " had " << describeTimestamps());
 
     // TODO: Remove change-reducing "&" before the official commit.
-    const auto * const reply = &freshestReply();
+    const auto reply = &freshestReply();
 
     time_t served_date = reply->date;
     int age = reply->header.getInt(Http::HdrType::AGE);

--- a/src/store.cc
+++ b/src/store.cc
@@ -1699,12 +1699,6 @@ StoreEntry::contentLen() const
     return objectLen() - mem_obj->baseReply().hdr_sz;
 }
 
-HttpReply const *
-StoreEntry::getReply() const
-{
-    return (mem_obj ? &mem_obj->baseReply() : nullptr);
-}
-
 const HttpReply &
 StoreEntry::baseReply() const
 {

--- a/src/store.cc
+++ b/src/store.cc
@@ -1708,6 +1708,13 @@ StoreEntry::getReply() const
 }
 
 const HttpReply &
+StoreEntry::baseReply() const
+{
+    Must(mem_obj);
+    return mem_obj->baseReply();
+}
+
+const HttpReply &
 StoreEntry::freshestReply() const
 {
     Must(mem_obj);

--- a/src/store.cc
+++ b/src/store.cc
@@ -1529,7 +1529,7 @@ StoreEntry::updateOnNotModified(const StoreEntry &e304)
     const auto &oldReply = mem_obj->freshestReply();
     const auto updatedReply = oldReply.recreateOnNotModified(e304.mem_obj->baseReply());
     if (updatedReply) // HTTP 304 brought in new information
-       mem_obj->updateReply(*updatedReply);
+        mem_obj->updateReply(*updatedReply);
     // else continue to use the previous update, if any
 
     if (!timestampsSet() && !updatedReply)

--- a/src/store.cc
+++ b/src/store.cc
@@ -936,7 +936,7 @@ StoreEntry::checkTooSmall()
                 mem_obj->object_sz < Config.Store.minObjectSize)
             return 1;
 
-    const auto clen = baseReply().content_length;
+    const auto clen = mem().baseReply().content_length;
     if (clen >= 0 && clen < Config.Store.minObjectSize)
         return 1;
     return 0;
@@ -948,7 +948,7 @@ StoreEntry::checkTooBig() const
     if (mem_obj->endOffset() > store_maxobjsize)
         return true;
 
-    const auto clen = baseReply().content_length;
+    const auto clen = mem_obj->baseReply().content_length;
     return (clen >= 0 && clen > store_maxobjsize);
 }
 
@@ -1272,7 +1272,7 @@ StoreEntry::validLength() const
 {
     int64_t diff;
     assert(mem_obj != NULL);
-    const auto reply = &baseReply();
+    const auto reply = &mem_obj->baseReply();
     debugs(20, 3, "storeEntryValidLength: Checking '" << getMD5Text() << "'");
     debugs(20, 5, "storeEntryValidLength:     object_len = " <<
            objectLen());
@@ -1695,13 +1695,6 @@ StoreEntry::contentLen() const
 {
     assert(mem_obj != NULL);
     return objectLen() - mem_obj->baseReply().hdr_sz;
-}
-
-const HttpReply &
-StoreEntry::baseReply() const
-{
-    Must(mem_obj);
-    return mem_obj->baseReply();
 }
 
 const HttpReply &

--- a/src/store.cc
+++ b/src/store.cc
@@ -1945,7 +1945,6 @@ StoreEntry::trimMemory(const bool preserveSwappable)
 bool
 StoreEntry::modifiedSince(const time_t ims, const int imslen) const
 {
-    int object_length;
     const time_t mod_time = lastModified();
 
     debugs(88, 3, "modifiedSince: '" << url() << "'");
@@ -1955,11 +1954,7 @@ StoreEntry::modifiedSince(const time_t ims, const int imslen) const
     if (mod_time < 0)
         return true;
 
-    /* Find size of the object */
-    object_length = getReply()->content_length;
-
-    if (object_length < 0)
-        object_length = contentLen();
+    assert(imslen < 0); // TODO: Either remove imslen or support it properly.
 
     if (mod_time > ims) {
         debugs(88, 3, "--> YES: entry newer than client");
@@ -1967,15 +1962,9 @@ StoreEntry::modifiedSince(const time_t ims, const int imslen) const
     } else if (mod_time < ims) {
         debugs(88, 3, "-->  NO: entry older than client");
         return false;
-    } else if (imslen < 0) {
-        debugs(88, 3, "-->  NO: same LMT, no client length");
-        return false;
-    } else if (imslen == object_length) {
-        debugs(88, 3, "-->  NO: same LMT, same length");
-        return false;
     } else {
-        debugs(88, 3, "--> YES: same LMT, different length");
-        return true;
+        debugs(88, 3, "-->  NO: same LMT");
+        return false;
     }
 }
 

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -700,7 +700,7 @@ Store::Controller::updateOnNotModified(StoreEntry *old, StoreEntry &e304)
     // (re)set old updatedReply_ before calling timestampsSet() below
     const auto &oldReply = old->latestReply();
     Must(e304.mem_obj->baseReply_);
-    const auto updatedReply = oldReply.updateOnNotModified(*e304.mem_obj->baseReply_);
+    const auto updatedReply = oldReply.recreateOnNotModified(*e304.mem_obj->baseReply_);
     if (updatedReply)
        old->mem_obj->updatedReply_ = updatedReply;
    // else old->mem_obj->updatedReply_ stays the same (and may still be nil)

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -697,23 +697,10 @@ Store::Controller::updateOnNotModified(StoreEntry *old, StoreEntry &e304)
     }
     e304.mem_obj->appliedUpdates = true;
 
-    // (re)set old updatedReply_ before calling timestampsSet() below
-    const auto &oldReply = old->latestReply();
-    Must(e304.mem_obj->baseReply_);
-    const auto updatedReply = oldReply.recreateOnNotModified(*e304.mem_obj->baseReply_);
-    if (updatedReply)
-       old->mem_obj->updatedReply_ = updatedReply;
-   // else old->mem_obj->updatedReply_ stays the same (and may still be nil)
-
-    if (!old->timestampsSet() && !updatedReply) {
+    if (!old->updateOnNotModified(e304)) {
         debugs(20, 5, "updated nothing in " << *old << " with " << e304);
         return;
     }
-
-    // XXX: Update old->mem_obj->vary_headers?
-
-    debugs(20, 5, "updating storage of " << *old << " after " << e304);
-    old->mem_obj->appliedUpdates = true; // helps in triage; may already be true
 
     if (sharedMemStore && old->mem_status == IN_MEMORY && !EBIT_TEST(old->flags, ENTRY_SPECIAL))
         sharedMemStore->updateHeaders(old);

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -677,20 +677,44 @@ Store::Controller::handleIdleEntry(StoreEntry &e)
 }
 
 void
-Store::Controller::updateOnNotModified(StoreEntry *old, const StoreEntry &newer)
+Store::Controller::updateOnNotModified(StoreEntry *old, StoreEntry &e304)
 {
-    /* update the old entry object */
     Must(old);
-    HttpReply *oldReply = const_cast<HttpReply*>(old->getReply());
+    const auto oldReply = old->getReply();
     Must(oldReply);
+    Must(e304.mem_obj);
 
-    const bool modified = oldReply->updateOnNotModified(newer.getReply());
-    if (!old->timestampsSet() && !modified)
+    // TODO: Also detect prior updateOnNotModified() calls that did not update
+    // reply headers, but keep in mind that timestampsSet() at least appears to
+    // depend on current time (in addition to the reply headers).
+    if (e304.mem_obj->updatedReply_) {
+        debugs(20, 5, "reusing precomputed update in " << *old);
+        assert(old->mem_obj->updatedReply_);
         return;
+    }
 
-    // XXX: Call memStore->updateHeaders(old) and swapDir->updateHeaders(old) to
-    // update stored headers, stored metadata, and in-transit metadata.
-    debugs(20, 3, *old << " headers were modified: " << modified);
+    Must(e304.mem_obj->baseReply_);
+    e304.mem_obj->updatedReply_ = oldReply->updateOnNotModified(*e304.mem_obj->baseReply_);
+
+    // (re)set updatedReply_ before calling timestampsSet() below
+    old->mem_obj->updatedReply_ = e304.mem_obj->updatedReply_; // may be nil
+
+    if (!old->timestampsSet() && !e304.mem_obj->updatedReply_) {
+        debugs(20, 5, "did nothing for " << *old);
+        return;
+    }
+
+    // XXX: Update old->mem_obj->vary_headers?
+
+    /* update stored image of the old entry */
+
+    debugs(20, 5, "updating storage for " << *old);
+
+    if (sharedMemStore && old->mem_status == IN_MEMORY && !EBIT_TEST(old->flags, ENTRY_SPECIAL))
+        sharedMemStore->updateHeaders(old);
+
+    if (old->swap_dirn > -1)
+        swapDir->updateHeaders(old);
 }
 
 bool

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -693,8 +693,6 @@ Store::Controller::updateOnNotModified(StoreEntry *old, StoreEntry &e304)
     //         sake, it is best to detect and skip such repeated update calls.
     if (e304.mem_obj->appliedUpdates) {
         debugs(20, 5, "ignored repeated update of " << *old << " with " << e304);
-        assert(old->mem_obj->updatedReply_);
-        // old->timestampsSet() has been called when updatedReply_ was reset
         return;
     }
     e304.mem_obj->appliedUpdates = true;

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -88,7 +88,7 @@ public:
     /// called to get rid of no longer needed entry data in RAM, if any
     void memoryOut(StoreEntry &, const bool preserveSwappable);
 
-    /// update old entry metadata and HTTP reply headers, using a 304 response
+    /// using a 304 response, update the old entry (metadata and reply headers)
     void updateOnNotModified(StoreEntry *old, StoreEntry &e304);
 
     /// tries to make the entry available for collapsing future requests

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -88,8 +88,8 @@ public:
     /// called to get rid of no longer needed entry data in RAM, if any
     void memoryOut(StoreEntry &, const bool preserveSwappable);
 
-    /// update old entry metadata and HTTP headers using a newer entry
-    void updateOnNotModified(StoreEntry *old, const StoreEntry &newer);
+    /// update old entry metadata and HTTP reply headers, using a 304 response
+    void updateOnNotModified(StoreEntry *old, StoreEntry &e304);
 
     /// tries to make the entry available for collapsing future requests
     bool allowCollapsing(StoreEntry *, const RequestFlags &, const HttpRequestMethod &);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -843,7 +843,7 @@ CheckQuickAbortIsReasonable(StoreEntry * entry)
         return true;
     }
 
-    const auto &reply = entry->baseReply();
+    const auto &reply = entry->baseReply(); // or stableReply()
 
     if (reply.hdr_sz <= 0) {
         // TODO: Check whether this condition works for HTTP/0 responses.

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -512,7 +512,7 @@ store_client::readBody(const char *, ssize_t len)
     const auto rep = entry->mem_obj ? &entry->baseReply() : nullptr;
     if (copyInto.offset == 0 && len > 0 && rep && rep->sline.status() == Http::scNone) {
         /* Our structure ! */
-        if (!entry->adjustableBaseReply().parseCharBuf(copyInto.data, headersEnd(copyInto.data, len))) {
+        if (!entry->mem_obj->adjustableBaseReply().parseCharBuf(copyInto.data, headersEnd(copyInto.data, len))) {
             debugs(90, DBG_CRITICAL, "Could not parse headers from on disk object");
         } else {
             parsed_header = 1;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -512,7 +512,7 @@ store_client::readBody(const char *, ssize_t len)
     const auto rep = entry->mem_obj ? &entry->baseReply() : nullptr;
     if (copyInto.offset == 0 && len > 0 && rep && rep->sline.status() == Http::scNone) {
         /* Our structure ! */
-        if (!const_cast<HttpReply*>(entry->getReply())->parseCharBuf(copyInto.data, headersEnd(copyInto.data, len))) {
+        if (!entry->adjustableBaseReply().parseCharBuf(copyInto.data, headersEnd(copyInto.data, len))) {
             debugs(90, DBG_CRITICAL, "Could not parse headers from on disk object");
         } else {
             parsed_header = 1;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -509,7 +509,7 @@ store_client::readBody(const char *, ssize_t len)
     if (len < 0)
         return fail();
 
-    const auto rep = entry->mem_obj ? &entry->baseReply() : nullptr;
+    const auto rep = entry->mem_obj ? &entry->mem().baseReply() : nullptr;
     if (copyInto.offset == 0 && len > 0 && rep && rep->sline.status() == Http::scNone) {
         /* Our structure ! */
         if (!entry->mem_obj->adjustableBaseReply().parseCharBuf(copyInto.data, headersEnd(copyInto.data, len))) {
@@ -843,7 +843,7 @@ CheckQuickAbortIsReasonable(StoreEntry * entry)
         return true;
     }
 
-    const auto &reply = entry->baseReply();
+    const auto &reply = mem->baseReply();
 
     if (reply.hdr_sz <= 0) {
         // TODO: Check whether this condition works for HTTP/0 responses.

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -843,7 +843,7 @@ CheckQuickAbortIsReasonable(StoreEntry * entry)
         return true;
     }
 
-    const auto &reply = entry->baseReply(); // or stableReply()
+    const auto &reply = entry->baseReply();
 
     if (reply.hdr_sz <= 0) {
         // TODO: Check whether this condition works for HTTP/0 responses.

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -864,7 +864,7 @@ CheckQuickAbortIsReasonable(StoreEntry * entry)
 
     if (reply.content_length < 0) {
         // XXX: cf.data.pre does not document what should happen in this case
-        // We know that quick_abort is enabled, but no limits can be applied.
+        // We know that quick_abort is enabled, but no limit can be applied.
         debugs(90, 3, "quick-abort? YES unknown content length");
         return true;
     }

--- a/src/store_log.cc
+++ b/src/store_log.cc
@@ -48,7 +48,7 @@ storeLog(int tag, const StoreEntry * e)
 
     ++storeLogTagsCounts[tag];
     if (mem != NULL) {
-        reply = &e->freshestReply();
+        reply = &mem->freshestReply();
         /*
          * XXX Ok, where should we print the dir number here?
          * Because if we print it before the swap file number, it'll break

--- a/src/store_log.cc
+++ b/src/store_log.cc
@@ -48,7 +48,7 @@ storeLog(int tag, const StoreEntry * e)
 
     ++storeLogTagsCounts[tag];
     if (mem != NULL) {
-        reply = e->getReply();
+        reply = &e->freshestReply();
         /*
          * XXX Ok, where should we print the dir number here?
          * Because if we print it before the swap file number, it'll break

--- a/src/store_swapmeta.cc
+++ b/src/store_swapmeta.cc
@@ -35,7 +35,7 @@ storeSwapTLVFree(tlv * n)
  * Build a TLV list for a StoreEntry
  */
 tlv *
-storeSwapMetaBuild(StoreEntry * e)
+storeSwapMetaBuild(const StoreEntry *e)
 {
     tlv *TLV = NULL;        /* we'll return this */
     tlv **T = &TLV;

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -57,7 +57,7 @@ storeSwapOutStart(StoreEntry * e)
      */
 
     // Create metadata now, possibly in vain: storeCreate needs swap_hdr_sz.
-    const char *buf = e->getSerialisedMetaData ();
+    const auto buf = e->getSerialisedMetaData(mem->swap_hdr_sz);
     assert(buf);
 
     /* Create the swap file */

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -28,7 +28,7 @@ HttpHeader::~HttpHeader() {STUB}
 HttpHeader &HttpHeader::operator =(const HttpHeader &other) STUB_RETVAL(*this)
 void HttpHeader::clean() STUB
 void HttpHeader::append(const HttpHeader *) STUB
-bool HttpHeader::update(HttpHeader const *) STUB_RETVAL(false)
+void HttpHeader::update(const HttpHeader *) STUB
 void HttpHeader::compact() STUB
 int HttpHeader::parse(const char *, size_t, Http::ContentLengthInterpreter &) STUB_RETVAL(-1)
 int HttpHeader::parse(const char *, size_t, bool, size_t &, Http::ContentLengthInterpreter &) STUB_RETVAL(-1)

--- a/src/tests/stub_HttpReply.cc
+++ b/src/tests/stub_HttpReply.cc
@@ -29,7 +29,7 @@ bool HttpReply::parseFirstLine(const char *start, const char *end) STUB_RETVAL(f
 void HttpReply::hdrCacheInit() STUB
 HttpReply * HttpReply::clone() const STUB_RETVAL(NULL)
 bool HttpReply::inheritProperties(const Http::Message *aMsg) STUB_RETVAL(false)
-HttpReply::Pointer HttpReply::updateOnNotModified(const HttpReply &) const STUB_RETVAL(nullptr)
+HttpReply::Pointer HttpReply::recreateOnNotModified(const HttpReply &) const STUB_RETVAL(nullptr)
 int64_t HttpReply::bodySize(const HttpRequestMethod&) const STUB_RETVAL(0)
 const HttpHdrContRange *HttpReply::contentRange() const STUB_RETVAL(nullptr)
 void HttpReply::configureContentLengthInterpreter(Http::ContentLengthInterpreter &) STUB

--- a/src/tests/stub_HttpReply.cc
+++ b/src/tests/stub_HttpReply.cc
@@ -29,7 +29,7 @@ bool HttpReply::parseFirstLine(const char *start, const char *end) STUB_RETVAL(f
 void HttpReply::hdrCacheInit() STUB
 HttpReply * HttpReply::clone() const STUB_RETVAL(NULL)
 bool HttpReply::inheritProperties(const Http::Message *aMsg) STUB_RETVAL(false)
-bool HttpReply::updateOnNotModified(HttpReply const*) STUB_RETVAL(false)
+HttpReply::Pointer HttpReply::updateOnNotModified(const HttpReply &) const STUB_RETVAL(nullptr)
 int64_t HttpReply::bodySize(const HttpRequestMethod&) const STUB_RETVAL(0)
 const HttpHdrContRange *HttpReply::contentRange() const STUB_RETVAL(nullptr)
 void HttpReply::configureContentLengthInterpreter(Http::ContentLengthInterpreter &) STUB

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -41,7 +41,7 @@ void Controller::updateLimits() STUB
 void Controller::handleIdleEntry(StoreEntry &) STUB
 void Controller::freeMemorySpace(const int) STUB
 void Controller::memoryOut(StoreEntry &, const bool) STUB
-void Controller::updateOnNotModified(StoreEntry *, const StoreEntry &) STUB
+void Controller::updateOnNotModified(StoreEntry *, StoreEntry &) STUB
 bool Controller::allowCollapsing(StoreEntry *, const RequestFlags &, const HttpRequestMethod &) STUB_RETVAL(false)
 void Controller::addReading(StoreEntry *, const cache_key *) STUB
 void Controller::addWriting(StoreEntry *, const cache_key *) STUB

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -26,7 +26,6 @@ bool StoreEntry::checkDeferRead(int fd) const STUB_RETVAL(false)
 const char *StoreEntry::getMD5Text() const STUB_RETVAL(NULL)
 StoreEntry::StoreEntry() STUB
 StoreEntry::~StoreEntry() STUB
-HttpReply const *StoreEntry::getReply() const STUB_RETVAL(NULL)
 void StoreEntry::write(StoreIOBuffer) STUB
 bool StoreEntry::isAccepting() const STUB_RETVAL(false)
 size_t StoreEntry::bytesWanted(Range<size_t> const, bool) const STUB_RETVAL(0)

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -32,7 +32,7 @@ bool StoreEntry::isAccepting() const STUB_RETVAL(false)
 size_t StoreEntry::bytesWanted(Range<size_t> const, bool) const STUB_RETVAL(0)
 void StoreEntry::complete() STUB
 store_client_t StoreEntry::storeClientType() const STUB_RETVAL(STORE_NON_CLIENT)
-char const *StoreEntry::getSerialisedMetaData() STUB_RETVAL(NULL)
+char const *StoreEntry::getSerialisedMetaData(size_t &length) const STUB_RETVAL(NULL)
 void StoreEntry::replaceHttpReply(HttpReply *, bool andStartWriting) STUB
 bool StoreEntry::mayStartSwapOut() STUB_RETVAL(false)
 void StoreEntry::trimMemory(const bool preserveSwappable) STUB

--- a/src/tests/stub_store_swapout.cc
+++ b/src/tests/stub_store_swapout.cc
@@ -18,6 +18,6 @@
 void storeUnlink(StoreEntry * e) STUB
 
 char *storeSwapMetaPack(tlv * tlv_list, int *length) STUB_RETVAL(NULL)
-tlv *storeSwapMetaBuild(StoreEntry * e) STUB_RETVAL(NULL)
+tlv *storeSwapMetaBuild(const StoreEntry *) STUB_RETVAL(nullptr)
 void storeSwapTLVFree(tlv * n) STUB
 

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -189,7 +189,7 @@ testRock::createEntry(const int i)
     flags.cachable = true;
     StoreEntry *const pe =
         storeCreateEntry(storeId(i), "dummy log url", flags, Http::METHOD_GET);
-    HttpReply *const rep = const_cast<HttpReply *>(pe->getReply());
+    const auto rep = pe->adjustableBaseReply();
     rep->setHeaders(Http::scOkay, "dummy test object", "x-squid-internal/test", 0, -1, squid_curtime + 100000);
 
     pe->setPublicKey();

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -203,7 +203,7 @@ testRock::addEntry(const int i)
     StoreEntry *const pe = createEntry(i);
 
     pe->buffer();
-    pe->getReply()->packHeadersUsingSlowPacker(*pe);
+    pe->freshestReply().packHeadersUsingSlowPacker(*pe);
     pe->flush();
     pe->timestampsSet();
     pe->complete();

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -203,7 +203,7 @@ testRock::addEntry(const int i)
     StoreEntry *const pe = createEntry(i);
 
     pe->buffer();
-    pe->freshestReply().packHeadersUsingSlowPacker(*pe);
+    pe->mem().freshestReply().packHeadersUsingSlowPacker(*pe);
     pe->flush();
     pe->timestampsSet();
     pe->complete();

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -189,8 +189,8 @@ testRock::createEntry(const int i)
     flags.cachable = true;
     StoreEntry *const pe =
         storeCreateEntry(storeId(i), "dummy log url", flags, Http::METHOD_GET);
-    const auto rep = pe->adjustableBaseReply();
-    rep->setHeaders(Http::scOkay, "dummy test object", "x-squid-internal/test", 0, -1, squid_curtime + 100000);
+    auto &rep = pe->mem().adjustableBaseReply();
+    rep.setHeaders(Http::scOkay, "dummy test object", "x-squid-internal/test", 0, -1, squid_curtime + 100000);
 
     pe->setPublicKey();
 

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -152,7 +152,7 @@ testUfs::testUfsSearch()
         pe->setPublicKey();
 
         pe->buffer();
-        pe->getReply()->packHeadersUsingSlowPacker(*pe);
+        pe->freshestReply().packHeadersUsingSlowPacker(*pe);
         pe->flush();
         pe->timestampsSet();
         pe->complete();

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -146,8 +146,8 @@ testUfs::testUfsSearch()
         RequestFlags flags;
         flags.cachable = true;
         StoreEntry *pe = storeCreateEntry("dummy url", "dummy log url", flags, Http::METHOD_GET);
-        const auto rep = &pe->adjustableReply();
-        rep->setHeaders(Http::scOkay, "dummy test object", "x-squid-internal/test", 0, -1, squid_curtime + 100000);
+        auto &reply = pe->mem().adjustableBaseReply();
+        reply.setHeaders(Http::scOkay, "dummy test object", "x-squid-internal/test", 0, -1, squid_curtime + 100000);
 
         pe->setPublicKey();
 

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -146,7 +146,7 @@ testUfs::testUfsSearch()
         RequestFlags flags;
         flags.cachable = true;
         StoreEntry *pe = storeCreateEntry("dummy url", "dummy log url", flags, Http::METHOD_GET);
-        HttpReply *rep = (HttpReply *) pe->getReply();  // bypass const
+        const auto rep = &pe->adjustableReply();
         rep->setHeaders(Http::scOkay, "dummy test object", "x-squid-internal/test", 0, -1, squid_curtime + 100000);
 
         pe->setPublicKey();

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -152,7 +152,7 @@ testUfs::testUfsSearch()
         pe->setPublicKey();
 
         pe->buffer();
-        pe->freshestReply().packHeadersUsingSlowPacker(*pe);
+        pe->mem().freshestReply().packHeadersUsingSlowPacker(*pe);
         pe->flush();
         pe->timestampsSet();
         pe->complete();

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -312,7 +312,7 @@ urnHandleReply(void *data, StoreIOBuffer result)
     }
 
     s = buf + k;
-    assert(urlres_e->getReply());
+    // TODO: Check whether we should parse urlres_e reply, as before 528b2c61.
     rep = new HttpReply;
     rep->parseCharBuf(buf, k);
     debugs(52, 3, "reply exists, code=" << rep->sline.status() << ".");


### PR DESCRIPTION
Commit 60ba25f disabled header updates (introduced in commit abf396e)
after we discovered critical inconsistencies in related metadata
updates. Finding a way to keep metadata consistent proved to be very
difficult. The primary challenge is the multitude of often concurrent
and semi-dependent activities associated with a single StoreEntry object
(e.g., writing an incoming miss response into RAM, caching the response,
loading a cache hit into RAM, and sending a response to the client).

Concurrent activities (re)set or use overlapping sets of 304-dependent
members, including StoreEntry "basics" (e.g. StoreEntry::swap_file_sz
and timestamp), "reply" (MemObject::reply_ including its hdr_sz member),
and "data" (MemObject::data_hdr). A data member update by one activity
affects other activities.

Splitting one StoreEntry object into two internally consistent and
"constant" StoreEntry objects (one old and one updated) does not work
well because there is no mechanism to share StoreEntry "data" storage
and invokeHandlers() call streams after the split.

To avoid crashes and response corruption due to inconsistent sizes and
offsets, all size-related data members must be based on the same entry
"version". If we update one such member, we must update all others.

Furthermore, due to copying of information into activity-local
variables/state, we cannot update anything while an activity is still
running. For example, two HTTP clients may use the same StoreEntry to
receive data, and one of them may already be in the middle of response
sending, using old response offsets/sizes, when a 304 update arrives for
the other.

With any updates of size-related StoreEntry data members ruled out, the
only remaining solution for preserving consistency is to keep all those
members constant/stale despite the 304 update! The updated size-related
info has to go somewhere else (inside the same StoreEntry object).

The updated headers are now stored in a new MemObject::updatedReply
field. The updated headers are swapped out, but the old StoreEntry is
not (and was not before these changes) associated with the new store
entry anchor. After the old StoreEntry is abandoned, new local hits will
use the updated anchors. Other worker hits will use the updated anchors
immediately, but they will create fresh StoreEntry objects.

We update freshness-related data members because the associated instant
decisions should not lead to inconsistencies, and using the latest info
is preferable. If any counter-examples are found, we may have to split
StoreEntry::timestamp/etc. fields into stale and fresh groups.

We do not update Vary-related data members because TBD.

Also removed HttpHeader::update() code that disabled needUpdate() checks
for non-CF configurations. The check is expensive but storing the
updated response is a lot more expensive so even if a small fraction of
checks prevents updates, we may improve performance. Also moved the
corresponding code into HttpReply so that most Header::update() callers
(that have nothing to do with 304 updates) do not spend time on it.

Also adjusted CheckQuickAbortIsReasonable(): The old expectlen setting
code did not check for unknown content length, relying on "-1 + hdr_sz"
to be negative only when no data has been received. We now use a more
direct (but possibly still broken for HTTP/0) test (hdr_sz <= 0) and
avoid using unknown content_length in arithmetic expressions. HTTP/0
aside, responses without Content-Length should still be aborted but now
with a correct "unknown content length" debug message.

MemObject is always constructed with an (empty) base reply. We now also
assert that MemObject always has a (possibly empty) base reply after
checking that all [indirect] replaceBaseReply() callers either
* supply a non-nil reply or
* call replaceHttpReply() with a true andStartWriting parameter, going
  through an existing assert(rep) in StoreEntry::startWriting().
