### PR TITLE
Reforward CONNECT failures with peers

### DIFF
--- a/src/err_type.h
+++ b/src/err_type.h
@@ -76,6 +76,7 @@ typedef enum {
 
     ERR_SECURE_ACCEPT_FAIL, // Rejects the SSL connection intead of error page
     ERR_REQUEST_START_TIMEOUT, // Aborts the connection instead of error page
+    ERR_RELAY_REMOTE, // Sends server reply instead of error page
 
     /* Cache Manager GUI can install a manager index/home page */
     MGR_INDEX,

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -83,6 +83,9 @@ class ErrorState
 public:
     ErrorState(err_type type, Http::StatusCode, HttpRequest * request);
     ErrorState(); // not implemented.
+    /// creates an ERR_RELAY_REMOTE error
+    ErrorState(HttpRequest * request, HttpReply *);
+
     ~ErrorState();
 
     /// Creates a general request forwarding error with the right http_status.
@@ -129,6 +132,8 @@ private:
      */
     const char *Convert(char token, bool building_deny_info_url, bool allowRecursion);
 
+    void init(HttpRequest *);
+
     /**
      * CacheManager / Debug dump of the ErrorState object.
      * Writes output into the given MemBuf.
@@ -139,22 +144,22 @@ private:
 public:
     err_type type;
     int page_id;
-    char *err_language;
+    char *err_language = nullptr;
     Http::StatusCode httpStatus;
 #if USE_AUTH
     Auth::UserRequest::Pointer auth_user_request;
 #endif
-    HttpRequest *request;
-    char *url;
-    int xerrno;
-    unsigned short port;
+    HttpRequest *request = nullptr;
+    char *url = nullptr;
+    int xerrno = 0;
+    unsigned short port = 0;
     String dnsError; ///< DNS lookup error message
-    time_t ttl;
+    time_t ttl = 0;
 
     Ip::Address src_addr;
-    char *redirect_url;
-    ERCB *callback;
-    void *callback_data;
+    char *redirect_url = nullptr;
+    ERCB *callback = nullptr;
+    void *callback_data = nullptr;
 
     struct {
         wordlist *server_msg;
@@ -164,15 +169,16 @@ public:
         MemBuf *listing;
     } ftp;
 
-    char *request_hdrs;
-    char *err_msg; /* Preformatted error message from the cache */
+    char *request_hdrs = nullptr;
+    char *err_msg = nullptr; /* Preformatted error message from the cache */
 
 #if USE_OPENSSL
-    Ssl::ErrorDetail *detail;
+    Ssl::ErrorDetail *detail = nullptr;
 #endif
     /// type-specific detail about the transaction error;
     /// overwrites xerrno; overwritten by detail, if any.
-    int detailCode;
+    int detailCode = ERR_DETAIL_NONE;
+    HttpReply *response_ = nullptr;
 };
 
 /**

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -242,8 +242,9 @@ private:
     /// details of the "last tunneling attempt" failure (if it failed)
     ErrorState *savedError = nullptr;
 
-public:
     void deleteThis();
+
+public:
     bool keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, Connection &from, Connection &to);
     bool keepGoingAfterConnectRead(size_t len, Comm::Flag errcode, int xerrno, Connection &from, Connection &to);
     void copy(size_t len, Connection &from, Connection &to, IOCB *);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1049,7 +1049,7 @@ TunnelStateData::retryOrBail(const char *context)
     serverDestinations.erase(serverDestinations.begin());
 
     if (checkRetry()) {
-        if (!serverDestinations.empty() && FwdState::EnoughTimeToReForward(startTime)) {
+        if (!serverDestinations.empty()) {
             closeServerConnection();
             debugs(26, 4, "re-forwarding");
             return startConnecting();
@@ -1235,7 +1235,7 @@ TunnelStateData::connectedToPeer(Security::EncryptorAnswer &answer)
         const auto failedDest = serverDestinations.front();
         saveError(error);
         savedError->port = failedDest->remote.port();
-        answer.error.clear(); // preserve error for errorSendComplete()
+        answer.error.clear();
         retryOrBail("TLS peer connection error");
         return;
     }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1056,6 +1056,8 @@ TunnelStateData::retryOrBail(const char *context)
         }
     }
 
+    /* bail */
+
     // TODO: Add sendSavedErrorOr(err_type type, Http::StatusCode, context).
     // Then, the remaining method code (below) should become the common part of
     // sendNewError() and sendSavedErrorOr(), used in "error detected" cases.
@@ -1068,6 +1070,12 @@ TunnelStateData::retryOrBail(const char *context)
     if (canSendError)
         return sendError(error, context);
     *status_ptr = error->httpStatus;
+
+    // This is a "Comm::IsConnOpen(client.conn) but !canSendError" case.
+    // Closing the connection (after finishing writing) is the best we can do.
+    if (!client.writer)
+        client.conn->close();
+    // else writeClientDone() must notice a closed server and close the client
 }
 
 /// closes the connection to the server without triggering the close handler


### PR DESCRIPTION
Three cases were covered:
    
* Errors on sending CONNECT request
* Errors on reading CONNECT response
* Errors on parsing CONNECT response

Also:

* Honor clientExpectsConnectResponse() and al->http.code  when
  retrying.
* Refactored the existing retry() with a new retryOrBail(), covering
  more conditions with checkRetry().
* Refactored connection close handlers, eliminating code duplication and
  also fixing, for example, a problem of not calling already scheduled
  handler.