### PR TITLE
Reforward CONNECT after TLS handshake failure with peer

### DIFF
--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -137,7 +137,8 @@ public:
         void dataSent (size_t amount);
         /// writes 'b' buffer, setting the 'writer' member to 'callback'.
         void write(const char *b, int size, AsyncCall::Pointer &callback, FREE * free_func);
-        void setCloseHandler(CLCB *handler, TunnelStateData *data);
+        /// sets a new close handler for the connection, removing the old one
+        void setCloseHandler(CLCB *, TunnelStateData *);
         void resetCloseHandler() { closer = nullptr; }
         int len;
         char *buf;
@@ -669,6 +670,10 @@ TunnelStateData::Connection::setCloseHandler(CLCB *handler, TunnelStateData *tun
 {
     assert(handler);
     assert(tunnelState);
+    if (!Comm::IsConnOpen(conn)) {
+        closer = nullptr;
+        return;
+    }
     if (closer)
         comm_remove_close_handler(conn->fd, closer);
     closer = comm_add_close_handler(conn->fd, handler, tunnelState);


### PR DESCRIPTION
When Squid received a CONNECT request and attempted to establish a
secure connection to an SSL cache_peer, it did not try the next
available destination after a TLS negotiation failure.

Why retry such TLS negotiation failures? Peer B may not have the same
misconfiguration that led to the negotiation failure when talking to
peer A. Admins may improve fault tolerance by using pools of different
peers or pools of identical peers that are reconfigured one by one. And
FwdState already does this – flags.connected_okay is not set until TLS
negotiation is successful.