### PR TITLE
Write on disk zero StoreEntry::swap_file_sz

### DIFF
--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -186,13 +186,18 @@ Rock::HeaderUpdater::startWriting()
 
     {
         debugs(20, 7, "fresh store meta for " << *update.entry);
-        size_t freshSwapHeaderSize = 0;
-        const auto oldSwapFileSize = update.entry->swap_file_sz;
-        // Serialize zero swap_file_sz so that de-serializing code could
-        // re-calculate it. See storeRebuildParseEntry() for details.
+        size_t freshSwapHeaderSize = 0; // set by getSerialisedMetaData() below
+
+        // There is a circular dependency between the correct/fresh value of
+        // entry->swap_file_sz and freshSwapHeaderSize. We break that loop by
+        // serializing zero swap_file_sz, just like the regular first-time
+        // swapout code may do. De-serializing code will re-calculate it in
+        // storeRebuildParseEntry(). TODO: Stop serializing entry->swap_file_sz.
+        const auto savedEntrySwapFileSize = update.entry->swap_file_sz;
         update.entry->swap_file_sz = 0;
         const auto freshSwapHeader = update.entry->getSerialisedMetaData(freshSwapHeaderSize);
-        update.entry->swap_file_sz = oldSwapFileSize;
+        update.entry->swap_file_sz = savedEntrySwapFileSize;
+
         Must(freshSwapHeader);
         writer->write(freshSwapHeader, freshSwapHeaderSize, 0, nullptr);
         stalePrefixSz += mem.swap_hdr_sz;

--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -187,7 +187,12 @@ Rock::HeaderUpdater::startWriting()
     {
         debugs(20, 7, "fresh store meta for " << *update.entry);
         size_t freshSwapHeaderSize = 0;
+        const auto oldSwapFileSize = update.entry->swap_file_sz;
+        // Serialize zero swap_file_sz so that de-serializing code could
+        // re-calculate it. See storeRebuildParseEntry() for details.
+        update.entry->swap_file_sz = 0;
         const auto freshSwapHeader = update.entry->getSerialisedMetaData(freshSwapHeaderSize);
+        update.entry->swap_file_sz = oldSwapFileSize;
         Must(freshSwapHeader);
         writer->write(freshSwapHeader, freshSwapHeaderSize, 0, nullptr);
         stalePrefixSz += mem.swap_hdr_sz;

--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -163,6 +163,26 @@ Rock::HeaderUpdater::noteDoneReading(int errflag)
     }
 }
 
+MemBuf *
+Rock::HeaderUpdater::calculateSizes(uint64_t &stalePrefixSz, uint64_t &freshPrefixSz)
+{
+    const auto &mem = update.entry->mem();
+    stalePrefixSz += mem.swap_hdr_sz;
+    const auto &staleReply = mem.baseReply();
+    Must(staleReply.hdr_sz >= 0); // for int-to-uint64_t conversion below
+    Must(staleReply.hdr_sz > 0); // already initialized
+    stalePrefixSz += staleReply.hdr_sz;
+
+    size_t freshSwapHeaderSize = 0;
+    const auto tmp = update.entry->getSerialisedMetaData(freshSwapHeaderSize);
+    freshPrefixSz += freshSwapHeaderSize;
+    xfree(tmp);
+
+    const auto httpHeader = mem.freshestReply().pack();
+    freshPrefixSz += httpHeader->contentSize();
+    return httpHeader;
+}
+
 void
 Rock::HeaderUpdater::startWriting()
 {
@@ -180,31 +200,32 @@ Rock::HeaderUpdater::startWriting()
     uint64_t stalePrefixSz = 0;
     uint64_t freshPrefixSz = 0;
 
-    off_t offset = 0; // current writing offset (for debugging)
+    const auto httpHeader = calculateSizes(stalePrefixSz, freshPrefixSz);
 
-    const auto &mem = update.entry->mem();
+    auto &swap_file_sz = update.fresh.anchor->basics.swap_file_sz;
+    Must(swap_file_sz >= stalePrefixSz);
+    swap_file_sz -= stalePrefixSz;
+    swap_file_sz += freshPrefixSz;
+
+    off_t offset = 0; // current writing offset (for debugging)
 
     {
         debugs(20, 7, "fresh store meta for " << *update.entry);
         size_t freshSwapHeaderSize = 0;
+        const auto oldSwapFileSize = update.entry->swap_file_sz;
+        // serialize with a new swap_file_sz
+        update.entry->swap_file_sz = swap_file_sz;
         const auto freshSwapHeader = update.entry->getSerialisedMetaData(freshSwapHeaderSize);
         Must(freshSwapHeader);
+        update.entry->swap_file_sz = oldSwapFileSize;
         writer->write(freshSwapHeader, freshSwapHeaderSize, 0, nullptr);
-        stalePrefixSz += mem.swap_hdr_sz;
-        freshPrefixSz += freshSwapHeaderSize;
         offset += freshSwapHeaderSize;
         xfree(freshSwapHeader);
     }
 
     {
         debugs(20, 7, "fresh HTTP header @ " << offset);
-        const auto httpHeader = mem.freshestReply().pack();
         writer->write(httpHeader->content(), httpHeader->contentSize(), -1, nullptr);
-        const auto &staleReply = mem.baseReply();
-        Must(staleReply.hdr_sz >= 0); // for int-to-uint64_t conversion below
-        Must(staleReply.hdr_sz > 0); // already initialized
-        stalePrefixSz += staleReply.hdr_sz;
-        freshPrefixSz += httpHeader->contentSize();
         offset += httpHeader->contentSize();
         delete httpHeader;
     }
@@ -220,10 +241,6 @@ Rock::HeaderUpdater::startWriting()
            "; swap_file_sz delta: -" << stalePrefixSz << " +" << freshPrefixSz);
 
     // Optimistic early update OK: Our write lock blocks access to swap_file_sz.
-    auto &swap_file_sz = update.fresh.anchor->basics.swap_file_sz;
-    Must(swap_file_sz >= stalePrefixSz);
-    swap_file_sz -= stalePrefixSz;
-    swap_file_sz += freshPrefixSz;
 
     writer->close(StoreIOState::wroteAll); // should call noteDoneWriting()
 }

--- a/src/fs/rock/RockHeaderUpdater.h
+++ b/src/fs/rock/RockHeaderUpdater.h
@@ -15,6 +15,8 @@
 #include "fs/rock/RockSwapDir.h"
 #include "ipc/StoreMap.h"
 
+class MemBuf;
+
 namespace Rock
 {
 
@@ -57,6 +59,8 @@ private:
 
     void startWriting();
     void noteDoneWriting(int errflag);
+
+    MemBuf *calculateSizes(uint64_t &stalePrefixSz, uint64_t &freshPrefixSz);
 
     Rock::SwapDir::Pointer store; ///< cache_dir where the entry is stored
     Ipc::StoreMapUpdate update; ///< Ipc::StoreMap update reservation

--- a/src/fs/rock/RockHeaderUpdater.h
+++ b/src/fs/rock/RockHeaderUpdater.h
@@ -15,8 +15,6 @@
 #include "fs/rock/RockSwapDir.h"
 #include "ipc/StoreMap.h"
 
-class MemBuf;
-
 namespace Rock
 {
 
@@ -59,8 +57,6 @@ private:
 
     void startWriting();
     void noteDoneWriting(int errflag);
-
-    MemBuf *calculateSizes(uint64_t &stalePrefixSz, uint64_t &freshPrefixSz);
 
     Rock::SwapDir::Pointer store; ///< cache_dir where the entry is stored
     Ipc::StoreMapUpdate update; ///< Ipc::StoreMap update reservation


### PR DESCRIPTION
Stale StoreEntry::swap_file_sz was stored on disk because we
calculated fresh swap_file_sz _after_ the body prefix, including
serialized swap_file_sz, was written.

We considered two approaches:

* Re-calculate swap_file_sz and serialize the fresh value. This
  approach has some difficulties because we need to separate the size
  calculation from the serialization itself
  (StoreEntry::getSerialisedMetaData()).

* Serialize zero swap_file_sz thus allowing to properly set it on
  de-serialization. We selected this approach because it is simpler and
  the regular code already uses it.
