### PR TITLE
Log early level-0/1 debugs() messages to cache_log

### DIFF
--- a/src/Debug.h
+++ b/src/Debug.h
@@ -33,11 +33,6 @@
 #define assert(EX)  ((EX)?((void)0):xassert("EX", __FILE__, __LINE__))
 #endif
 
-/* context-based debugging, the actual type is subject to change */
-typedef int Ctx;
-Ctx ctx_enter(const char *descr);
-void ctx_exit(Ctx ctx);
-
 /* defined debug section limits */
 #define MAX_DEBUG_SECTIONS 100
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -100,6 +100,9 @@ public:
     /// prefixes each grouped debugs() line after the first one in the group
     static std::ostream& Extra(std::ostream &os) { return os << "\n    "; }
 
+    /// silently erases saved early debugs() messages (if any)
+    static void ForgetSaved();
+
     /// reacts to ongoing program termination (e.g., flushes buffered messages)
     static void SwanSong();
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -106,7 +106,7 @@ public:
     /// reacts to ongoing program termination (e.g., flushes buffered messages)
     static void SwanSong();
 
-    /* cache_log */
+    /* cache_log channel */
 
     /// Opens and starts using the configured cache_log file.
     /// Also applies configured debug_options (if any).
@@ -121,33 +121,34 @@ public:
     /// Call this or UseCacheLog() to stop early message accumulation.
     static void BanCacheLogUse();
 
-    /* stderr */
+    /* stderr channel */
 
-    /// In the absence of ResetStderrChannelLevel() calls, future debugs() with
+    /// In the absence of ResetStderrLevel() calls, future debugs() with
     /// the given (or lower) level will be written to stderr (at least). If
-    /// called many times, the highest parameter wins. ResetStderrChannelLevel()
+    /// called many times, the highest parameter wins. ResetStderrLevel()
     /// overwrites this default-setting method, regardless of the calls order.
-    static void EnsureDefaultStderrChannelLevel(int maxDefault);
+    static void EnsureDefaultStderrLevel(int maxDefault);
 
     /// Future debugs() messages with the given (or lower) level will be written
     /// to stderr (at least). If called many times, the last call wins.
-    static void ResetStderrChannelLevel(int maxLevel);
+    static void ResetStderrLevel(int maxLevel);
 
-    /// Finalizes stderr configuration when no (more) ResetStderrChannelLevel()
-    /// and EnsureDefaultStderrChannelLevel() calls are expected.
-    static void SettleStderrChannel();
+    /// Finalizes stderr configuration when no (more) ResetStderrLevel()
+    /// and EnsureDefaultStderrLevel() calls are expected.
+    static void SettleStderr();
 
     /// Whether at least some debugs() messages may be written to stderr. The
-    /// answer may be affected by BanCacheLogUse() and SettleStderrChannel().
-    static bool StderrChannelEnabled();
+    /// answer may be affected by BanCacheLogUse() and SettleStderr().
+    static bool StderrEnabled();
 
-    /* syslog */
+    /* syslog channel */
 
     /// enables logging to syslog (using the specified facility, when not nil)
-    static void ConfigureSysLog(const char *facility);
+    static void ConfigureSyslog(const char *facility);
 
-    /// called after the last ConfigureSysLog() call (if any)
-    static void SettleSysLogChannel();
+    /// Finalizes syslog configuration when no (more) ConfigureSyslog() calls
+    /// are expected.
+    static void SettleSyslog();
 
 private:
     static Context *Current; ///< deepest active context; nil outside debugs()

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -118,6 +118,9 @@ public:
     /// Call this or UseCacheLog() to stop early message accumulation.
     static void BanCacheLogging();
 
+    /// Stops using cache_log (if it was in use). No effect on stderr use.
+    static void StopCacheLogUse();
+
     /* stderr */
 
     /// In the absence of ResetErrChannelLevel() calls, future debugs() messages

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -65,6 +65,10 @@ public:
         Context *upper; ///< previous or parent record in nested debugging calls
         std::ostringstream buf; ///< debugs() output sink
         bool forceAlert; ///< the current debugs() will be a syslog ALERT
+
+        /// whether this debugs() call originated when we were too busy handling
+        /// other logging needs (e.g., logging another concurrent debugs() call)
+        bool waitingForIdle;
     };
 
     /// whether debugging the given section and the given level produces output
@@ -107,6 +111,9 @@ public:
     /// Call this _before_ logging the termination reason to maximize the
     /// chances of that valuable debugs() getting through to the admin.
     static void PrepareToDie();
+
+    /// Logs messages of Finish()ed debugs() calls that were queued earlier.
+    static void LogWaitingForIdle();
 
     /* cache_log channel */
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -133,8 +133,7 @@ public:
 
     /// Whether debugs() message with the given level will be written to errlog.
     /// When called w/o a parameter, returns whether any message can be written.
-    /// Unreliable until FinalizeErrLogLevel().
-    /// XXX: A _db_init() call may change the answer!
+    /// The result may change until UseCacheLog() error, FinalizeErrLogLevel().
     static bool ErrLogEnabled(int level = DBG_CRITICAL);
 
     /* syslog */

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -145,14 +145,6 @@ public:
     static void SettleSysLogging();
 
 private:
-    /// debugs() messages with this (or lower) level will be written to stderr
-    /// (and possibly other channels). Negative values disable stderr logging.
-    /// This restriction is ignored if Squid tries but fails to open cache.log.
-    static int MaxErrLogLevel;
-
-    /// MaxErrLogLevel default; ignored after FinalizeErrLogLevel()
-    static int MaxErrLogLevelDefault;
-
     static Context *Current; ///< deepest active context; nil outside debugs()
 };
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -131,10 +131,9 @@ public:
     /// called after the last EnsureDefaultErrLogLevel()/ResetErrLogLevel() call
     static void SettleErrLogging();
 
-    /// Whether debugs() message with the given level will be written to errlog.
-    /// When called w/o a parameter, returns whether any message can be written.
+    /// Whether some debugs() messages may be written to errlog.
     /// The result may change until UseCacheLog() error, FinalizeErrLogLevel().
-    static bool ErrLogEnabled(int level = DBG_CRITICAL);
+    static bool ErrLogEnabled();
 
     /* syslog */
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -103,8 +103,10 @@ public:
     /// silently erases saved early debugs() messages (if any)
     static void ForgetSaved();
 
-    /// reacts to ongoing program termination (e.g., flushes buffered messages)
-    static void SwanSong();
+    /// Reacts to ongoing program termination (e.g., flushes buffered messages).
+    /// Call this _before_ logging the termination reason to maximize the
+    /// chances of that valuable debugs() getting through to the admin.
+    static void PrepareToDie();
 
     /* cache_log channel */
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -110,36 +110,36 @@ public:
 
     /// Opens and starts using the configured cache_log file.
     /// Also applies configured debug_options (if any).
-    /// Call this or BanCacheLogging() to stop early message accumulation.
+    /// Call this or BanCacheLogUse() to stop early message accumulation.
     static void UseCacheLog();
 
-    /// Honors the decision to use stderr instead of a cache_log file.
+    /// Stops using cache_log (if it was in use).
+    static void StopCacheLogUse();
+
+    /// Starts using stderr as a cache_log file replacement.
     /// Also applies configured debug_options (if any).
     /// Call this or UseCacheLog() to stop early message accumulation.
-    static void BanCacheLogging();
-
-    /// Stops using cache_log (if it was in use). No effect on stderr use.
-    static void StopCacheLogUse();
+    static void BanCacheLogUse();
 
     /* stderr */
 
-    /// In the absence of ResetErrChannelLevel() calls, future debugs() messages
-    /// with the given (or lower) level will be written to stderr (at least). If
-    /// called many times, the highest parameter wins. ResetErrChannelLevel()
+    /// In the absence of ResetStderrChannelLevel() calls, future debugs() with
+    /// the given (or lower) level will be written to stderr (at least). If
+    /// called many times, the highest parameter wins. ResetStderrChannelLevel()
     /// overwrites this default-setting method, regardless of the calls order.
-    static void EnsureDefaultErrChannelLevel(int maxDefault);
+    static void EnsureDefaultStderrChannelLevel(int maxDefault);
 
     /// Future debugs() messages with the given (or lower) level will be written
     /// to stderr (at least). If called many times, the last call wins.
-    static void ResetErrChannelLevel(int maxLevel);
+    static void ResetStderrChannelLevel(int maxLevel);
 
-    /// Finalizes stderr configuration when no (more) ResetErrChannelLevel() and
-    /// EnsureDefaultErrChannelLevel() calls are expected.
-    static void SettleErrChannel();
+    /// Finalizes stderr configuration when no (more) ResetStderrChannelLevel()
+    /// and EnsureDefaultStderrChannelLevel() calls are expected.
+    static void SettleStderrChannel();
 
     /// Whether at least some debugs() messages may be written to stderr. The
-    /// answer may be affected by BanCacheLogging() and SettleErrChannel().
-    static bool ErrChannelEnabled();
+    /// answer may be affected by BanCacheLogUse() and SettleStderrChannel().
+    static bool StderrChannelEnabled();
 
     /* syslog */
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -44,6 +44,8 @@
 
 #define DBG_PARSE_NOTE(x) (opt_parse_cfg_only?0:(x)) /**< output is always to be displayed on '-k parse' but at level-x normally. */
 
+class DebugMessageHeader;
+
 class Debug
 {
 
@@ -60,6 +62,8 @@ public:
 
     private:
         friend class Debug;
+        friend class DebugMessageHeader;
+
         void rewind(const int aSection, const int aLevel);
         void formatStream();
         Context *upper; ///< previous or parent record in nested debugging calls
@@ -161,6 +165,8 @@ public:
     static void SettleSyslog();
 
 private:
+    static void LogMessage(const Debug::Context &context);
+
     static Context *Current; ///< deepest active context; nil outside debugs()
 };
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -90,8 +90,6 @@ public:
 
     static void parseOptions(char const *);
 
-    /// debugging section of the current debugs() call
-    static int Section() { return Current ? Current->section : 0; }
     /// minimum level required by the current debugs() call
     static int Level() { return Current ? Current->level : 1; }
     /// maximum level currently allowed
@@ -165,7 +163,7 @@ public:
     static void SettleSyslog();
 
 private:
-    static void LogMessage(const Debug::Context &context);
+    static void LogMessage(const Context &);
 
     static Context *Current; ///< deepest active context; nil outside debugs()
 };

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -108,18 +108,19 @@ public:
 
     /* cache_log channel */
 
+    /// Starts using stderr as a cache_log file replacement.
+    /// Also applies configured debug_options (if any).
+    /// Call this or UseCacheLog() to stop early message accumulation.
+    static void BanCacheLogUse();
+
     /// Opens and starts using the configured cache_log file.
     /// Also applies configured debug_options (if any).
     /// Call this or BanCacheLogUse() to stop early message accumulation.
     static void UseCacheLog();
 
-    /// Stops using cache_log (if it was in use).
-    static void StopCacheLogUse();
-
+    /// Closes and stops using cache_log (if it was open).
     /// Starts using stderr as a cache_log file replacement.
-    /// Also applies configured debug_options (if any).
-    /// Call this or UseCacheLog() to stop early message accumulation.
-    static void BanCacheLogUse();
+    static void StopCacheLogUse();
 
     /* stderr channel */
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -105,12 +105,13 @@ public:
 
     /* cache.log */
 
-    /// Opens configured cache_log file (if any).
+    /// Ensures that the cache_log file location has been specified.
+    /// Opens the configured cache_log file.
     /// Also applies configured debug_options (if any).
     /// Call this or BanCacheLogging() to stop early message accumulation.
     static void UseCacheLog();
 
-    /// Ensures that cache_log file has not been opened.
+    /// Ensures that the cache_log file has not been opened.
     /// Also applies configured debug_options (if any).
     /// Call this or UseCacheLog() to stop early message accumulation.
     static void BanCacheLogging();

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -80,7 +80,7 @@ public:
     static int override_X;
     static bool log_syslog;
 
-    static void ConfigureOptions(char const *);
+    static void parseOptions(char const *);
 
     /// debugging section of the current debugs() call
     static int Section() { return Current ? Current->section : 0; }
@@ -100,48 +100,48 @@ public:
     /// prefixes each grouped debugs() line after the first one in the group
     static std::ostream& Extra(std::ostream &os) { return os << "\n    "; }
 
-    /// Ensure that any previously buffered debugs() messages are written.
-    static void Flush();
+    /// reacts to ongoing program termination (e.g., flushes buffered messages)
+    static void SwanSong();
 
-    /* cache.log */
+    /* cache_log */
 
-    /// Ensures that the cache_log file location has been specified.
-    /// Opens the configured cache_log file.
+    /// Opens and starts using the configured cache_log file.
     /// Also applies configured debug_options (if any).
     /// Call this or BanCacheLogging() to stop early message accumulation.
     static void UseCacheLog();
 
-    /// Ensures that the cache_log file has not been opened.
+    /// Honors the decision to use stderr instead of a cache_log file.
     /// Also applies configured debug_options (if any).
     /// Call this or UseCacheLog() to stop early message accumulation.
     static void BanCacheLogging();
 
-    /* errlog */
+    /* stderr */
 
-    /// In the absence of ResetErrLogLevel() calls, future debugs() messages
+    /// In the absence of ResetErrChannelLevel() calls, future debugs() messages
     /// with the given (or lower) level will be written to stderr (at least). If
-    /// called many times, the highest parameter wins. Calls have no effect if
-    /// ResetErrLogLevel() is called before/after this default-setting method.
-    static void EnsureDefaultErrLogLevel(int maxDefault);
+    /// called many times, the highest parameter wins. ResetErrChannelLevel()
+    /// overwrites this default-setting method, regardless of the calls order.
+    static void EnsureDefaultErrChannelLevel(int maxDefault);
 
     /// Future debugs() messages with the given (or lower) level will be written
     /// to stderr (at least). If called many times, the last call wins.
-    static void ResetErrLogLevel(int maxLevel);
+    static void ResetErrChannelLevel(int maxLevel);
 
-    /// called after the last EnsureDefaultErrLogLevel()/ResetErrLogLevel() call
-    static void SettleErrLogging();
+    /// Finalizes stderr configuration when no (more) ResetErrChannelLevel() and
+    /// EnsureDefaultErrChannelLevel() calls are expected.
+    static void SettleErrChannel();
 
-    /// Whether some debugs() messages may be written to errlog.
-    /// The result may change until UseCacheLog() error, FinalizeErrLogLevel().
-    static bool ErrLogEnabled();
+    /// Whether at least some debugs() messages may be written to stderr. The
+    /// answer may be affected by BanCacheLogging() and SettleErrChannel().
+    static bool ErrChannelEnabled();
 
     /* syslog */
 
     /// enables logging to syslog (using the specified facility, when not nil)
-    static void ConfigureSysLogging(const char *facility);
+    static void ConfigureSysLog(const char *facility);
 
-    /// called after the last ConfigureSysLogging() call (if any)
-    static void SettleSysLogging();
+    /// called after the last ConfigureSysLog() call (if any)
+    static void SettleSysLogChannel();
 
 private:
     static Context *Current; ///< deepest active context; nil outside debugs()

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -153,9 +153,6 @@ FILE *DebugStream();
 /// change-avoidance macro; new code should call DebugStream() instead
 #define debug_log DebugStream()
 
-/// start logging to stderr (instead of cache.log, if any)
-void StopUsingDebugLog();
-
 /// a hack for low-level file descriptor manipulations in ipcCreate()
 void ResyncDebugLog(FILE *newDestination);
 

--- a/src/Instance.cc
+++ b/src/Instance.cc
@@ -164,6 +164,14 @@ RemoveInstance()
         return; // nothing to do
 
     debugs(50, DBG_IMPORTANT, "Removing " << PidFileDescription(ThePidFileToRemove));
+
+    // Do not write to cache_log after our PID file is removed because another
+    // instance may already be logging there. Stop logging now because, if we
+    // wait until safeunlink(), some debugs() may slip through into the now
+    // "unlocked" cache_log, especially if we avoid the sensitive suid() area.
+    // Use stderr to capture late debugs() that did not make it into cache_log.
+    Debug::StopCacheLogUse();
+
     const char *filename = ThePidFileToRemove.c_str(); // avoid complex operations inside enter_suid()
     enter_suid();
     safeunlink(filename, 0);

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -106,7 +106,6 @@ MemObject::MemObject()
 MemObject::~MemObject()
 {
     debugs(20, 3, "MemObject destructed, this=" << this);
-    const Ctx ctx = ctx_enter(hasUris() ? urlXXX() : "[unknown_ctx]");
 
 #if URL_CHECKSUM_DEBUG
     checkUrlChecksum();
@@ -128,8 +127,6 @@ MemObject::~MemObject()
     assert(clients.head == NULL);
 
 #endif
-
-    ctx_exit(ctx);              /* must exit before we free mem->url */
 }
 
 HttpReply &

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -14,6 +14,37 @@
 
 #include <iosfwd>
 
+/** \file
+ *
+ * Most error-reporting code cannot know what transaction or task Squid was
+ * working on when the error occurred. For example, when Squid HTTP request
+ * parser discovers a malformed header field, the parser can report the field
+ * contents, but that information is often useless for the admin without
+ * processing context details like which client sent the request or what the
+ * requested URL was. Moreover, even when the error reporting code does have
+ * access to some context details, it cannot separate important facts from noise
+ * because such classification is usually deployment-specific (i.e. cannot be
+ * hard-coded) and requires human expertise. The situation is aggravated by a
+ * busy Squid instance constantly switching from one processing context to
+ * another.
+ *
+ * To solve these problems, Squid assigns a CodeContext object to a processing
+ * context. When Squid switches to another processing context, it switches the
+ * current CodeContext object as well. When Squid prints a level-0 or level-1
+ * message to cache.log, it asks the current CodeContext object (if any) to
+ * report context details, allowing the admin to correlate the cache.log message
+ * with an access.log record.
+ *
+ * Squid also reports processing context changes to cache.log when Squid
+ * level-5+ debugging is enabled.
+ *
+ * CodeContext is being retrofitted into existing code with lots of places that
+ * switch processing context. Identifying and adjusting all those places takes
+ * time. Until then, there will be incorrect and missing context attributions.
+ *
+ * @{
+ **/
+
 /// Interface for reporting what Squid code is working on.
 /// Such reports are usually requested outside creator's call stack.
 /// They are especially useful for attributing low-level errors to transactions.
@@ -116,6 +147,8 @@ CallContextCreator(Fun &&creator)
     creator();
     CodeContext::Reset(savedCodeContext);
 }
+
+/// @}
 
 #endif
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <functional>
 #include <memory>
 
 /* for shutting_down flag in xassert() */
@@ -184,7 +185,7 @@ protected:
         explicit Logger(DebugChannel &ch) : channel(ch) {}
         Logger &operator=(const DebugMessage &message) {
             if (Debug::Enabled(message.header.section, message.header.level))
-                channel.log(message.header, message.body);
+                channel.get().log(message.header, message.body);
             return *this;
         }
         // These no-op operators are provided to satisfy LegacyOutputIterator requirements,
@@ -193,7 +194,8 @@ protected:
         Logger &operator++() { return *this; }
         Logger &operator++(int) { return *this; }
     private:
-        DebugChannel &channel;
+        // wrap: output iterators must be CopyAssignable; raw references are not
+        std::reference_wrapper<DebugChannel> channel; ///< output destination
     };
     /// stores the given early message (if possible) or forgets it (otherwise)
     void saveMessage(const DebugMessageHeader &header, const std::string &body);

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -321,6 +321,10 @@ DebugModule::swanSong()
     cacheLogChannel.stopEarlyMessageCollection();
     stderrChannel.stopEarlyMessageCollection();
     syslogChannel.stopEarlyMessageCollection();
+
+    // Do not close/destroy channels: While the Debug module is not _guaranteed_
+    // to get control after swanSong(), debugs() calls are still very much
+    // _possible_, and we want to support/log them for as long as we can.
 }
 
 void

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -499,10 +499,13 @@ StderrChannel::takeOver(CacheLogChannel &cacheLogChannel)
     coveringForCacheLog = true;
 
     // Stop collecting before dumping cacheLogChannel messages so that we do not
-    // end up saving messages already saved by cacheLogChannel.
-    stopEarlyMessageCollection();
+    // end up saving messages already saved by cacheLogChannel, but log their
+    // messages first because cacheLogChannel was the primary channel.
+    const auto ours = releaseEarlyMessages();
     if (const auto theirs = cacheLogChannel.releaseEarlyMessages())
         logSaved(*theirs);
+    if (ours)
+        logSaved(*ours);
 }
 
 void

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -262,7 +262,7 @@ public:
     ~DebugModule() = delete;
 
     /// \copydoc Debug::SwanSong()
-    void flush();
+    void swanSong();
 
     /// Log the given debugs() message to appropriate channel(s) (eventually).
     /// Assumes the message has passed the global section/level filter.
@@ -311,11 +311,16 @@ DebugModule::log(const DebugMessageHeader &header, const std::string &body)
 }
 
 void
-DebugModule::flush()
+DebugModule::swanSong()
 {
+    // If we have not opened cache_log yet, flushing its channel would do
+    // nothing. Switch to stderr to improve our chances to print saved messages.
+    if (!TheLog.file())
+        banCacheLog();
+
+    cacheLogChannel.stopEarlyMessageCollection();
     stderrChannel.stopEarlyMessageCollection();
     syslogChannel.stopEarlyMessageCollection();
-    cacheLogChannel.stopEarlyMessageCollection();
 }
 
 void
@@ -368,13 +373,10 @@ DebugChannel::stopEarlyMessageCollection()
         log(*toLog);
 }
 
-// XXX: call banCacheLog() if necessary to force logging of buffered
-// messages. Otherwise, they will not be shown if we have not opened cache_log
-// before abort()ing.
 void
 Debug::SwanSong()
 {
-    Module().flush();
+    Module().swanSong();
 }
 
 void

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -425,8 +425,8 @@ DebugChannel::saveMessage(const DebugMessageHeader &header, const std::string &b
     if (earlyMessages->size() >= limit) {
         DebugMessages doomedMessages;
         earlyMessages->swap(doomedMessages);
+        purged = doomedMessages.size(); // before handleOverflow() may change it
         handleOverflow(doomedMessages);
-        purged = doomedMessages.size();
     }
 
     earlyMessages->emplace_back(header, body);

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -1001,8 +1001,14 @@ Debug::UseCacheLog()
 void
 Debug::StopCacheLogUse()
 {
-    TheLog.clear(); // may already be closed
-    Module().cacheLogChannel.stopEarlyMessageCollection(); // may already be stopped
+    if (TheLog.file()) {
+        // UseCacheLog() was successful.
+        Module().cacheLogChannel.stopEarlyMessageCollection(); // paranoid
+        TheLog.clear();
+    } else {
+        // UseCacheLog() was not called at all or failed to open cache_log.
+        Module().banCacheLogUse(); // may already be banned
+    }
 }
 
 void

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -991,6 +991,13 @@ Debug::BanCacheLogging()
 }
 
 void
+Debug::StopCacheLogUse()
+{
+    TheLog.clear(); // may already be closed
+    Module().cacheLogChannel.stopEarlyMessageCollection(); // may already be stopped
+}
+
+void
 Debug::SettleSysLogChannel()
 {
 #if HAVE_SYSLOG && defined(LOG_LOCAL4)

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -741,7 +741,6 @@ debugOpenLog(const char *logfile)
         // Report the problem after the switch above to improve our chances of
         // also reporting early debugs() messages (that should be logged first).
         debugs(0, DBG_CRITICAL, "ERROR: Cannot open cache_log (" << logfilename << ") for writing;" <<
-               Debug::Extra << "now using stderr instead;" <<
                Debug::Extra << "fopen(3) error: " << xstrerr(xerrno));
     }
 }

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -557,8 +557,8 @@ StderrChannel::shouldWrite(const int level) const
         return level <= ExplicitStderrLevel;
 
     // whether the given level is allowed by emergency handling circumstances
-    // (coveringForCacheLog or DBG_CRITICAL messages) or configuration aspects (e.g., -k or -z)
-    return coveringForCacheLog || level == DBG_CRITICAL || level <= DefaultStderrLevel;
+    // (coveringForCacheLog) or configuration aspects (e.g., -k or -z)
+    return coveringForCacheLog || level <= DefaultStderrLevel;
 }
 
 void

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -443,7 +443,9 @@ ResyncDebugLog(FILE *newFile)
 void
 DebugChannel::stopEarlyMessageCollection()
 {
-    logSaved();
+    if (earlyMessages)
+        logSaved();
+    // else already stopped
 }
 
 void

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -374,6 +374,15 @@ DebugChannel::stopEarlyMessageCollection()
 }
 
 void
+Debug::ForgetSaved()
+{
+    auto &module = Module();
+    (void)module.cacheLogChannel.releaseEarlyMessages();
+    (void)module.stderrChannel.releaseEarlyMessages();
+    (void)module.syslogChannel.releaseEarlyMessages();
+}
+
+void
 Debug::SwanSong()
 {
     Module().swanSong();

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -29,10 +29,8 @@ int Debug::rotateNumber = -1;
 int Debug::MaxErrLogLevel = -1;
 int Debug::MaxErrLogLevelDefault = -1;
 
-static int Ctx_Lock = 0;
 static const char *debugLogTime(void);
 static const char *debugLogKid(void);
-static void ctx_print(void);
 #if HAVE_SYSLOG
 #ifdef LOG_LOCAL4
 static int syslog_facility = 0;
@@ -371,10 +369,6 @@ _db_print(const bool forceAlert, const char *format,...)
     EnterCriticalSection(dbg_mutex);
 #endif
 
-    /* give a chance to context-based debugging to print current context */
-    if (!Ctx_Lock)
-        ctx_print();
-
     va_start(args1, format);
     va_start(args2, format);
     va_start(args3, format);
@@ -417,10 +411,6 @@ _db_print_file(const char *format, va_list args)
 
     if (SavingEarlyMessagesToChannel(CacheChannel))
         return;
-
-    /* give a chance to context-based debugging to print current context */
-    if (!Ctx_Lock)
-        ctx_print();
 
     vfprintf(TheLog.file(), format, args);
     fflush(TheLog.file());
@@ -920,169 +910,6 @@ xassert(const char *msg, const char *file, int line)
         Debug::Flush();
         abort();
     }
-}
-
-/*
- * Context-based Debugging
- *
- * Rationale
- * ---------
- *
- * When you have a long nested processing sequence, it is often impossible
- * for low level routines to know in what larger context they operate. If a
- * routine coredumps, one can restore the context using debugger trace.
- * However, in many case you do not want to coredump, but just want to report
- * a potential problem. A report maybe useless out of problem context.
- *
- * To solve this potential problem, use the following approach:
- *
- * int
- * top_level_foo(const char *url)
- * {
- *      // define current context
- *      // note: we stack but do not dup ctx descriptions!
- *      Ctx ctx = ctx_enter(url);
- *      ...
- *      // go down; middle_level_bar will eventually call bottom_level_boo
- *      middle_level_bar(method, protocol);
- *      ...
- *      // exit, clean after yourself
- *      ctx_exit(ctx);
- * }
- *
- * void
- * bottom_level_boo(int status, void *data)
- * {
- *      // detect exceptional condition, and simply report it, the context
- *      // information will be available somewhere close in the log file
- *      if (status == STRANGE_STATUS)
- *      debugs(13, 6, "DOS attack detected, data: " << data);
- *      ...
- * }
- *
- * Current implementation is extremely simple but still very handy. It has a
- * negligible overhead (descriptions are not duplicated).
- *
- * When the _first_ debug message for a given context is printed, it is
- * prepended with the current context description. Context is printed with
- * the same debugging level as the original message.
- *
- * Note that we do not print context every type you do ctx_enter(). This
- * approach would produce too many useless messages.  For the same reason, a
- * context description is printed at most _once_ even if you have 10
- * debugging messages within one context.
- *
- * Contexts can be nested, of course. You must use ctx_enter() to enter a
- * context (push it onto stack).  It is probably safe to exit several nested
- * contexts at _once_ by calling ctx_exit() at the top level (this will pop
- * all context till current one). However, as in any stack, you cannot start
- * in the middle.
- *
- * Analysis:
- * i)   locate debugging message,
- * ii)  locate current context by going _upstream_ in your log file,
- * iii) hack away.
- *
- *
- * To-Do:
- * -----
- *
- *       decide if we want to dup() descriptions (adds overhead) but allows to
- *       add printf()-style interface
- *
- * implementation:
- * ---------------
- *
- * descriptions for contexts over CTX_MAX_LEVEL limit are ignored, you probably
- * have a bug if your nesting goes that deep.
- */
-
-#define CTX_MAX_LEVEL 255
-
-/*
- * produce a warning when nesting reaches this level and then double
- * the level
- */
-static int Ctx_Warn_Level = 32;
-/* all descriptions has been printed up to this level */
-static int Ctx_Reported_Level = -1;
-/* descriptions are still valid or active up to this level */
-static int Ctx_Valid_Level = -1;
-/* current level, the number of nested ctx_enter() calls */
-static int Ctx_Current_Level = -1;
-/* saved descriptions (stack) */
-static const char *Ctx_Descrs[CTX_MAX_LEVEL + 1];
-/* "safe" get secription */
-static const char *ctx_get_descr(Ctx ctx);
-
-Ctx
-ctx_enter(const char *descr)
-{
-    ++Ctx_Current_Level;
-
-    if (Ctx_Current_Level <= CTX_MAX_LEVEL)
-        Ctx_Descrs[Ctx_Current_Level] = descr;
-
-    if (Ctx_Current_Level == Ctx_Warn_Level) {
-        debugs(0, DBG_CRITICAL, "# ctx: suspiciously deep (" << Ctx_Warn_Level << ") nesting:");
-        Ctx_Warn_Level *= 2;
-    }
-
-    return Ctx_Current_Level;
-}
-
-void
-ctx_exit(Ctx ctx)
-{
-    assert(ctx >= 0);
-    Ctx_Current_Level = (ctx >= 0) ? ctx - 1 : -1;
-
-    if (Ctx_Valid_Level > Ctx_Current_Level)
-        Ctx_Valid_Level = Ctx_Current_Level;
-}
-
-/*
- * the idea id to print each context description at most once but provide enough
- * info for deducing the current execution stack
- */
-static void
-ctx_print(void)
-{
-    /* lock so _db_print will not call us recursively */
-    ++Ctx_Lock;
-    /* ok, user saw [0,Ctx_Reported_Level] descriptions */
-    /* first inform about entries popped since user saw them */
-
-    if (Ctx_Valid_Level < Ctx_Reported_Level) {
-        if (Ctx_Reported_Level != Ctx_Valid_Level + 1)
-            _db_print(false, "ctx: exit levels from %2d down to %2d\n",
-                      Ctx_Reported_Level, Ctx_Valid_Level + 1);
-        else
-            _db_print(false, "ctx: exit level %2d\n", Ctx_Reported_Level);
-
-        Ctx_Reported_Level = Ctx_Valid_Level;
-    }
-
-    /* report new contexts that were pushed since last report */
-    while (Ctx_Reported_Level < Ctx_Current_Level) {
-        ++Ctx_Reported_Level;
-        ++Ctx_Valid_Level;
-        _db_print(false, "ctx: enter level %2d: '%s'\n", Ctx_Reported_Level,
-                  ctx_get_descr(Ctx_Reported_Level));
-    }
-
-    /* unlock */
-    --Ctx_Lock;
-}
-
-/* checks for nulls and overflows */
-static const char *
-ctx_get_descr(Ctx ctx)
-{
-    if (ctx < 0 || ctx > CTX_MAX_LEVEL)
-        return "<lost>";
-
-    return Ctx_Descrs[ctx] ? Ctx_Descrs[ctx] : "<null>";
 }
 
 Debug::Context *Debug::Current = nullptr;

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -512,7 +512,7 @@ DebugChannel::StopSavingAndLog(DebugChannel &channelA, DebugChannel *channelBOrN
     const auto writtenEarlier = channelA.written;
 
     std::merge(as.begin(), as.end(), bs.begin(), bs.end(), Logger(channelA),
-    [&](const CompiledDebugMessage &mA, const CompiledDebugMessage &mB) {
+    [](const CompiledDebugMessage &mA, const CompiledDebugMessage &mB) {
     return mA.header.recordNumber < mB.header.recordNumber;
     });
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -354,12 +354,6 @@ DebugStream() {
 }
 
 void
-StopUsingDebugLog()
-{
-    TheLog.clear();
-}
-
-void
 ResyncDebugLog(FILE *newFile)
 {
     TheLog.file_ = newFile;

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -1012,8 +1012,7 @@ SyslogChannel::write(const DebugMessageHeader &header, const std::string &body)
 void
 SyslogChannel::write(const DebugMessageHeader &, const std::string &)
 {
-    // cannot get here because shouldWrite() is always false
-    assert(opened);
+    assert(!"unreachable code because opened, shouldWrite() are always false");
 }
 
 #endif /* HAVE_SYSLOG */

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -558,8 +558,8 @@ StderrChannel::shouldWrite(const int level) const
         return level <= ExplicitStderrLevel;
 
     // whether the given level is allowed by emergency handling circumstances
-    // (coveringForCacheLog) or configuration aspects (e.g., -k or -z)
-    return coveringForCacheLog || level <= DefaultStderrLevel;
+    // (coveringForCacheLog or DBG_CRITICAL messages) or configuration aspects (e.g., -k or -z)
+    return coveringForCacheLog || level == DBG_CRITICAL || level <= DefaultStderrLevel;
 }
 
 void
@@ -568,11 +568,10 @@ StderrChannel::log(const DebugMessageHeader &header, const std::string &body)
     if (header.recordNumber <= lastWrittenRecordNumber)
         return;
 
-    if (saveMessage(header, body))
+    if (!shouldWrite(header.level)) {
+        (void)saveMessage(header, body);
         return;
-
-    if (!shouldWrite(header.level))
-        return;
+    }
 
     // We must write this eligible unsaved message, but we must log previously
     // saved early messages before writeToStream() below to avoid reordering.

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <memory>
 
 /* for shutting_down flag in xassert() */
 #include "globals.h"

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -469,8 +469,9 @@ DebugChannel::log(const DebugMessageHeader &header, const std::string &body)
     if (!shouldWrite(header))
         return saveMessage(header, body);
 
-    // We must write this eligible unsaved message, but we must log previously
-    // saved early messages before write() below to avoid reordering.
+    // We only save messages before we learn whether the channel is going to be used.
+    // We now know that it will be used. Also logs saved early messages (if
+    // they became eligible now) before lastWrittenRecordNumber blocks them.
     stopEarlyMessageCollection();
 
     write(header, body);

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -275,9 +275,15 @@ public:
     SyslogChannel syslogChannel;
 };
 
-/// configured cache.log file or stderr
+/// cache_log file
 /// safe during static initialization, even if it has not been constructed yet
+/// safe during program termination, even if it has been destructed already
 static DebugFile TheLog;
+
+FILE *
+DebugStream() {
+    return TheLog.file() ? TheLog.file() : stderr;
+}
 
 /* DebugModule */
 
@@ -348,11 +354,6 @@ Module() {
     }
 
     return *Module_;
-}
-
-FILE *
-DebugStream() {
-    return TheLog.file() ? TheLog.file() : stderr;
 }
 
 void

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -447,16 +447,14 @@ ErrLogChannel::takeOverCacheLog()
     flushed = true; // may already be true
 
     const auto saved = EarlyMessages ? EarlyMessages->raw().size() : 0;
-    if (!saved) {
-        // no logging debt to worry about
-        return;
-    }
+    if (!saved)
+        return; // no logging debt to analyze
 
-    if (!logged) {
-        // no danger of reordering messages on stderr
-        writeAllSaved();
-        return;
-    }
+    if (!logged)
+        return writeAllSaved(); // no danger of reordering messages on stderr
+
+    if (MaxErrLogLevel >= EarlyMessagesMaxLevel)
+        return; // we would have logged any saved messages
 
     // It is possible that we have logged some of the saved lines (e.g., -d1)
     // and/or logged some of the lines that follow the saved lines (e.g., -Xd2).

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -401,8 +401,7 @@ DebugChannel::logSaved(const DebugMessages &messages)
 {
     const auto writtenEarlier = written;
     for (const auto &message: messages) {
-        if (Debug::Enabled(message.header.section, message.header.level) &&
-                lastWrittenRecordNumber < message.header.recordNumber)
+        if (Debug::Enabled(message.header.section, message.header.level))
             log(message.header, message.body);
     }
     const auto writtenNow = written - writtenEarlier;
@@ -465,7 +464,8 @@ DebugChannel::noteWritten(const DebugMessageHeader &header)
 void
 CacheLogChannel::log(const DebugMessageHeader &header, const std::string &body)
 {
-    assert(header.recordNumber > lastWrittenRecordNumber);
+    if (header.recordNumber <= lastWrittenRecordNumber)
+        return;
 
     if (earlyMessages)
         return (void)saveMessage(header, body);
@@ -504,7 +504,8 @@ StderrChannel::shouldWrite(const int level, const bool overflowed) const
 void
 StderrChannel::log(const DebugMessageHeader &header, const std::string &body)
 {
-    assert(header.recordNumber > lastWrittenRecordNumber);
+    if (header.recordNumber <= lastWrittenRecordNumber)
+        return;
 
     if (saveMessage(header, body))
         return;
@@ -923,7 +924,8 @@ SyslogPriority(const DebugMessageHeader &header)
 void
 SyslogChannel::log(const DebugMessageHeader &header, const std::string &body)
 {
-    assert(header.recordNumber > lastWrittenRecordNumber);
+    if (header.recordNumber <= lastWrittenRecordNumber)
+        return;
 
     if (earlyMessages)
         return (void)saveMessage(header, body);

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -504,7 +504,6 @@ Debug::SettleErrLogging()
     if (MaxErrLogLevel < 0)
         MaxErrLogLevel = MaxErrLogLevelDefault; // may remain disabled/negative
 
-    // XXX: This is too early iff TheLog.failed() becomes true later!
     Module().errLogChannel.stopEarlyMessageCollection();
 }
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -261,7 +261,7 @@ public:
 
     /// Log the given debugs() message to appropriate channel(s) (eventually).
     /// Assumes the message has passed the global section/level filter.
-    void log(const DebugMessageHeader &header, const std::string &body);
+    void log(const DebugMessageHeader &, const std::string &body);
 
     /// Start using an open cache_log file as the primary debugs() destination.
     /// Stop using stderr as a cache_log replacement (if we were doing that).

--- a/src/fatal.cc
+++ b/src/fatal.cc
@@ -95,7 +95,7 @@ fatal_dump(const char *message)
     if (opt_catch_signals)
         storeDirWriteCleanLogs(0);
 
-    Debug::Flush();
+    Debug::SwanSong();
 
     abort();
 }

--- a/src/fatal.cc
+++ b/src/fatal.cc
@@ -96,7 +96,6 @@ fatal_dump(const char *message)
         storeDirWriteCleanLogs(0);
 
     Debug::PrepareToDie();
-
     abort();
 }
 

--- a/src/fatal.cc
+++ b/src/fatal.cc
@@ -95,7 +95,7 @@ fatal_dump(const char *message)
     if (opt_catch_signals)
         storeDirWriteCleanLogs(0);
 
-    Debug::EarlyMessagesCheckpoint(0);
+    Debug::Flush();
 
     abort();
 }

--- a/src/fatal.cc
+++ b/src/fatal.cc
@@ -95,7 +95,7 @@ fatal_dump(const char *message)
     if (opt_catch_signals)
         storeDirWriteCleanLogs(0);
 
-    Debug::SwanSong();
+    Debug::PrepareToDie();
 
     abort();
 }

--- a/src/http.cc
+++ b/src/http.cc
@@ -666,17 +666,12 @@ HttpStateData::processReplyHeader()
 {
     /** Creates a blank header. If this routine is made incremental, this will not do */
 
-    /* NP: all exit points to this function MUST call ctx_exit(ctx) */
-    Ctx ctx = ctx_enter(entry->mem_obj->urlXXX());
-
     debugs(11, 3, "processReplyHeader: key '" << entry->getMD5Text() << "'");
 
     assert(!flags.headers_parsed);
 
-    if (!inBuf.length()) {
-        ctx_exit(ctx);
+    if (!inBuf.length())
         return;
-    }
 
     /* Attempt to parse the first line; this will define where the protocol, status, reason-phrase and header begin */
     {
@@ -701,7 +696,6 @@ HttpStateData::processReplyHeader()
                 inBuf = hp->remaining();
             } else {
                 debugs(33, 5, "Incomplete response, waiting for end of response headers");
-                ctx_exit(ctx);
                 return;
             }
         }
@@ -714,7 +708,6 @@ HttpStateData::processReplyHeader()
             HttpReply *newrep = new HttpReply;
             newrep->sline.set(Http::ProtocolVersion(), hp->parseStatusCode);
             setVirginReply(newrep);
-            ctx_exit(ctx);
             return;
         }
     }
@@ -757,7 +750,6 @@ HttpStateData::processReplyHeader()
 
     if (newrep->sline.protocol == AnyP::PROTO_HTTP && Http::Is1xx(newrep->sline.status())) {
         handle1xx(newrep);
-        ctx_exit(ctx);
         return;
     }
 
@@ -780,8 +772,6 @@ HttpStateData::processReplyHeader()
     processSurrogateControl (vrep);
 
     request->hier.peer_reply_status = newrep->sline.status();
-
-    ctx_exit(ctx);
 }
 
 /// ignore or start forwarding the 1xx response (a.k.a., control message)
@@ -908,7 +898,6 @@ HttpStateData::haveParsedReplyHeaders()
 {
     Client::haveParsedReplyHeaders();
 
-    Ctx ctx = ctx_enter(entry->mem_obj->urlXXX());
     HttpReply *rep = finalReply();
     const Http::StatusCode statusCode = rep->sline.status();
 
@@ -1032,8 +1021,6 @@ HttpStateData::haveParsedReplyHeaders()
     headersLog(1, 0, request->method, rep);
 
 #endif
-
-    ctx_exit(ctx);
 }
 
 HttpStateData::ConnectionStatus

--- a/src/main.cc
+++ b/src/main.cc
@@ -2166,18 +2166,6 @@ SquidShutdown()
 
     debugs(1, DBG_IMPORTANT, "Squid Cache (Version " << version_string << "): Exiting normally.");
 
-    /* TODO: (Re)move correct but increasingly misplaced comment: We
-     * exit() in many places, not just here.
-     * DPW 2006-10-23
-     * We used to fclose(debug_log) here if it was set, but then
-     * we forgot to set it to NULL.  That caused some coredumps
-     * because exit() ends up calling a bunch of destructors and
-     * such.   So rather than forcing the debug_log to close, we'll
-     * leave it open so that those destructors can write some
-     * debugging if necessary.  The file will be closed anyway when
-     * the process truly exits.
-     */
-
     exit(shutdown_status);
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1356,9 +1356,9 @@ OnTerminate()
         return;
     terminating = true;
 
-    debugs(1, DBG_CRITICAL, "FATAL: Dying from an exception handling failure; exception: " << CurrentException);
+    Debug::PrepareToDie();
 
-    Debug::SwanSong();
+    debugs(1, DBG_CRITICAL, "FATAL: Dying from an exception handling failure; exception: " << CurrentException);
 
     abort();
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -1726,8 +1726,6 @@ SquidMain(int argc, char **argv)
 static void
 sendSignal(void)
 {
-    StopUsingDebugLog();
-
 #if USE_WIN32_SERVICE
     // WIN32_sendSignal() does not need the PID value to signal,
     // but we must exit if there is no valid PID (TODO: Why?).

--- a/src/main.cc
+++ b/src/main.cc
@@ -525,7 +525,7 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
         /** \par d
          * debugs() messages with the given debugging level (and the more
          * important ones) should be written to stderr */
-        Debug::ResetErrChannelLevel(xatoi(optValue));
+        Debug::ResetStderrChannelLevel(xatoi(optValue));
         break;
 
     case 'f':
@@ -591,8 +591,8 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
 
         // Cannot use cache.log: use stderr for important messages (by default)
         // and stop expecting a Debug::SettleCacheLogging() call.
-        Debug::EnsureDefaultErrChannelLevel(DBG_IMPORTANT);
-        Debug::BanCacheLogging();
+        Debug::EnsureDefaultStderrChannelLevel(DBG_IMPORTANT);
+        Debug::BanCacheLogUse();
         break;
 
     case 'm':
@@ -693,7 +693,7 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
         opt_create_swap_dirs = 1;
         // We will use cache.log, but this command is often executed on the
         // command line, so use stderr to show important messages (by default).
-        Debug::EnsureDefaultErrChannelLevel(DBG_IMPORTANT);
+        Debug::EnsureDefaultStderrChannelLevel(DBG_IMPORTANT);
         break;
 
     case optForeground:
@@ -1448,7 +1448,7 @@ ConfigureDebugging()
     if (!Config.chroot_dir || Chrooted)
         Debug::UseCacheLog();
     else
-        Debug::BanCacheLogging();
+        Debug::BanCacheLogUse();
 }
 
 static void
@@ -1538,7 +1538,7 @@ SquidMain(int argc, char **argv)
 
     cmdLine.forEachOption(mainHandleCommandLineOption);
 
-    Debug::SettleErrChannel();
+    Debug::SettleStderrChannel();
     Debug::SettleSysLogChannel();
 
     if (opt_foreground && opt_no_daemon) {
@@ -1953,7 +1953,7 @@ watch_child(const CommandLine &masterCommand)
 
     dup2(nullfd, 0);
 
-    if (!Debug::ErrChannelEnabled()) {
+    if (!Debug::StderrChannelEnabled()) {
         dup2(nullfd, 1);
         dup2(nullfd, 2);
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -1881,6 +1881,8 @@ GoIntoBackground()
         exit(EXIT_SUCCESS);
     }
     // child, running as a background daemon
+    extern const char *XXX_Role;
+    XXX_Role = "master";
     Must(setsid() > 0); // ought to succeed after fork()
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1356,10 +1356,9 @@ OnTerminate()
         return;
     terminating = true;
 
-    Debug::PrepareToDie();
-
     debugs(1, DBG_CRITICAL, "FATAL: Dying from an exception handling failure; exception: " << CurrentException);
 
+    Debug::PrepareToDie();
     abort();
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1435,8 +1435,6 @@ ConfigureCurrentKid(const CommandLine &cmdLine)
 }
 
 /// Start directing debugs() messages to the configured cache.log.
-/// Until this function is called, all allowed messages go to stderr.
-/// XXX: The comment line above is stale.
 static void
 ConfigureDebugging()
 {
@@ -1492,6 +1490,7 @@ int
 SquidMain(int argc, char **argv)
 {
     const CommandLine cmdLine(argc, argv, shortOpStr, squidOptions);
+
     ConfigureCurrentKid(cmdLine);
 
 #if defined(SQUID_MAXFD_LIMIT)

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -441,13 +441,6 @@ Mem::Init(void)
     if (MemIsInitialized)
         return;
 
-    /** \par
-     * NOTE: Mem::Init() is called before the config file is parsed
-     * and before the debugging module has been initialized.  Any
-     * debug messages here at level 0 or 1 will always be printed
-     * on stderr. XXX: Stale comment.
-     */
-
     /**
      * Then initialize all pools.
      * \par

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -44,7 +44,7 @@ _db_rotate_log(void)
 static void
 LogMessage(const std::string &message)
 {
-    if (!Debug::ErrLogEnabled(Debug::Level()))
+    if (Debug::Level() > DBG_IMPORTANT)
         return;
 
     if (!stderr)
@@ -56,10 +56,7 @@ LogMessage(const std::string &message)
 }
 
 bool
-Debug::ErrLogEnabled(const int level)
-{
-    return level <= DBG_IMPORTANT;
-}
+Debug::ErrLogEnabled() STUB_RETVAL(false)
 
 void Debug::Flush() STUB
 

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -39,10 +39,10 @@ void
 _db_rotate_log(void)
 {}
 
-static void
-LogMessage(const std::string &message)
+void
+Debug::LogMessage(const Context &context)
 {
-    if (Debug::Level() > DBG_IMPORTANT)
+    if (context.level > DBG_IMPORTANT)
         return;
 
     if (!stderr)
@@ -50,7 +50,7 @@ LogMessage(const std::string &message)
 
     fprintf(stderr, "%s| %s\n",
             "stub time", // debugLogTime(squid_curtime),
-            message.c_str());
+            context.buf.str().c_str());
 }
 
 bool
@@ -86,7 +86,7 @@ void
 Debug::Finish()
 {
     if (Current) {
-        LogMessage(Current->buf.str());
+        LogMessage(*Current);
         delete Current;
         Current = nullptr;
     }

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -54,7 +54,7 @@ LogMessage(const std::string &message)
 }
 
 bool
-Debug::ErrChannelEnabled() STUB_RETVAL(false)
+Debug::StderrChannelEnabled() STUB_RETVAL(false)
 
 void Debug::SwanSong() STUB
 

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -54,10 +54,6 @@ _db_init(const char *, const char *)
 {}
 
 void
-_db_set_syslog(const char *)
-{}
-
-void
 _db_rotate_log(void)
 {}
 
@@ -96,10 +92,10 @@ _db_print_stderr(const char *format, va_list args)
     vfprintf(stderr, format, args);
 }
 
-void Debug::EarlyMessagesCheckpoint(int) STUB
+void Debug::Flush() STUB
 
 void
-Debug::parseOptions(char const *)
+Debug::ConfigureOptions(char const *)
 {}
 
 Debug::Context *Debug::Current = nullptr;

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -27,7 +27,6 @@ int Debug::override_X = 0;
 bool Debug::log_syslog = false;
 void Debug::ForceAlert() STUB
 
-void StopUsingDebugLog() STUB
 void ResyncDebugLog(FILE *) STUB
 
 FILE *

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -54,7 +54,7 @@ LogMessage(const std::string &message)
 }
 
 bool
-Debug::StderrChannelEnabled() STUB_RETVAL(false)
+Debug::StderrEnabled() STUB_RETVAL(false)
 
 void Debug::SwanSong() STUB
 

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -56,7 +56,7 @@ LogMessage(const std::string &message)
 bool
 Debug::StderrEnabled() STUB_RETVAL(false)
 
-void Debug::SwanSong() STUB
+void Debug::PrepareToDie() STUB
 
 void
 Debug::parseOptions(char const *)

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -25,8 +25,6 @@ int Debug::rotateNumber = 0;
 int Debug::Levels[MAX_DEBUG_SECTIONS];
 int Debug::override_X = 0;
 bool Debug::log_syslog = false;
-int Debug::MaxErrLogLevel = DBG_IMPORTANT;
-int Debug::MaxErrLogLevelDefault = DBG_IMPORTANT;
 
 void Debug::ForceAlert() STUB
 
@@ -40,46 +38,27 @@ DebugStream()
 }
 
 void
-_db_init(const char *, const char *)
-{}
-
-void
 _db_rotate_log(void)
 {}
 
 static void
-_db_print_stderr(const char *format, va_list args);
-
-void
-_db_print(const char *format,...)
+LogMessage(const std::string &message)
 {
-    static char f[BUFSIZ];
-    va_list args1;
-    va_list args2;
-    va_list args3;
-
-    va_start(args1, format);
-    va_start(args2, format);
-    va_start(args3, format);
-
-    snprintf(f, BUFSIZ, "%s| %s",
-             "stub time", //debugLogTime(squid_curtime),
-             format);
-
-    _db_print_stderr(f, args2);
-
-    va_end(args1);
-    va_end(args2);
-    va_end(args3);
-}
-
-static void
-_db_print_stderr(const char *format, va_list args)
-{
-    if (1 < Debug::Level())
+    if (!Debug::ErrLogEnabled(Debug::Level()))
         return;
 
-    vfprintf(stderr, format, args);
+    if (!stderr)
+        return;
+
+    fprintf(stderr, "%s| %s\n",
+            "stub time", // debugLogTime(squid_curtime),
+            message.c_str());
+}
+
+bool
+Debug::ErrLogEnabled(const int level)
+{
+    return level <= DBG_IMPORTANT;
 }
 
 void Debug::Flush() STUB
@@ -112,7 +91,7 @@ void
 Debug::Finish()
 {
     if (Current) {
-        _db_print("%s\n", Current->buf.str().c_str());
+        LogMessage(Current->buf.str());
         delete Current;
         Current = nullptr;
     }

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -25,7 +25,6 @@ int Debug::rotateNumber = 0;
 int Debug::Levels[MAX_DEBUG_SECTIONS];
 int Debug::override_X = 0;
 bool Debug::log_syslog = false;
-
 void Debug::ForceAlert() STUB
 
 void StopUsingDebugLog() STUB
@@ -56,12 +55,12 @@ LogMessage(const std::string &message)
 }
 
 bool
-Debug::ErrLogEnabled() STUB_RETVAL(false)
+Debug::ErrChannelEnabled() STUB_RETVAL(false)
 
-void Debug::Flush() STUB
+void Debug::SwanSong() STUB
 
 void
-Debug::ConfigureOptions(char const *)
+Debug::parseOptions(char const *)
 {}
 
 Debug::Context *Debug::Current = nullptr;

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -39,16 +39,6 @@ DebugStream()
     return stderr;
 }
 
-Ctx
-ctx_enter(const char *)
-{
-    return -1;
-}
-
-void
-ctx_exit(Ctx)
-{}
-
 void
 _db_init(const char *, const char *)
 {}

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -290,8 +290,6 @@ PrintRusage(void)
 void
 death(int sig)
 {
-    Debug::PrepareToDie();
-
     if (sig == SIGSEGV)
         debugs(1, DBG_CRITICAL, ForceAlert << "FATAL: Received Segment Violation...dying.");
     else if (sig == SIGBUS)
@@ -358,6 +356,7 @@ death(int sig)
         puts(dead_msg());
     }
 
+    Debug::PrepareToDie();
     abort();
 }
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -356,7 +356,7 @@ death(int sig)
         puts(dead_msg());
     }
 
-    Debug::EarlyMessagesCheckpoint(0);
+    Debug::Flush();
 
     abort();
 }
@@ -385,10 +385,10 @@ sigusr2_handle(int sig)
     DebugSignal = sig;
 
     if (state == 0) {
-        Debug::parseOptions("ALL,7");
+        Debug::ConfigureOptions("ALL,7");
         state = 1;
     } else {
-        Debug::parseOptions(Debug::debugOptions);
+        Debug::ConfigureOptions(Debug::debugOptions);
         state = 0;
     }
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -356,7 +356,7 @@ death(int sig)
         puts(dead_msg());
     }
 
-    Debug::Flush();
+    Debug::SwanSong();
 
     abort();
 }
@@ -385,10 +385,10 @@ sigusr2_handle(int sig)
     DebugSignal = sig;
 
     if (state == 0) {
-        Debug::ConfigureOptions("ALL,7");
+        Debug::parseOptions("ALL,7");
         state = 1;
     } else {
-        Debug::ConfigureOptions(Debug::debugOptions);
+        Debug::parseOptions(Debug::debugOptions);
         state = 0;
     }
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -290,6 +290,8 @@ PrintRusage(void)
 void
 death(int sig)
 {
+    Debug::PrepareToDie();
+
     if (sig == SIGSEGV)
         debugs(1, DBG_CRITICAL, ForceAlert << "FATAL: Received Segment Violation...dying.");
     else if (sig == SIGBUS)
@@ -355,8 +357,6 @@ death(int sig)
 
         puts(dead_msg());
     }
-
-    Debug::SwanSong();
 
     abort();
 }


### PR DESCRIPTION
Log early level-0/1 debugs() messages to cache_log

Commit d7ca82e dropped cache.log-recording of debugs() messages produced
by `finalizeConfig` runners (e.g., `WARNING: mem-cache size is...`).
This change restores that functionality (by buffering early messages
until the cache.log file is opened) and improves early debugs() handling
as detailed below.

## Squid has three channels for debugs() messages:

* cache.log (`cache_log`): Settles as squid.conf settings take effect.
* stderr (mostly `-d`): Settles when command line options take effect.
* syslog (mostly `-s`): Settles when command line options take effect.

Squid always ignores debugging messages with section/level mismatching
Debug::Levels configuration (driven by a combination of the `-k debug`,
`-X`, and `debug_options` directives). _Beyond_ that ever-present
top-level filter, each debugging channel has its own set of rules that
determine which filtered debugs() messages the channel accepts; the
following approximate summary is based on the changes in this commit:

* cache.log: all messages;
* stderr: either messages satisfying explicit `-d` level restrictions or
  messages that Squid failed to write to cache.log (if no -d);
* syslog: level-0/1 messages and `ForceAllert` messages.

This change encapsulates channel-specific logic in dedicated classes.

## Guiding design principles

* **no repetition**: A channel must record each message at most once.
* **no reordering**: Each channel must preserve same-process debugs()
  call order across all recorded messages.
* **no loss**: Each channel must log all messages matching the channel
  configuration/filters.
* **no delay**: Each channel must record each message ASAP.
* **cache.log primacy**: Admins want messages logged to cache.log if
  possible and to stderr/syslog only if necessary or explicitly
  requested.
* **cache.log locking**: No cache.log updates without a PID lock.

## The fix

Commit d7ca82e dropped level-0/1 messages produced by `finalizeConfig`
runners because, since that commit, the cache.log channel was opened
_after_ the `finalizeConfig` event. Official code also dropped other,
even earlier level-0/1 messages, violating the "cache.log primacy"
principle. We now save early level-0/1 messages into a buffer. This
buffering can be misinterpreted as violating the "no [artificial] delay"
principle, but the messages are actually written to cache.log ASAP;
without the buffer the messages would be missing from the "primary"
cache.log and, in many use cases without stderr capturing, completely.

If Squid fails to open cache.log, early messages saved for the cache.log
channel are given to the stderr channel (following the "no loss"
principle). The stderr channel logs those messages that obey explicit
`-d` restrictions and do not violate the "no reordering" and "no
repetition" principles. Violations are tracked by assigning each message
its debugs() call sequence number.

The early messages buffer is currently dedicated to level-0/1 messages
because we were worried that level-2+ messages (if enabled via `-X`)
would overflow any reasonably-sized buffer[^1]. Correctly handling such
overflows is very difficult (we tried), so we avoid them instead.

## Side effects and surprises

To allow admins to see early level-1 cache.log messages (without adding
an `if early` check to the debugs() macro[^2]), we changed the _initial_
Debug::Levels value from `ALL,0` to `ALL,1`, matching the debug_options
default set later. This fix uncovered a few early level-1 messages that
were previously hidden[^3]:

    09:46:36| Startup: Initializing Authentication Schemes ...
    09:46:36| Startup: Initialized Authentication Scheme 'basic'
    09:46:36| Startup: Initialized Authentication Scheme 'digest'
    09:46:36| Startup: Initialized Authentication Scheme 'negotiate'
    09:46:36| Startup: Initialized Authentication Scheme 'ntlm'
    09:46:36| Startup: Initialized Authentication.
    09:46:36| Processing Configuration File: .../squid.conf ...
    09:46:36| Initializing https:// proxy context
    09:46:36| Set Current Directory to /usr/local/squid/var

The fact that many debugs() messages happen before cache_log can be
opened is fairly obvious, but it is also true that stderr and syslog
channels cannot write messages immediately. Both channels need to wait
for the command line options to be parsed. Even the global `stderr`
variable may not be available during very early debugs() calls! Each
channel now buffers level-0/1 messages until it settles.

Since the early message buffers are limited to level-0/1 messages,
initial cache.log records logged by `squid -X` are level-0/1 messages,
followed by true ALL,9 debugging. The admins can get early ALL,9
messages via stderr, of course.

The `-z` command-line option no longer overrides `-d` settings.

Squid no longer writes to cache_log after removing the PID file.

fatal() text and the `Squid Cache...: Terminated abnormally.` message
are no longer dropped during certain early process terminations.

`squid -k ...` logs some new level-0/1 messages to stderr.

Improved support for assert()/debugs() triggered from within the Debug
module: Besides crashes, such "internal" debugs() could be logged before
earlier "external" messages and some assert() messages could be lost.

----

[1]: The restriction to only buffer level-0/1 messages can be easily
removed (after research and discussion) if there is consensus that the
actual memory required to accumulate all typical level-2+ early messages
is worth spending on making `squid -X` write all messages to cache.log.

[2]: Squid has thousands of debugs() calls (and counting), including
many calls on performance-sensitive paths. Most debugs() calls should do
nothing by default. Thus, the speed at which the debugs() macro can skip
logging is an important common case on the performance sensitive path.
Similarly, disruption to CPU processing pipeline due to top-level
debugs() checks may be important. Actually writing the message to the
cache.log may not be that important -- at that time, the performance
battle can be considered lost -- but the initial rejection is.

[3]: This change is not about the levels of any specific messages. Wrong
message levels (if any) should be fixed separately. This change does not
imply that any of the newly discovered messages have the wrong level.
