### PR TITLE
Fix loading of 32+KB HTTP headers from the shared memory cache

### DIFF
--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -507,7 +507,7 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
                 // XXX: have to copy because httpMsgParseStep() requires 0-termination
                 replyBuffer.append(sliceBuf.data, sliceBuf.length);
                 replyBuffer.terminate();
-                Http::StatusCode error = Http::scNone;
+                auto error = Http::scNone;
 
                 if (rep->parse(replyBuffer.buf, replyBuffer.size, wasEof, &error)) {
                     assert(rep->pstate == Http::Message::psParsed);

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -509,11 +509,13 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
                 replyBuffer.terminate();
                 Http::StatusCode error = Http::scNone;
 
-                if (rep->parse(replyBuffer.buf, replyBuffer.size, wasEof, &error))
+                if (rep->parse(replyBuffer.buf, replyBuffer.size, wasEof, &error)) {
                     assert(rep->pstate == Http::Message::psParsed);
-                else if (error)
+                } else if (error) {
                     return false;
-                // else more data needed
+                } else {
+                    assert(!wasEof); // more data needed
+                }
             }
         }
         // else skip a [possibly incomplete] slice that we copied earlier

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -470,6 +470,11 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
     Ipc::StoreMapSliceId sid = anchor.start; // optimize: remember the last sid
     bool wasEof = anchor.complete() && sid < 0;
     int64_t sliceOffset = 0;
+
+    MemBuf replyBuffer;
+    replyBuffer.init();
+    const auto rep = &e.mem().adjustableBaseReply();
+
     while (sid >= 0) {
         const Ipc::StoreMapSlice &slice = map->readableSlice(index, sid);
         // slice state may change during copying; take snapshots now
@@ -492,10 +497,24 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
             const StoreIOBuffer sliceBuf(wasSize - prefixSize,
                                          e.mem_obj->endOffset(),
                                          page + prefixSize);
-            if (!copyFromShmSlice(e, sliceBuf, wasEof))
-                return false;
+
+            copyFromShmSlice(e, sliceBuf);
             debugs(20, 8, "entry " << index << " copied slice " << sid <<
                    " from " << extra.page << '+' << prefixSize);
+
+            // parse headers if needed; they might span multiple slices!
+            if (rep->pstate < Http::Message::psParsed) {
+                // XXX: have to copy because httpMsgParseStep() requires 0-termination
+                replyBuffer.append(sliceBuf.data, sliceBuf.length);
+                replyBuffer.terminate();
+                Http::StatusCode error = Http::scNone;
+
+                if (rep->parse(replyBuffer.buf, replyBuffer.size, wasEof, &error))
+                    assert(rep->pstate == Http::Message::psParsed);
+                else if (error)
+                    return false;
+                // else more data needed
+            }
         }
         // else skip a [possibly incomplete] slice that we copied earlier
 
@@ -536,31 +555,10 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
 }
 
 /// imports one shared memory slice into local memory
-bool
-MemStore::copyFromShmSlice(StoreEntry &e, const StoreIOBuffer &buf, bool eof)
+void
+MemStore::copyFromShmSlice(StoreEntry &e, const StoreIOBuffer &buf)
 {
     debugs(20, 7, "buf: " << buf.offset << " + " << buf.length);
-
-    // from store_client::readBody()
-    // parse headers if needed; they might span multiple slices!
-    const auto rep = &e.mem().adjustableBaseReply();
-    if (rep->pstate < Http::Message::psParsed) {
-        // XXX: have to copy because httpMsgParseStep() requires 0-termination
-        MemBuf mb;
-        mb.init(buf.length+1, buf.length+1);
-        mb.append(buf.data, buf.length);
-        mb.terminate();
-        const int result = rep->httpMsgParseStep(mb.buf, buf.length, eof);
-        if (result > 0) {
-            assert(rep->pstate == Http::Message::psParsed);
-        } else if (result < 0) {
-            debugs(20, DBG_IMPORTANT, "Corrupted mem-cached headers: " << e);
-            return false;
-        } else { // more slices are needed
-            assert(!eof);
-        }
-    }
-    debugs(20, 7, "rep pstate: " << rep->pstate);
 
     // local memory stores both headers and body so copy regardless of pstate
     const int64_t offBefore = e.mem_obj->endOffset();
@@ -569,7 +567,6 @@ MemStore::copyFromShmSlice(StoreEntry &e, const StoreIOBuffer &buf, bool eof)
     // expect to write the entire buf because StoreEntry::write() never fails
     assert(offAfter >= 0 && offBefore <= offAfter &&
            static_cast<size_t>(offAfter - offBefore) == buf.length);
-    return true;
 }
 
 /// whether we should cache the entry

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -472,7 +472,8 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
     int64_t sliceOffset = 0;
 
     MemBuf replyBuffer;
-    replyBuffer.init();
+    const auto initialSize = HTTP_REPLY_BUF_SZ > Config.maxReplyHeaderSize ? Config.maxReplyHeaderSize : HTTP_REPLY_BUF_SZ;
+    replyBuffer->init(initialSize, Config.maxReplyHeaderSize);
     const auto rep = &e.mem().adjustableBaseReply();
 
     while (sid >= 0) {

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -512,6 +512,7 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
                 if (rep->parse(replyBuffer.buf, replyBuffer.size, wasEof, &error)) {
                     assert(rep->pstate == Http::Message::psParsed);
                 } else if (error) {
+                    debugs(20, DBG_IMPORTANT, "BUG: Corrupted mem-cached headers: " << e);
                     return false;
                 } else {
                     assert(!wasEof); // more data needed

--- a/src/MemStore.h
+++ b/src/MemStore.h
@@ -80,7 +80,7 @@ protected:
     void copyToShm(StoreEntry &e);
     void copyToShmSlice(StoreEntry &e, Ipc::StoreMapAnchor &anchor, Ipc::StoreMap::Slice &slice);
     bool copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnchor &anchor);
-    bool copyFromShmSlice(StoreEntry &e, const StoreIOBuffer &buf, bool eof);
+    void copyFromShmSlice(StoreEntry &e, const StoreIOBuffer &buf);
 
     void updateHeadersOrThrow(Ipc::StoreMapUpdate &update);
 


### PR DESCRIPTION
Accumulate raw header data in the httpMsgParseStep() caller.

The default maximum reply header size (reply_header_max_size) is 64K and
even larger limits may be configured. Squid loads shared memory cache
data in 32KB pages (Ipc::Mem::PageSize). The original implementation
probably assumed that httpMsgParseStep() accumulates raw data as needed,
but it actually restarts parsing from scratch, leading to parsing errors
for Mem-cached response headers exceeding ~32KB. The admin would see a
level-1 "Corrupted mem-cached headers..." cache.log message, and Squid
would invalidate and skip the existing shared memory cache entry.


