### PR TITLE
Ignore orphaned Transients entries

### DIFF
--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -65,14 +65,11 @@ ResolvedPeers::findSpareOrNextPeer(const Comm::Connection &currentPeer)
     const auto familyToAvoid = ConnectionFamily(currentPeer);
     // Optimization: Also stop at the first mismatching peer because all
     // same-peer paths are grouped together.
-    auto found = std::find_if(paths_.begin(), paths_.end(),
+    return std::find_if(paths_.begin(), paths_.end(),
     [peerToMatch, familyToAvoid](const Comm::ConnectionPointer &conn) {
         return peerToMatch != conn->getPeer() ||
                familyToAvoid != ConnectionFamily(*conn);
     });
-    if (found != paths_.end() && peerToMatch == (*found)->getPeer())
-        return found;
-    return paths_.end();
 }
 
 Comm::ConnectionPointer

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -251,6 +251,13 @@ Transients::addEntry(StoreEntry *e, const cache_key *key, const Store::IoStatus 
     }
 }
 
+bool
+Transients::hasWriter(const StoreEntry &e) {
+    if (!e.hasTransients() || !e.mem_obj)
+        return false;
+    return map->peekAtWriter(e.mem_obj->xitTable.index);
+}
+
 void
 Transients::noteFreeMapSlice(const Ipc::StoreMapSliceId)
 {

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -85,6 +85,9 @@ public:
     bool isReader(const StoreEntry &) const;
     /// whether the entry is in "writing to Transients" I/O state
     bool isWriter(const StoreEntry &) const;
+    /// whether there is a writer into the Transients entry, this
+    /// StoreEntry is attached to
+    bool hasWriter(const StoreEntry &);
 
     static int64_t EntryLimit();
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -253,6 +253,18 @@ Ipc::StoreMap::peekAtReader(const sfileno fileno) const
     return NULL;
 }
 
+const Ipc::StoreMap::Anchor *
+Ipc::StoreMap::peekAtWriter(const sfileno fileno) const
+{
+    const Anchor &s = anchorAt(fileno);
+    if (s.writing())
+        return &s; // immediate access by lock holder so no locking
+    if (s.reading())
+        return nullptr;
+    assert(false); // must be locked for reading or writing
+    return nullptr;
+}
+
 const Ipc::StoreMap::Anchor &
 Ipc::StoreMap::peekAtEntry(const sfileno fileno) const
 {

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -262,6 +262,9 @@ public:
     /// only works on locked entries; returns nil unless the slice is readable
     const Anchor *peekAtReader(const sfileno fileno) const;
 
+    /// only works on locked entries; returns nil unless the slice is writable
+    const Anchor *peekAtWriter(const sfileno fileno) const;
+
     /// only works on locked entries; returns the corresponding Anchor
     const Anchor &peekAtEntry(const sfileno fileno) const;
 

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -355,6 +355,8 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         const bool found = anchorToCache(entry, inSync);
         if (found && !inSync)
             throw TexcHere("cannot sync");
+        else if (!found && !transients->hasWriter(entry)) // cannot anchor right now and will not be able in the future
+            throw TexcHere("orphaned transients entry");
     }
 }
 


### PR DESCRIPTION
This problem was discovered for rock-only cache configurations.
    
After a reply has been cached on disk and the transaction finishes,
the corresponding Transients entry is not freed. Another request
(with a different public key) may occupy the same rock slot (overriding
the already cached entry), making the initial Transients entry
'orphaned'. Subsequent requests to the initially cached resource now
stall, because after receiving the available Transients entry the Squid
worker keeps waiting for a notification from another worker, incorrectly
assuming that this worker (i.e., the entry writer) exists and is going
to fetch it. Since in reality there is no such writer, the transaction
hangs and is aborted after timeout.
    
In order to avoid this effect, we should not return such 'orphaned'
Transients entries. In other words, the caller may use a Transients
entry if and only if either this entry has been already anchored to a
cache or it has a writer (i.e., another worker is about to create that
cache soon).
