### PR TITLE
Preserve caller context across Store data delivery

### DIFF
--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_STORECLIENT_H
 #define SQUID_STORECLIENT_H
 
+#include "base/CodeContext.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
 #include "StoreIOState.h"
@@ -99,6 +100,8 @@ public:
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
     StoreIOBuffer copyInto;
+
+    CodeContext::Pointer codeContext; ///< requestor's context
 
 private:
     bool moreToSend() const;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -199,6 +199,7 @@ store_client::store_client(StoreEntry *e) :
     owner(cbdataReference(data)),
 #endif
     entry(e),
+    codeContext(CodeContext::Current()),
     type(e->storeClientType()),
     object_ok(true)
 {
@@ -787,7 +788,9 @@ StoreEntry::invokeHandlers()
         if (sc->flags.disk_io_pending)
             continue;
 
-        storeClientCopy2(this, sc);
+        CallBack(sc->codeContext, [&] {
+            storeClientCopy2(this, sc);
+        });
     }
     PROF_stop(InvokeHandlers);
 }


### PR DESCRIPTION
StoreEntry::invokeHandlers() sends a recently loaded response data to
the waiting store_clients. During concurrent cache hits (including,
but not limited to collapsed ones), the response can be loaded into
Store by one transaction and delivered to several different transactions
(i.e. store_clients). This Store "hit sharing service" must restore the
context of the transactions it serves.