### PR TITLE
Check more preconditions before retrying TLS handshake failure with peer

### DIFF
--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1014,8 +1014,9 @@ TunnelStateData::checkRetry()
         return false;
     if (!FwdState::EnoughTimeToReForward(startTime))
         return false;
-    if (noConnections())
+    if (!Comm::IsConnOpen(client.conn))
         return false;
+    // whether the server connection is open does not matter here
     return true;
 }
 


### PR DESCRIPTION
Compared to bag14 631828a, the new conditions are "Squid is not shutting
down", "there is still time to connect", and "the client is still here".

Master commit 25d2603 adds a similar method with an additional check.
The master method checks whether the server connection is closed. That
check is in master for consistency or convenience sake: noConnections()
is called in many similar master TunnelStateData contexts. Master closes
the server connection before we checkRetry() so noConnections() in
master is equivalent to our "no client connection" condition.