### PR TITLE
Fixed getting entries with large headers from disk cache

### DIFF
--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -75,7 +75,6 @@ public:
     void readBody(const char *buf, ssize_t len);
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
-    bool expectHeader() const;
 
     int64_t cmp_offset;
 #if STORE_CLIENT_LIST_DEBUG
@@ -114,6 +113,8 @@ private:
 
     void initReplyBuffer();
     void freeReplyBuffer();
+    bool expectingHttpHeader() const;
+    bool parseHttpHeader(const ssize_t len);
 
     int type;
     bool object_ok;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -112,6 +112,9 @@ private:
     bool startSwapin();
     bool unpackHeader(char const *buf, ssize_t len);
 
+    void initReplyBuffer();
+    void freeReplyBuffer();
+
     int type;
     bool object_ok;
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -99,6 +99,7 @@ public:
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
     StoreIOBuffer copyInto;
+    /// accumulates raw header bytes while parsing large headers (> HTTP_REPLY_BUF_SZ)
     MemBuf *replyBuffer;
 
 private:

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -75,6 +75,7 @@ public:
     void readBody(const char *buf, ssize_t len);
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
+    bool expectHeader() const;
 
     int64_t cmp_offset;
 #if STORE_CLIENT_LIST_DEBUG
@@ -99,6 +100,7 @@ public:
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
     StoreIOBuffer copyInto;
+    MemBuf *replyBuffer;
 
 private:
     bool moreToSend() const;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -99,8 +99,8 @@ public:
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
     StoreIOBuffer copyInto;
-    /// accumulates raw header bytes while parsing large headers (> HTTP_REPLY_BUF_SZ)
-    MemBuf *replyBuffer;
+    /// accumulates raw header bytes while parsing headers (incrementally)
+    MemBuf *replyHeaderBytes;
 
 private:
     bool moreToSend() const;
@@ -112,8 +112,8 @@ private:
     bool startSwapin();
     bool unpackHeader(char const *buf, ssize_t len);
 
-    void initReplyBuffer();
-    void freeReplyBuffer();
+    void startBufferingReplyBytes();
+    void stopBufferingHeaderBytes();
     bool expectingHttpHeader() const;
     bool parseHttpHeader(const ssize_t len);
 

--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -96,7 +96,7 @@ Http::Message::parse(const char *buf, const size_t sz, bool eof, Http::StatusCod
     }
 
     if (hdr_len > Config.maxReplyHeaderSize || (hdr_len <= 0 && sz > Config.maxReplyHeaderSize)) {
-        debugs(58, DBG_IMPORTANT, "Too large reply header (" << hdr_len << " > " << Config.maxReplyHeaderSize);
+        debugs(58, DBG_IMPORTANT, "Too large reply header (" << hdr_len << " > " << Config.maxReplyHeaderSize << ")");
         *error = Http::scHeaderTooLarge;
         return false;
     }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -685,11 +685,8 @@ store_client::readHeader(char const *buf, ssize_t len)
         return;
     } catch (const IncompleteHeaderException &) {
         debugs(90, 2, "Could not parse header: more data needed");
-    } catch (const std::exception &ex) {
-        debugs(90, DBG_IMPORTANT, ex.what());
-        return fail();
     } catch (...) {
-        debugs(90, DBG_IMPORTANT, "error: " << CurrentException);
+        debugs(90, DBG_IMPORTANT,  CurrentException);
         return fail();
     }
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -544,7 +544,7 @@ store_client::readBody(const char *, ssize_t len)
     // Don't assert disk_io_pending here.. may be called by read_header
     flags.disk_io_pending = false;
     assert(_callback.pending());
-    debugs(90, 3, "storeClientReadBody: len " << len << " offset " << copyInto.offset);
+    debugs(90, 3, "storeClientReadBody: len " << len << "");
 
     if (len < 0)
         return fail();
@@ -559,11 +559,12 @@ store_client::readBody(const char *, ssize_t len)
             /* Copy read data back into memory.
              * copyInto.offset includes headers, which is what mem cache needs
              */
-            const auto mem_offset = entry->mem_obj->endOffset();
+            const auto memOffset = entry->mem_obj->endOffset();
             if (doneParsingHeader) {
                 assert(replyHeaderBytes);
                 entry->mem_obj->write(StoreIOBuffer(replyHeaderBytes, 0));
-            } else if (copyInto.offset == mem_offset && mem_offset > 0) {
+            } else if (copyInto.offset == memOffset && memOffset > 0) {
+                assert(!expectingHeader);
                 entry->mem_obj->write(StoreIOBuffer(len, copyInto.offset, copyInto.data));
             }
         }


### PR DESCRIPTION
Before this fix, when getting the entry from a disk cache, the
header parsing code could deal only with a single page at a time and
hence the maximum header size which could be parsed was 4K (the default
page size). Larger headers caused a parsing error with a level-0
message "Could not parse headers from on-disk object" thus leaving
the reply unparsed. This invalid reply (with "HTTP/1.1   0 Init"
status line) was then sent back to the client.

XXX: The opening of the next paragraph is misleading. The default maximum reply header size is largely irrelevant. The code may need to be able to parse even larger buffers and the official code cannot parse (some) smaller buffers either. See #72 for a slightly better description.

Since the default maximum reply header size (as defined by
reply_header_max_size parameter) is 64K, we need to be able to parse
disk headers up to this value. Basically, we need to detect
whether a large header goes beyond the first page boundary and parse
two (or more) pages in this case.

Also do not ignore HTTP header parsing errors when loading from
disk. The problem was that a parsing error only caused the level-0
and did not abort hit processing; as a result, an invalid response
was sent to the client.
