### PR TITLE
Preserve caller context across Happy Eyeballs connection attempts

### DIFF
--- a/lib/smblib/smblib.c
+++ b/lib/smblib/smblib.c
@@ -149,10 +149,10 @@ SMB_Handle_Type SMB_Connect_Server(SMB_Handle_Type Con_Handle,
     /* Now connect to the remote end, but first upper case the name of the
        service we are going to call, sine some servers want it in uppercase */
 
-    for (i=0; i < strlen(server); i++)
-        called[i] = xtoupper(server[i]);
+    for (i=0; i < strlen(con -> desthost); i++)
+        called[i] = xtoupper(con -> desthost[i]);
 
-    called[strlen(server)] = 0;    /* Make it a string */
+    called[strlen(con -> desthost)] = 0;    /* Make it a string */
 
     for (i=0; i < strlen(con -> myname); i++)
         calling[i] = xtoupper(con -> myname[i]);
@@ -265,10 +265,10 @@ SMB_Handle_Type SMB_Connect(SMB_Handle_Type Con_Handle,
     /* Now connect to the remote end, but first upper case the name of the
        service we are going to call, sine some servers want it in uppercase */
 
-    for (i=0; i < strlen(host); i++)
-        called[i] = xtoupper(host[i]);
+    for (i=0; i < strlen(con -> desthost); i++)
+        called[i] = xtoupper(con -> desthost[i]);
 
-    called[strlen(host)] = 0;    /* Make it a string */
+    called[strlen(con -> desthost)] = 0;    /* Make it a string */
 
     for (i=0; i < strlen(con -> myname); i++)
         calling[i] = xtoupper(con -> myname[i]);

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -150,6 +150,8 @@ public:
     /// the start of the first connection attempt for the currentPeer
     HappyAbsoluteTime primeStart = 0;
 
+    CodeContext::Pointer codeContext; ///< requestor's context
+
 private:
     /// a connection opening attempt in progress (or falsy)
     class Attempt {

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -21,13 +21,13 @@
 #include "auth/Gadgets.h"
 #include "auth/State.h"
 #include "base/LookupTable.h"
-#include "base64.h"
 #include "cache_cf.h"
 #include "event.h"
 #include "helper.h"
 #include "HttpHeaderTools.h"
 #include "HttpReply.h"
 #include "HttpRequest.h"
+#include "md5.h"
 #include "mgr/Registration.h"
 #include "rfc2617.h"
 #include "sbuf/SBuf.h"
@@ -89,7 +89,7 @@ DigestFieldsLookupTable(DIGEST_INVALID_ATTR, DigestAttrs);
  */
 
 static void authenticateDigestNonceCacheCleanup(void *data);
-static digest_nonce_h *authenticateDigestNonceFindNonce(const char *nonceb64);
+static digest_nonce_h *authenticateDigestNonceFindNonce(const char *noncehex);
 static void authenticateDigestNonceDelete(digest_nonce_h * nonce);
 static void authenticateDigestNonceSetup(void);
 static void authDigestNonceEncode(digest_nonce_h * nonce);
@@ -108,11 +108,14 @@ authDigestNonceEncode(digest_nonce_h * nonce)
     if (nonce->key)
         xfree(nonce->key);
 
-    nonce->key = xcalloc(base64_encode_len(sizeof(digest_nonce_data)), 1);
-    struct base64_encode_ctx ctx;
-    base64_encode_init(&ctx);
-    size_t blen = base64_encode_update(&ctx, reinterpret_cast<char*>(nonce->key), sizeof(digest_nonce_data), reinterpret_cast<const uint8_t*>(&(nonce->noncedata)));
-    blen += base64_encode_final(&ctx, reinterpret_cast<char*>(nonce->key)+blen);
+    SquidMD5_CTX Md5Ctx;
+    HASH H;
+    SquidMD5Init(&Md5Ctx);
+    SquidMD5Update(&Md5Ctx, reinterpret_cast<const uint8_t *>(&nonce->noncedata), sizeof(nonce->noncedata));
+    SquidMD5Final(reinterpret_cast<uint8_t *>(H), &Md5Ctx);
+
+    nonce->key = xcalloc(sizeof(HASHHEX), 1);
+    CvtHex(H, static_cast<char *>(nonce->key));
 }
 
 digest_nonce_h *
@@ -147,12 +150,12 @@ authenticateDigestNonceNew(void)
      *
      * Now for my reasoning:
      * We will not accept a unrecognised nonce->we have all recognisable
-     * nonces stored. If we send out unique base64 encodings we guarantee
+     * nonces stored. If we send out unique encodings we guarantee
      * that a given nonce applies to only one user (barring attacks or
      * really bad timing with expiry and creation).  Using a random
      * component in the nonce allows us to loop to find a unique nonce.
      * We use H(nonce_data) so the nonce is meaningless to the reciever.
-     * So our nonce looks like base64(H(timestamp,pointertohash,randomdata))
+     * So our nonce looks like hex(H(timestamp,pointertohash,randomdata))
      * And even if our randomness is not very random we don't really care
      * - the timestamp and memory pointer also guarantee local uniqueness
      * in the input to the hash function.
@@ -251,7 +254,7 @@ static void
 authenticateDigestNonceCacheCleanup(void *)
 {
     /*
-     * We walk the hash by nonceb64 as that is the unique key we
+     * We walk the hash by noncehex as that is the unique key we
      * use.  For big hash tables we could consider stepping through
      * the cache, 100/200 entries at a time. Lets see how it flies
      * first.
@@ -320,7 +323,7 @@ authDigestNonceUnlink(digest_nonce_h * nonce)
 }
 
 const char *
-authenticateDigestNonceNonceb64(const digest_nonce_h * nonce)
+authenticateDigestNonceNonceHex(const digest_nonce_h * nonce)
 {
     if (!nonce)
         return NULL;
@@ -329,18 +332,18 @@ authenticateDigestNonceNonceb64(const digest_nonce_h * nonce)
 }
 
 static digest_nonce_h *
-authenticateDigestNonceFindNonce(const char *nonceb64)
+authenticateDigestNonceFindNonce(const char *noncehex)
 {
     digest_nonce_h *nonce = NULL;
 
-    if (nonceb64 == NULL)
+    if (noncehex == NULL)
         return NULL;
 
-    debugs(29, 9, "looking for nonceb64 '" << nonceb64 << "' in the nonce cache.");
+    debugs(29, 9, "looking for noncehex '" << noncehex << "' in the nonce cache.");
 
-    nonce = static_cast < digest_nonce_h * >(hash_lookup(digest_nonce_cache, nonceb64));
+    nonce = static_cast < digest_nonce_h * >(hash_lookup(digest_nonce_cache, noncehex));
 
-    if ((nonce == NULL) || (strcmp(authenticateDigestNonceNonceb64(nonce), nonceb64)))
+    if ((nonce == NULL) || (strcmp(authenticateDigestNonceNonceHex(nonce), noncehex)))
         return NULL;
 
     debugs(29, 9, "Found nonce '" << nonce << "'");
@@ -534,12 +537,12 @@ Auth::Digest::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Ht
 
     debugs(29, 9, "Sending type:" << hdrType <<
            " header: 'Digest realm=\"" << realm << "\", nonce=\"" <<
-           authenticateDigestNonceNonceb64(nonce) << "\", qop=\"" << QOP_AUTH <<
+           authenticateDigestNonceNonceHex(nonce) << "\", qop=\"" << QOP_AUTH <<
            "\", stale=" << (stale ? "true" : "false"));
 
     /* in the future, for WWW auth we may want to support the domain entry */
     httpHeaderPutStrf(&rep->header, hdrType, "Digest realm=\"" SQUIDSBUFPH "\", nonce=\"%s\", qop=\"%s\", stale=%s",
-                      SQUIDSBUFPRINT(realm), authenticateDigestNonceNonceb64(nonce), QOP_AUTH, stale ? "true" : "false");
+                      SQUIDSBUFPRINT(realm), authenticateDigestNonceNonceHex(nonce), QOP_AUTH, stale ? "true" : "false");
 }
 
 /* Initialize helpers and the like for this auth scheme. Called AFTER parsing the
@@ -841,10 +844,10 @@ Auth::Digest::Config::decode(char const *proxy_auth, const char *aRequestRealm)
             break;
 
         case DIGEST_NONCE:
-            safe_free(digest_request->nonceb64);
+            safe_free(digest_request->noncehex);
             if (value.size() != 0)
-                digest_request->nonceb64 = xstrndup(value.rawBuf(), value.size() + 1);
-            debugs(29, 9, "Found nonce '" << digest_request->nonceb64 << "'");
+                digest_request->noncehex = xstrndup(value.rawBuf(), value.size() + 1);
+            debugs(29, 9, "Found nonce '" << digest_request->noncehex << "'");
             break;
 
         case DIGEST_NC:
@@ -920,7 +923,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const char *aRequestRealm)
     }
 
     /* and a nonce? */
-    if (!digest_request->nonceb64 || digest_request->nonceb64[0] == '\0') {
+    if (!digest_request->noncehex || digest_request->noncehex[0] == '\0') {
         debugs(29, 2, "Empty or not present nonce");
         rv = authDigestLogUsername(username, digest_request, aRequestRealm);
         safe_free(username);
@@ -995,7 +998,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const char *aRequestRealm)
     /** below nonce state dependent **/
 
     /* now the nonce */
-    nonce = authenticateDigestNonceFindNonce(digest_request->nonceb64);
+    nonce = authenticateDigestNonceFindNonce(digest_request->noncehex);
     /* check that we're not being hacked / the username hasn't changed */
     if (nonce && nonce->user && strcmp(username, nonce->user->username())) {
         debugs(29, 2, "Username for the nonce does not equal the username for the request");
@@ -1071,7 +1074,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const char *aRequestRealm)
     debugs(29, 9, "username = '" << digest_user->username() << "'\nrealm = '" <<
            digest_request->realm << "'\nqop = '" << digest_request->qop <<
            "'\nalgorithm = '" << digest_request->algorithm << "'\nuri = '" <<
-           digest_request->uri << "'\nnonce = '" << digest_request->nonceb64 <<
+           digest_request->uri << "'\nnonce = '" << digest_request->noncehex <<
            "'\nnc = '" << digest_request->nc << "'\ncnonce = '" <<
            digest_request->cnonce << "'\nresponse = '" <<
            digest_request->response << "'\ndigestnonce = '" << nonce << "'");

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -29,7 +29,7 @@ class User;
 typedef struct _digest_nonce_data digest_nonce_data;
 typedef struct _digest_nonce_h digest_nonce_h;
 
-/* data to be encoded into the nonce's b64 representation */
+/* data to be encoded into the nonce's hex representation */
 struct _digest_nonce_data {
     time_t creationtime;
     /* in memory address of the nonce struct (similar purpose to an ETag) */
@@ -58,7 +58,7 @@ struct _digest_nonce_h : public hash_link {
 void authDigestNonceUnlink(digest_nonce_h * nonce);
 int authDigestNonceIsValid(digest_nonce_h * nonce, char nc[9]);
 int authDigestNonceIsStale(digest_nonce_h * nonce);
-const char *authenticateDigestNonceNonceb64(const digest_nonce_h * nonce);
+const char *authenticateDigestNonceNonceHex(const digest_nonce_h * nonce);
 int authDigestNonceLastRequest(digest_nonce_h * nonce);
 void authenticateDigestNonceShutdown(void);
 void authDigestNoncePurge(digest_nonce_h * nonce);

--- a/src/auth/digest/UserRequest.h
+++ b/src/auth/digest/UserRequest.h
@@ -44,7 +44,7 @@ public:
     virtual void startHelperLookup(HttpRequest *request, AccessLogEntry::Pointer &al, AUTHCB *, void *);
     virtual const char *credentialsStr();
 
-    char *nonceb64;             /* "dcd98b7102dd2f0e8b11d0f600bfb0c093" */
+    char *noncehex;             /* "dcd98b7102dd2f0e8b11d0f600bfb0c093" */
     char *cnonce;               /* "0a4f113b" */
     char *realm;                /* = "testrealm@host.com" */
     char *pszPass;              /* = "Circle Of Life" */

--- a/src/base/InstanceId.cc
+++ b/src/base/InstanceId.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 1996-2019 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "base/InstanceId.h"
+
+#include <iostream>
+
+std::ostream&
+operator <<(std::ostream &os, const ScopedId &id)
+{
+    if (id.value)
+        os << id.scope << id.value;
+    else if (id.scope)
+        os << id.scope;
+    else
+        os << "[unknown]";
+    return os;
+}
+

--- a/src/base/InstanceId.h
+++ b/src/base/InstanceId.h
@@ -32,17 +32,7 @@ public:
     uint64_t value;
 };
 
-inline std::ostream&
-operator <<(std::ostream &os, const ScopedId &id)
-{
-    if (id.value)
-        os << id.scope << id.value;
-    else if (id.scope)
-        os << id.scope;
-    else
-        os << "[unknown]";
-    return os;
-}
+std::ostream &operator <<(std::ostream &os, const ScopedId &id);
 
 typedef unsigned int InstanceIdDefaultValueType;
 /** Identifier for class instances

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -33,6 +33,7 @@ libbase_la_SOURCES = \
 	HardFun.h \
 	Here.cc \
 	Here.h \
+	InstanceId.cc \
 	InstanceId.h \
 	Lock.h \
 	LookupTable.h \

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 78    DNS lookups; interacts with dns/rfc1035.cc */
 
 #include "squid.h"
+#include "base/CodeContext.h"
 #include "base/InstanceId.h"
 #include "base/RunnersRegistry.h"
 #include "comm.h"
@@ -103,7 +104,9 @@ class idns_query
     CBDATA_CLASS(idns_query);
 
 public:
-    idns_query() {
+    idns_query():
+        codeContext(CodeContext::Current())
+    {
         callback = nullptr;
         memset(&query, 0, sizeof(query));
         *buf = 0;
@@ -141,8 +144,11 @@ public:
     struct timeval sent_t;
     struct timeval queue_t;
     dlink_node lru;
+
     IDNSCB *callback;
     void *callback_data = nullptr;
+    CodeContext::Pointer codeContext; ///< requestor's context
+
     int attempt = 0;
     int rcode = 0;
     idns_query *queue = nullptr;
@@ -1104,6 +1110,7 @@ idnsCallbackNewCallerWithOldAnswers(IDNSCB *callback, void *cbdata, const idns_q
     for (auto query = master; query; query = query->slave) {
         if (query->pending)
             continue; // no answer yet
+        // no CallBack(CodeContext...) -- we always run in requestor's context
         if (!idnsCallbackOneWithAnswer(callback, cbdata, *query, lastAnswer))
             break; // the caller disappeared
     }
@@ -1116,8 +1123,10 @@ idnsCallbackAllCallersWithNewAnswer(const idns_query * const answered, const boo
     const auto master = answered->master ? answered->master : answered;
     // iterate all queued lookup callers
     for (auto looker = master; looker; looker = looker->queue) {
-        (void)idnsCallbackOneWithAnswer(looker->callback, looker->callback_data,
-                                        *answered, lastAnswer);
+        CallBack(looker->codeContext, [&] {
+            (void)idnsCallbackOneWithAnswer(looker->callback, looker->callback_data,
+            *answered, lastAnswer);
+        });
     }
 }
 


### PR DESCRIPTION
Happy Eyeballs jobs use two HappyOrderEnforcer services to enforce
various global and local limits. These services create job calls in
HappyOrderEnforcer::checkpoint(), which, in turn, does not have a context
since it is activated via events mechanism. Now, each HappyConnOpener
job remembers its context and restores it when creating these job calls.
