### PR TITLE
Happy Eyeballs: Do not discard viable reforwarding destinations

### DIFF
--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -518,6 +518,7 @@ HappyConnOpener::startConnecting(Attempt &attempt, Comm::ConnectionPointer &dest
 {
     Must(!attempt.path);
     Must(!attempt.connector);
+    Must(!attempt.connOpener.valid());
     Must(dest);
 
     const auto bumpThroughPeer = cause->flags.sslBumped && dest->getPeer();

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -485,10 +485,9 @@ HappyConnOpener::sendSuccess(const Comm::ConnectionPointer &conn, bool reused, c
 void
 HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {
-    if (attempt) {
-        destinations->retryPath(attempt.path);
-        attempt.cancel(reason);
-    }
+    Must(attempt);
+    destinations->retryPath(attempt.path);
+    attempt.cancel(reason);
 }
 
 /// inform the initiator about our failure to connect (if needed)

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -396,16 +396,17 @@ HappyConnOpener::swanSong()
 
     // TODO: Find an automated, faster way to kill no-longer-needed jobs.
 
-    if (prime) {
-        cancelAttempt(prime, "HappyConnOpener object destructed");
-    }
-
     if (spare) {
-        cancelAttempt(spare, "HappyConnOpener object destructed");
+        // cancel the spare attempt first to preserve destination order
+        cancelAttempt(spare, "job finished during a spare attempt");
         if (gotSpareAllowance) {
             TheSpareAllowanceGiver.jobDroppedAllowance();
             gotSpareAllowance = false;
         }
+    }
+
+    if (prime) {
+        cancelAttempt(prime, "job finished during a prime attempt");
     }
 
     AsyncJob::swanSong();
@@ -879,9 +880,8 @@ HappyConnOpener::ranOutOfTimeOrAttempts() const
 void
 HappyConnOpener::Attempt::cancel(const char *reason)
 {
-    if (connector)
+    if (connector) {
         connector->cancel(reason);
-    if (connOpener.valid()) {
         CallJobHere(17, 3, connOpener, Comm::ConnOpener, noteAbort);
     }
     clear();

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -397,11 +397,11 @@ HappyConnOpener::swanSong()
     // TODO: Find an automated, faster way to kill no-longer-needed jobs.
 
     if (prime) {
-        prime.cancel("HappyConnOpener object destructed");
+        cancelAttempt(prime, "HappyConnOpener object destructed");
     }
 
     if (spare) {
-        spare.cancel("HappyConnOpener object destructed");
+        cancelAttempt(spare, "HappyConnOpener object destructed");
         if (gotSpareAllowance) {
             TheSpareAllowanceGiver.jobDroppedAllowance();
             gotSpareAllowance = false;
@@ -481,11 +481,11 @@ HappyConnOpener::sendSuccess(const Comm::ConnectionPointer &conn, bool reused, c
 }
 
 void
-HappyConnOpener::cancelAttempt(Attempt &attempt)
+HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {
     if (attempt) {
         destinations->retryPath(attempt.path);
-        attempt.cancel("aborting spare ConnOpener attempt");
+        attempt.cancel(reason);
     }
 }
 
@@ -595,7 +595,6 @@ HappyConnOpener::connectDone(const CommConnectCbParams &params)
 
     const char *what = itWasPrime ? "new prime connection" : "new spare connection";
     if (params.flag == Comm::OK) {
-        cancelAttempt(itWasPrime ? spare : prime);
         sendSuccess(params.conn, false, what);
         return;
     }

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -480,6 +480,8 @@ HappyConnOpener::sendSuccess(const Comm::ConnectionPointer &conn, bool reused, c
     callback_ = nullptr;
 }
 
+/// if the given attempt is in progress, cancels it and re-inserts
+/// the path into the beginning of candidates list
 void
 HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -518,7 +518,6 @@ HappyConnOpener::startConnecting(Attempt &attempt, Comm::ConnectionPointer &dest
 {
     Must(!attempt.path);
     Must(!attempt.connector);
-    Must(!attempt.connOpener.valid());
     Must(dest);
 
     const auto bumpThroughPeer = cause->flags.sslBumped && dest->getPeer();

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -197,7 +197,7 @@ private:
     Answer *futureAnswer(const Comm::ConnectionPointer &);
     void sendSuccess(const Comm::ConnectionPointer &conn, bool reused, const char *connKind);
     void sendFailure();
-    void cancelAttempt(Attempt &);
+    void cancelAttempt(Attempt &, const char *reason);
 
     const time_t fwdStart; ///< requestor start time
 

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -157,10 +157,13 @@ private:
     class Attempt {
     public:
         explicit operator bool() const { return static_cast<bool>(path); }
-        void clear() { path = nullptr; connector = nullptr; }
+        void clear() { path = nullptr; connector = nullptr; connOpener = nullptr; }
+        /// cancels the attempt, aborting the Comm::ConnOpener job
+        void cancel(const char *reason);
 
         Comm::ConnectionPointer path; ///< the destination we are connecting to
         AsyncCall::Pointer connector; ///< our Comm::ConnOpener callback
+        Comm::ConnOpener::Pointer connOpener; ///< our Comm::ConnOpener job
     };
 
     /* AsyncJob API */
@@ -194,6 +197,7 @@ private:
     Answer *futureAnswer(const Comm::ConnectionPointer &);
     void sendSuccess(const Comm::ConnectionPointer &conn, bool reused, const char *connKind);
     void sendFailure();
+    void cancelAttempt(Attempt &);
 
     const time_t fwdStart; ///< requestor start time
 

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -158,7 +158,7 @@ private:
     public:
         explicit operator bool() const { return static_cast<bool>(path); }
         void clear() { path = nullptr; connector = nullptr; connOpener = nullptr; }
-        /// cancels the attempt, aborting the Comm::ConnOpener job
+        /// cancels the attempt
         void cancel(const char *reason);
 
         Comm::ConnectionPointer path; ///< the destination we are connecting to


### PR DESCRIPTION
When HappyConnOpener starts opening two connections, both destinations
are removed from the shared destinations list. As soon as one connection
(X) succeeded, the other destination (Y) was essentially forgotten.  If
FwdState, after using X, decided to reforward the request, then the
request was never reforwarded to Y. We now return Y to the list.

Also abort the still-active ConnOpener job upon the termination of its
"parent" HappyConnOpener job. Without an explicit termination, those
abandoned child jobs wasted OS and Squid resources while the OS was
trying to open the requested connection. They would terminate on a
timeout or when the connection was finally opened (and discarded).

Waiting for the child ConnOpener job to end is a useful optimization,
but it remains a TODO. It requires complex accumulation avoidance logic.
