### PR TITLE
eventAdd() contexts analysis

### DIFF
--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -137,8 +137,8 @@ IpcIoFile::open(int flags, mode_t mode, RefCount<IORequestor> callback)
 
     WaitingForOpen.push_back(this);
 
-    eventAdd("IpcIoFile::OpenTimeout", &IpcIoFile::OpenTimeout,
-             this, Timeout, 0, false); // "this" pointer is used as id
+    eventAddGlobal1("IpcIoFile::OpenTimeout", &IpcIoFile::OpenTimeout,
+             this, Timeout, 0); // "this" pointer is used as id
 }
 
 void
@@ -581,8 +581,8 @@ IpcIoFile::scheduleTimeoutCheck()
     // one-for-all CheckTimeouts() that is not specific to any request.
     CallService(nullptr, [&] {
         // we check all older requests at once so some may be wait for 2*Timeout
-        eventAdd("IpcIoFile::CheckTimeouts", &IpcIoFile::CheckTimeouts,
-        reinterpret_cast<void *>(diskId), Timeout, 0, false);
+        eventAddGlobal1("IpcIoFile::CheckTimeouts", &IpcIoFile::CheckTimeouts,
+        reinterpret_cast<void *>(diskId), Timeout, 0);
         timeoutCheckScheduled = true;
     });
 }
@@ -809,10 +809,10 @@ IpcIoFile::WaitBeforePop()
 
         debugs(47, 3, HERE << "rate limiting by " << toSpend << " ms to get" <<
                (1e3*maxRate) << "/sec rate");
-        eventAdd("IpcIoFile::DiskerHandleMoreRequests",
+        eventAddGlobal1("IpcIoFile::DiskerHandleMoreRequests",
                  &IpcIoFile::DiskerHandleMoreRequests,
                  const_cast<char*>("rate limiting"),
-                 toSpend/1e3, 0, false);
+                 toSpend/1e3, 0);
         DiskerHandleMoreRequestsScheduled = true;
         return true;
     } else if (balance < -maxImbalance) {
@@ -847,10 +847,10 @@ IpcIoFile::DiskerHandleRequests()
             if (!DiskerHandleMoreRequestsScheduled) {
                 // the gap must be positive for select(2) to be given a chance
                 const double minBreakSecs = 0.001;
-                eventAdd("IpcIoFile::DiskerHandleMoreRequests",
+                eventAddGlobal1("IpcIoFile::DiskerHandleMoreRequests",
                          &IpcIoFile::DiskerHandleMoreRequests,
                          const_cast<char*>("long I/O loop"),
-                         minBreakSecs, 0, false);
+                         minBreakSecs, 0);
                 DiskerHandleMoreRequestsScheduled = true;
             }
             debugs(47, 3, HERE << "pausing after " << popped << " I/Os in " <<

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -204,7 +204,7 @@ HappyOrderEnforcer::startedWaiting(const HappyAbsoluteTime lastStart, const int 
     // by hot reconfiguration changes or current time jumps.
     if (!waiting() || newWaitEnd < waitEnd_) {
         const auto waitTime = newWaitEnd - current_dtime;
-        eventAdd(name, &HappyOrderEnforcer::NoteWaitOver, const_cast<HappyOrderEnforcer*>(this), waitTime, 0, false);
+        eventAddGlobal1(name, &HappyOrderEnforcer::NoteWaitOver, const_cast<HappyOrderEnforcer*>(this), waitTime, 0);
         waitEnd_ = newWaitEnd;
         assert(waiting());
     }

--- a/src/ProfStats.cc
+++ b/src/ProfStats.cc
@@ -304,7 +304,7 @@ xprof_event(void *data)
 
     xprof_chk_overhead(30);
 
-    eventAdd("cpuProfiling", xprof_event, NULL, 1.0, 1);
+    eventAddGlobal0("cpuProfiling", xprof_event, 1.0, 1);
 }
 
 #endif /* USE_XPROF_STATS */

--- a/src/adaptation/icap/ServiceRep.cc
+++ b/src/adaptation/icap/ServiceRep.cc
@@ -648,7 +648,7 @@ void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
     const int delay = when - squid_curtime;
     debugs(93,5, HERE << "will fetch OPTIONS in " << delay << " sec");
 
-    eventAdd("Adaptation::Icap::ServiceRep::noteTimeToUpdate",
+    eventAddGlobal2("Adaptation::Icap::ServiceRep::noteTimeToUpdate",
              &ServiceRep_noteTimeToUpdate, this, delay, 0, true);
     updateScheduled = true;
 }

--- a/src/auth/CredentialsCache.cc
+++ b/src/auth/CredentialsCache.cc
@@ -131,7 +131,7 @@ CredentialsCache::scheduleCleanup()
 {
     if (!gcScheduled_ && store_.size()) {
         gcScheduled_ = true;
-        eventAdd(cacheCleanupEventName, &CredentialsCache::Cleanup,
+        eventAddGlobal2(cacheCleanupEventName, &CredentialsCache::Cleanup,
                  this, Auth::TheConfig.garbageCollectInterval, 1);
     }
 }

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -284,7 +284,7 @@ authenticateDigestNonceCacheCleanup(void *)
     debugs(29, 3, "Finished cleaning the nonce cache.");
 
     if (static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->active())
-    	eventAddGlobal0("Digest nonce cache maintenance", authenticateDigestNonceCacheCleanup, static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->nonceGCInterval, 1);
+        eventAddGlobal0("Digest nonce cache maintenance", authenticateDigestNonceCacheCleanup, static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->nonceGCInterval, 1);
 }
 
 static void

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -220,7 +220,7 @@ authenticateDigestNonceSetup(void)
     if (!digest_nonce_cache) {
         digest_nonce_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
         assert(digest_nonce_cache);
-        eventAdd("Digest nonce cache maintenance", authenticateDigestNonceCacheCleanup, NULL, static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->nonceGCInterval, 1);
+        eventAddGlobal0("Digest nonce cache maintenance", authenticateDigestNonceCacheCleanup, static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->nonceGCInterval, 1);
     }
 }
 
@@ -284,7 +284,7 @@ authenticateDigestNonceCacheCleanup(void *)
     debugs(29, 3, "Finished cleaning the nonce cache.");
 
     if (static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->active())
-        eventAdd("Digest nonce cache maintenance", authenticateDigestNonceCacheCleanup, NULL, static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->nonceGCInterval, 1);
+    	eventAddGlobal0("Digest nonce cache maintenance", authenticateDigestNonceCacheCleanup, static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->nonceGCInterval, 1);
 }
 
 static void

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -400,7 +400,7 @@ clientdbGC(void *)
     }
 
     if (bucket < CLIENT_DB_HASH_SIZE)
-    	eventAddGlobal0("client_db garbage collector", clientdbGC, 0.15, 0);
+        eventAddGlobal0("client_db garbage collector", clientdbGC, 0.15, 0);
     else {
         bucket = 0;
         cleanup_running = 0;

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -82,7 +82,7 @@ clientdbAdd(const Ip::Address &addr)
 
     if ((statCounter.client_http.clients > max_clients) && !cleanup_running && cleanup_scheduled < 2) {
         ++cleanup_scheduled;
-        eventAdd("client_db garbage collector", clientdbScheduledGC, NULL, 90, 0);
+        eventAddGlobal0("client_db garbage collector", clientdbScheduledGC, 90, 0);
     }
 
     return c;
@@ -400,7 +400,7 @@ clientdbGC(void *)
     }
 
     if (bucket < CLIENT_DB_HASH_SIZE)
-        eventAdd("client_db garbage collector", clientdbGC, NULL, 0.15, 0);
+    	eventAddGlobal0("client_db garbage collector", clientdbGC, 0.15, 0);
     else {
         bucket = 0;
         cleanup_running = 0;
@@ -408,7 +408,7 @@ clientdbGC(void *)
 
         if (!cleanup_scheduled) {
             cleanup_scheduled = 1;
-            eventAdd("client_db garbage collector", clientdbScheduledGC, NULL, 6 * 3600, 0);
+            eventAddGlobal0("client_db garbage collector", clientdbScheduledGC, 6 * 3600, 0);
         }
 
         debugs(49, 2, "clientdbGC: Removed " << cleanup_removed << " entries");

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1633,7 +1633,7 @@ void
 commPlanHalfClosedCheck()
 {
     if (!WillCheckHalfClosed && !TheHalfClosed->empty()) {
-    	eventAddGlobal0("commHalfClosedCheck", &commHalfClosedCheck, 1.0, 1);
+        eventAddGlobal0("commHalfClosedCheck", &commHalfClosedCheck, 1.0, 1);
         WillCheckHalfClosed = true;
     }
 }

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1339,7 +1339,7 @@ ClientInfo::kickQuotaQueue()
     if (!eventWaiting && !selectWaiting && hasQueue()) {
         // wait at least a second if the bucket is empty
         const double delay = (bucketLevel < 1.0) ? 1.0 : 0.0;
-        eventAdd("commHandleWriteHelper", &commHandleWriteHelper,
+        eventAddGlobal2("commHandleWriteHelper", &commHandleWriteHelper,
                  quotaQueue, delay, 0, true);
         eventWaiting = true;
     }
@@ -1633,7 +1633,7 @@ void
 commPlanHalfClosedCheck()
 {
     if (!WillCheckHalfClosed && !TheHalfClosed->empty()) {
-        eventAdd("commHalfClosedCheck", &commHalfClosedCheck, NULL, 1.0, 1);
+    	eventAddGlobal0("commHalfClosedCheck", &commHalfClosedCheck, 1.0, 1);
         WillCheckHalfClosed = true;
     }
 }

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -378,9 +378,9 @@ Comm::ConnOpener::retrySleep()
     Must(!calls_.sleep_);
     closeFd();
     calls_.sleep_ = true;
-    eventAdd("Comm::ConnOpener::DelayedConnectRetry",
+    eventAddGlobal1("Comm::ConnOpener::DelayedConnectRetry",
              Comm::ConnOpener::DelayedConnectRetry,
-             new Pointer(this), 0.05, 0, false);
+             new Pointer(this), 0.05, 0);
 }
 
 /// cleans up this job sleep state

--- a/src/delay_pools.cc
+++ b/src/delay_pools.cc
@@ -470,7 +470,7 @@ DelayPools::InitDelayData()
 
     DelayPools::delay_data = new DelayPool[pools()];
 
-    eventAdd("DelayPools::Update", DelayPools::Update, NULL, 1.0, 1);
+    eventAddGlobal0("DelayPools::Update", DelayPools::Update, 1.0, 1);
 }
 
 void
@@ -487,7 +487,7 @@ DelayPools::Update(void *unused)
     if (!pools())
         return;
 
-    eventAdd("DelayPools::Update", Update, NULL, 1.0, 1);
+    eventAddGlobal0("DelayPools::Update", Update, 1.0, 1);
 
     int incr = squid_curtime - LastUpdate;
 

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -786,7 +786,7 @@ idnsTickleQueue(void)
 
     const double when = min(Config.Timeout.idns_query, Config.Timeout.idns_retransmit)/1000.0;
 
-    eventAdd("idnsCheckQueue", idnsCheckQueue, NULL, when, 1);
+    eventAddGlobal0("idnsCheckQueue", idnsCheckQueue, when, 1);
 
     event_queued = 1;
 }

--- a/src/event.cc
+++ b/src/event.cc
@@ -106,32 +106,28 @@ ev_entry::~ev_entry()
         cbdataReferenceDone(arg);
 }
 
-/*
-void
-eventAdd(const char *name, EVH * func, void *arg, double when, int weight, bool cbdata)
-{
-    EventScheduler::GetInstance()->schedule(name, func, arg, when, weight, cbdata);
-}
-*/
-
+// used for event callers, having a specific transaction context
 void
 eventAddContextual(const char *name, EVH * func, void *arg, double when, int weight, bool cbdata)
 {
     EventScheduler::GetInstance()->schedule(name, func, arg, when, weight, cbdata);
 }
 
+// used for event callers that do not supply callback data
 void
 eventAddGlobal0(const char *name, EVH * func, double when, int weight, bool cbdata)
 {
     EventScheduler::GetInstance()->schedule(name, func, nullptr, when, weight, cbdata);
 }
 
+// used for event callers, supplying cbdata-unprotected callback data
 void
 eventAddGlobal1(const char *name, EVH * func, void *arg, double when, int weight)
 {
     EventScheduler::GetInstance()->schedule(name, func, nullptr, when, weight, false);
 }
 
+// used for event callers, lacking a specific transaction context (but supplying cbdata-protected calback data)
 void
 eventAddGlobal2(const char *name, EVH * func, void *arg, double when, int weight, bool cbdata)
 {

--- a/src/event.cc
+++ b/src/event.cc
@@ -106,15 +106,40 @@ ev_entry::~ev_entry()
         cbdataReferenceDone(arg);
 }
 
+/*
 void
 eventAdd(const char *name, EVH * func, void *arg, double when, int weight, bool cbdata)
 {
     EventScheduler::GetInstance()->schedule(name, func, arg, when, weight, cbdata);
 }
+*/
 
-/* same as eventAdd but adds a random offset within +-1/3 of delta_ish */
 void
-eventAddIsh(const char *name, EVH * func, void *arg, double delta_ish, int weight)
+eventAddContextual(const char *name, EVH * func, void *arg, double when, int weight, bool cbdata)
+{
+    EventScheduler::GetInstance()->schedule(name, func, arg, when, weight, cbdata);
+}
+
+void
+eventAddGlobal0(const char *name, EVH * func, double when, int weight, bool cbdata)
+{
+    EventScheduler::GetInstance()->schedule(name, func, nullptr, when, weight, cbdata);
+}
+
+void
+eventAddGlobal1(const char *name, EVH * func, void *arg, double when, int weight)
+{
+    EventScheduler::GetInstance()->schedule(name, func, nullptr, when, weight, false);
+}
+
+void
+eventAddGlobal2(const char *name, EVH * func, void *arg, double when, int weight, bool cbdata)
+{
+    EventScheduler::GetInstance()->schedule(name, func, arg, when, weight, cbdata);
+}
+
+void
+eventAddIshContextual(const char *name, EVH * func, void *arg, double delta_ish, int weight)
 {
     if (delta_ish >= 3.0) {
         // Default seed is fine. We just need values random enough
@@ -125,7 +150,37 @@ eventAddIsh(const char *name, EVH * func, void *arg, double delta_ish, int weigh
         delta_ish = thirdIsh(rng);
     }
 
-    eventAdd(name, func, arg, delta_ish, weight);
+	eventAddContextual(name, func, arg, delta_ish, weight);
+}
+
+void eventAddIshGlobal0(const char *name, EVH * func, double delta_ish, int weight)
+{
+    if (delta_ish >= 3.0) {
+        // Default seed is fine. We just need values random enough
+        // relative to each other to prevent waves of synchronised activity.
+        static std::mt19937 rng;
+        auto third = (delta_ish/3.0);
+        xuniform_real_distribution<> thirdIsh(delta_ish - third, delta_ish + third);
+        delta_ish = thirdIsh(rng);
+    }
+
+    eventAddGlobal0(name, func, delta_ish, weight);
+}
+
+/* same as eventAdd but adds a random offset within +-1/3 of delta_ish */
+void
+eventAddIshGlobal2(const char *name, EVH * func, void *arg, double delta_ish, int weight)
+{
+    if (delta_ish >= 3.0) {
+        // Default seed is fine. We just need values random enough
+        // relative to each other to prevent waves of synchronised activity.
+        static std::mt19937 rng;
+        auto third = (delta_ish/3.0);
+        xuniform_real_distribution<> thirdIsh(delta_ish - third, delta_ish + third);
+        delta_ish = thirdIsh(rng);
+    }
+
+	eventAddGlobal2(name, func, arg, delta_ish, weight);
 }
 
 void

--- a/src/event.cc
+++ b/src/event.cc
@@ -95,6 +95,7 @@ ev_entry::ev_entry(char const * aName, EVH * aFunction, void * aArgument, double
     when(evWhen),
     weight(aWeight),
     cbdata(haveArg),
+    codeContext(CodeContext::Current()),
     next(NULL)
 {
 }
@@ -238,6 +239,8 @@ EventScheduler::checkEvents(int)
         /* XXX assumes event->name is static memory! */
         AsyncCall::Pointer call = asyncCall(41,5, event->name,
                                             EventDialer(event->func, event->arg, event->cbdata));
+        call->codeContext = event->codeContext;
+
         ScheduleCallHere(call);
 
         last_event_ran = event->name; // XXX: move this to AsyncCallQueue

--- a/src/event.h
+++ b/src/event.h
@@ -19,8 +19,15 @@ class StoreEntry;
 
 typedef void EVH(void *);
 
-void eventAdd(const char *name, EVH * func, void *arg, double when, int, bool cbdata=true);
-void eventAddIsh(const char *name, EVH * func, void *arg, double delta_ish, int);
+//void eventAdd(const char *name, EVH * func, void *arg, double when, int, bool cbdata=true);
+void eventAddContextual(const char *name, EVH * func, void *arg, double when, int, bool cbdata=true);
+void eventAddGlobal0(const char *name, EVH * func, double when, int weight, bool cbdata = true);
+void eventAddGlobal1(const char *name, EVH * func, void *arg, double when, int weight);
+void eventAddGlobal2(const char *name, EVH * func, void *arg, double when, int, bool cbdata=true);
+//void eventAddIsh(const char *name, EVH * func, void *arg, double delta_ish, int);
+void eventAddIshContextual(const char *name, EVH * func, void *arg, double delta_ish, int);
+void eventAddIshGlobal0(const char *name, EVH * func, double delta_ish, int);
+void eventAddIshGlobal2(const char *name, EVH * func, void *arg, double delta_ish, int);
 void eventDelete(EVH * func, void *arg);
 void eventInit(void);
 void eventFreeMemory(void);

--- a/src/event.h
+++ b/src/event.h
@@ -10,6 +10,7 @@
 #define SQUID_EVENT_H
 
 #include "AsyncEngine.h"
+#include "base/CodeContext.h"
 #include "mem/forward.h"
 
 class StoreEntry;
@@ -40,6 +41,7 @@ public:
     int weight;
     bool cbdata;
 
+    CodeContext::Pointer codeContext; ///< event creator's context
     ev_entry *next;
 };
 

--- a/src/fqdncache.cc
+++ b/src/fqdncache.cc
@@ -202,7 +202,7 @@ fqdncache_purgelru(void *)
     dlink_node *prev = NULL;
     fqdncache_entry *f;
     int removed = 0;
-    eventAdd("fqdncache_purgelru", fqdncache_purgelru, NULL, 10.0, 1);
+    eventAddGlobal0("fqdncache_purgelru", fqdncache_purgelru, 10.0, 1);
 
     for (m = lru_list.tail; m; m = prev) {
         if (fqdncacheCount() < fqdncache_low)

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -266,7 +266,7 @@ void
 Rock::Rebuild::checkpoint()
 {
     if (!done())
-        eventAdd("Rock::Rebuild", Rock::Rebuild::Steps, this, 0.01, 1, true);
+        eventAddGlobal2("Rock::Rebuild", Rock::Rebuild::Steps, this, 0.01, 1, true);
 }
 
 bool

--- a/src/fs/ufs/RebuildState.cc
+++ b/src/fs/ufs/RebuildState.cc
@@ -95,7 +95,7 @@ Fs::Ufs::RebuildState::RebuildStep(void *data)
 
     // delay storeRebuildComplete() when reconfiguring to protect storeCleanup()
     if (!rb->isDone() || reconfiguring)
-        eventAdd("storeRebuild", RebuildStep, rb, 0.01, 1);
+        eventAddGlobal2("storeRebuild", RebuildStep, rb, 0.01, 1);
     else {
         -- StoreController::store_dirs_rebuilding;
         storeRebuildComplete(&rb->counts);

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -290,7 +290,7 @@ Fs::Ufs::UFSSwapDir::init()
     rebuild();
 
     if (!started_clean_event) {
-        eventAdd("UFS storeDirClean", CleanEvent, NULL, 15.0, 1);
+        eventAddGlobal0("UFS storeDirClean", CleanEvent, 15.0, 1);
         started_clean_event = 1;
     }
 
@@ -824,7 +824,7 @@ void
 Fs::Ufs::UFSSwapDir::rebuild()
 {
     ++StoreController::store_dirs_rebuilding;
-    eventAdd("storeRebuild", Fs::Ufs::RebuildState::RebuildStep, new Fs::Ufs::RebuildState(this), 0.0, 1);
+    eventAddGlobal2("storeRebuild", Fs::Ufs::RebuildState::RebuildStep, new Fs::Ufs::RebuildState(this), 0.0, 1);
 }
 
 void
@@ -1095,7 +1095,7 @@ void
 Fs::Ufs::UFSSwapDir::CleanEvent(void *)
 {
     const int n = HandleCleanEvent();
-    eventAdd("storeDirClean", CleanEvent, NULL,
+    eventAddGlobal0("storeDirClean", CleanEvent,
              15.0 * exp(-0.25 * n), 1);
 }
 

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -529,7 +529,7 @@ netdbSaveState(void *foo)
     debugs(38, DBG_IMPORTANT, "NETDB state saved; " <<
            count << " entries, " <<
            tvSubMsec(start, current_time) << " msec" );
-    eventAddIsh("netdbSaveState", netdbSaveState, NULL, 3600.0, 1);
+    eventAddIshGlobal("netdbSaveState", netdbSaveState, 3600.0, 1);
 }
 
 static void
@@ -897,7 +897,7 @@ netdbInit(void)
 
     host_table = hash_create((HASHCMP *) strcmp, n, hash_string);
 
-    eventAddIsh("netdbSaveState", netdbSaveState, NULL, 3600.0, 1);
+    eventAddIshGlobal("netdbSaveState", netdbSaveState, 3600.0, 1);
 
     netdbReloadState();
 

--- a/src/ipc/Forwarder.cc
+++ b/src/ipc/Forwarder.cc
@@ -59,8 +59,8 @@ Ipc::Forwarder::start()
     }
 
     SendMessage(Ipc::Port::CoordinatorAddr(), message);
-    eventAdd("Ipc::Forwarder::requestTimedOut", &Forwarder::RequestTimedOut,
-             this, timeout, 0, false);
+    eventAddGlobal1("Ipc::Forwarder::requestTimedOut", &Forwarder::RequestTimedOut,
+             this, timeout, 0);
 }
 
 void

--- a/src/ipc/Inquirer.cc
+++ b/src/ipc/Inquirer.cc
@@ -78,8 +78,8 @@ Ipc::Inquirer::inquire()
     TypedMsgHdr message;
     request->pack(message);
     SendMessage(Port::MakeAddr(strandAddrLabel, kidId), message);
-    eventAdd("Ipc::Inquirer::requestTimedOut", &Inquirer::RequestTimedOut,
-             this, timeout, 0, false);
+    eventAddGlobal1("Ipc::Inquirer::requestTimedOut", &Inquirer::RequestTimedOut,
+             this, timeout, 0);
 }
 
 /// called when a strand is done writing its output

--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -140,9 +140,9 @@ void Ipc::UdsSender::startSleep()
 {
     Must(!sleeping);
     sleeping = true;
-    eventAdd("Ipc::UdsSender::DelayedRetry",
+    eventAddGlobal1("Ipc::UdsSender::DelayedRetry",
              Ipc::UdsSender::DelayedRetry,
-             new Pointer(this), 1, 0, false); // TODO: Use Fibonacci increments
+             new Pointer(this), 1, 0); // TODO: Use Fibonacci increments
 }
 
 /// stop sleeping (or do nothing if we were not)

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -354,7 +354,7 @@ ipcache_purgelru(void *)
     dlink_node *prev = NULL;
     ipcache_entry *i;
     int removed = 0;
-    eventAdd("ipcache_purgelru", ipcache_purgelru, NULL, 10.0, 1);
+    eventAddGlobal0("ipcache_purgelru", ipcache_purgelru, 10.0, 1);
 
     for (m = lru_list.tail; m; m = prev) {
         if (ipcacheCount() < ipcache_low)

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -202,7 +202,7 @@ logfileFlushEvent(void *data)
      * schedule a write if we haven't done so in the last second or two.
      */
     logfileQueueWrite(lf);
-    eventAdd("logfileFlush", logfileFlushEvent, lf, 1.0, 1);
+    eventAddGlobal2("logfileFlush", logfileFlushEvent, lf, 1.0, 1);
 }
 
 /* External code */
@@ -245,7 +245,7 @@ logfile_mod_daemon_open(Logfile * lf, const char *path, size_t, int)
     xfree(tmpbuf);
 
     /* Start the flush event */
-    eventAdd("logfileFlush", logfileFlushEvent, lf, 1.0, 1);
+    eventAddGlobal2("logfileFlush", logfileFlushEvent, lf, 1.0, 1);
 
     return 1;
 }

--- a/src/log/TcpLogger.cc
+++ b/src/log/TcpLogger.cc
@@ -273,9 +273,9 @@ Log::TcpLogger::connectDone(const CommConnectCbParams &params)
 
         if (!reconnectScheduled) {
             reconnectScheduled = true;
-            eventAdd("Log::TcpLogger::DelayedReconnect",
+            eventAddGlobal1("Log::TcpLogger::DelayedReconnect",
                      Log::TcpLogger::DelayedReconnect,
-                     new Pointer(this), 0.5, 0, false);
+                     new Pointer(this), 0.5, 0);
         }
     } else {
         if (connectFailures > 0) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -224,7 +224,7 @@ private:
         Auth::Scheme::FreeAll();
 #endif
 
-        eventAdd("SquidTerminate", &StopEventLoop, NULL, 0, 1, false);
+        eventAddGlobal0("SquidTerminate", &StopEventLoop, 0, 1, false);
     }
 
     void doShutdown(time_t wait);
@@ -323,7 +323,7 @@ SignalEngine::doShutdown(time_t wait)
     WIN32_svcstatusupdate(SERVICE_STOP_PENDING, (wait + 1) * 1000);
 #endif
 
-    eventAdd("SquidShutdown", &FinalShutdownRunners, this, (double) (wait + 1), 1, false);
+    eventAddGlobal1("SquidShutdown", &FinalShutdownRunners, this, (double) (wait + 1), 1);
 }
 
 void
@@ -907,7 +907,7 @@ mainReconfigureStart(void)
     icapLogClose();
 #endif
 
-    eventAdd("mainReconfigureFinish", &mainReconfigureFinish, NULL, 0, 1,
+    eventAddGlobal0("mainReconfigureFinish", &mainReconfigureFinish, 0, 1,
              false);
 }
 
@@ -1023,7 +1023,7 @@ mainReconfigureFinish(void *)
 
     if (Config.onoff.announce) {
         if (!eventFind(start_announce, NULL))
-            eventAdd("start_announce", start_announce, NULL, 3600.0, 1);
+        	eventAddGlobal0("start_announce", start_announce, 3600.0, 1);
     } else {
         if (eventFind(start_announce, NULL))
             eventDelete(start_announce, NULL);
@@ -1337,22 +1337,22 @@ mainInitialize(void)
     Config.ClientDelay.finalize();
 #endif
 
-    eventAdd("storeMaintain", Store::Maintain, nullptr, 1.0, 1);
+    eventAddGlobal0("storeMaintain", Store::Maintain, 1.0, 1);
 
     if (Config.onoff.announce)
-        eventAdd("start_announce", start_announce, nullptr, 3600.0, 1);
+    	eventAddGlobal0("start_announce", start_announce, 3600.0, 1);
 
-    eventAdd("ipcache_purgelru", ipcache_purgelru, nullptr, 10.0, 1);
+    eventAddGlobal0("ipcache_purgelru", ipcache_purgelru, 10.0, 1);
 
-    eventAdd("fqdncache_purgelru", fqdncache_purgelru, nullptr, 15.0, 1);
+    eventAddGlobal0("fqdncache_purgelru", fqdncache_purgelru, 15.0, 1);
 
 #if USE_XPROF_STATS
 
-    eventAdd("cpuProfiling", xprof_event, nullptr, 1.0, 1);
+    eventAddGlobal0("cpuProfiling", xprof_event, 1.0, 1);
 
 #endif
 
-    eventAdd("memPoolCleanIdlePools", Mem::CleanIdlePools, nullptr, 15.0, 1);
+    eventAddGlobal0("memPoolCleanIdlePools", Mem::CleanIdlePools, 15.0, 1);
 
     configured_once = 1;
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -1023,7 +1023,7 @@ mainReconfigureFinish(void *)
 
     if (Config.onoff.announce) {
         if (!eventFind(start_announce, NULL))
-        	eventAddGlobal0("start_announce", start_announce, 3600.0, 1);
+            eventAddGlobal0("start_announce", start_announce, 3600.0, 1);
     } else {
         if (eventFind(start_announce, NULL))
             eventDelete(start_announce, NULL);
@@ -1340,7 +1340,7 @@ mainInitialize(void)
     eventAddGlobal0("storeMaintain", Store::Maintain, 1.0, 1);
 
     if (Config.onoff.announce)
-    	eventAddGlobal0("start_announce", start_announce, 3600.0, 1);
+        eventAddGlobal0("start_announce", start_announce, 3600.0, 1);
 
     eventAddGlobal0("ipcache_purgelru", ipcache_purgelru, 10.0, 1);
 

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -400,7 +400,7 @@ void
 Mem::CleanIdlePools(void *)
 {
     MemPools::GetInstance().clean(static_cast<time_t>(clean_interval));
-    eventAdd("memPoolCleanIdlePools", CleanIdlePools, NULL, clean_interval, 1);
+    eventAddGlobal0("memPoolCleanIdlePools", CleanIdlePools, clean_interval, 1);
 }
 
 void

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -415,7 +415,7 @@ static void
 peerClearRRLoop(void *data)
 {
     peerClearRR();
-    eventAdd("peerClearRR", peerClearRRLoop, data, 5 * 60.0, 0);
+    eventAddGlobal2("peerClearRR", peerClearRRLoop, data, 5 * 60.0, 0);
 }
 
 /**
@@ -1244,7 +1244,7 @@ peerDNSConfigure(const ipcache_addrs *ia, const Dns::LookupDetails &, void *data
 #if USE_ICMP
     if (p->type != PEER_MULTICAST && IamWorkerProcess())
         if (!p->options.no_netdb_exchange)
-            eventAddIsh("netdbExchangeStart", netdbExchangeStart, p, 30.0, 1);
+            eventAddIshGlobal2("netdbExchangeStart", netdbExchangeStart, p, 30.0, 1);
 #endif
 
     if (p->standby.mgr.valid())
@@ -1261,7 +1261,7 @@ peerRefreshDNS(void *data)
 
     if (!data && 0 == stat5minClientRequests()) {
         /* no recent client traffic, wait a bit */
-        eventAddIsh("peerRefreshDNS", peerRefreshDNS, NULL, 180.0, 1);
+        eventAddIshGlobal0("peerRefreshDNS", peerRefreshDNS, 180.0, 1);
         return;
     }
 
@@ -1269,7 +1269,7 @@ peerRefreshDNS(void *data)
         ipcache_nbgethostbyname(p->host, peerDNSConfigure, p);
 
     /* Reconfigure the peers every hour */
-    eventAddIsh("peerRefreshDNS", peerRefreshDNS, NULL, 3600.0, 1);
+    eventAddIshGlobal0("peerRefreshDNS", peerRefreshDNS, 3600.0, 1);
 }
 
 static void
@@ -1382,7 +1382,7 @@ peerCountMcastPeersSchedule(CachePeer * p, time_t when)
     if (p->mcast.flags.count_event_pending)
         return;
 
-    eventAdd("peerCountMcastPeersStart",
+    eventAddGlobal2("peerCountMcastPeersStart",
              peerCountMcastPeersStart,
              p,
              (double) when, 1);
@@ -1426,7 +1426,7 @@ peerCountMcastPeersStart(void *data)
     icpCreateAndSend(ICP_QUERY, 0, url, reqnum, 0,
                      icpOutgoingConn->fd, p->in_addr, psstate->al);
     fake->ping_status = PING_WAITING;
-    eventAdd("peerCountMcastPeersDone",
+    eventAddGlobal2("peerCountMcastPeersDone",
              peerCountMcastPeersDone,
              psstate,
              Config.Timeout.mcast_icp_query / 1000.0, 1);

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -231,7 +231,7 @@ peerDigestNewDelay(const StoreEntry * e)
 static void
 peerDigestSetCheck(PeerDigest * pd, time_t delay)
 {
-    eventAdd("peerDigestCheck", peerDigestCheck, pd, (double) delay, 1);
+    eventAddGlobal2("peerDigestCheck", peerDigestCheck, pd, (double) delay, 1);
     pd->times.next_check = squid_curtime + delay;
     debugs(72, 3, "peerDigestSetCheck: will check peer " << pd->host << " in " << delay << " secs");
 }

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -623,7 +623,7 @@ PeerSelector::selectSomeNeighbor()
 
             if (ping.n_replies_expected > 0) {
                 entry->ping_status = PING_WAITING;
-                eventAdd("PeerSelector::HandlePingTimeout",
+                eventAddContextual("PeerSelector::HandlePingTimeout",
                          HandlePingTimeout,
                          this,
                          0.001 * ping.timeout,

--- a/src/send-announce.cc
+++ b/src/send-announce.cc
@@ -35,7 +35,7 @@ start_announce(void *)
 
     ipcache_nbgethostbyname(Config.Announce.host, send_announce, NULL);
 
-    eventAdd("send_announce", start_announce, NULL, (double) Config.Announce.period, 1);
+    eventAddGlobal0("send_announce", start_announce, (double) Config.Announce.period, 1);
 }
 
 static void

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -362,7 +362,7 @@ statObjects(void *data)
         return;
     } else if (state->sentry->checkDeferRead(-1)) {
         state->sentry->flush();
-        eventAdd("statObjects", statObjects, state, 0.1, 1);
+        eventAddGlobal2("statObjects", statObjects, state, 0.1, 1);
         return;
     }
 
@@ -385,7 +385,7 @@ statObjects(void *data)
         state->sentry->append(mb.buf, mb.size);
     mb.clean();
 
-    eventAdd("statObjects", statObjects, state, 0.0, 1);
+    eventAddGlobal2("statObjects", statObjects, state, 0.0, 1);
 }
 
 static void
@@ -398,7 +398,7 @@ statObjectsStart(StoreEntry * sentry, STOBJFLT * filter)
     sentry->lock("statObjects");
     state->theSearch = Store::Root().search();
 
-    eventAdd("statObjects", statObjects, state, 0.0, 1);
+    eventAddGlobal2("statObjects", statObjects, state, 0.0, 1);
 }
 
 static void
@@ -1268,7 +1268,7 @@ statInit(void)
 
     statCountersInit(&statCounter);
 
-    eventAdd("statAvgTick", statAvgTick, NULL, (double) COUNT_INTERVAL, 1);
+    eventAddGlobal0("statAvgTick", statAvgTick, (double) COUNT_INTERVAL, 1);
 
     ClientActiveRequests.head = NULL;
 
@@ -1281,7 +1281,7 @@ static void
 statAvgTick(void *)
 {
     struct rusage rusage;
-    eventAdd("statAvgTick", statAvgTick, NULL, (double) COUNT_INTERVAL, 1);
+    eventAddGlobal0("statAvgTick", statAvgTick, (double) COUNT_INTERVAL, 1);
     squid_getrusage(&rusage);
     statCounter.page_faults = rusage_pagefaults(&rusage);
     statCounter.cputime = rusage_cputime(&rusage);

--- a/src/store.cc
+++ b/src/store.cc
@@ -1225,7 +1225,7 @@ storeLateRelease(void *)
     static int n = 0;
 
     if (Store::Controller::store_dirs_rebuilding) {
-    	eventAddGlobal0("storeLateRelease", storeLateRelease, 1.0, 1);
+        eventAddGlobal0("storeLateRelease", storeLateRelease, 1.0, 1);
         return;
     }
 

--- a/src/store.cc
+++ b/src/store.cc
@@ -1136,7 +1136,7 @@ StoreEntry::abort()
     if (mem_obj->abort.callback) {
         if (!cbdataReferenceValid(mem_obj->abort.data))
             debugs(20, DBG_IMPORTANT,HERE << "queueing event when abort.data is not valid");
-        eventAdd("mem_obj->abort.callback",
+        eventAddContextual("mem_obj->abort.callback",
                  mem_obj->abort.callback,
                  mem_obj->abort.data,
                  0.0,
@@ -1179,7 +1179,7 @@ Store::Maintain(void *)
     Store::Root().maintain();
 
     /* Reregister a maintain event .. */
-    eventAdd("MaintainSwapSpace", Maintain, NULL, 1.0, 1);
+    eventAddGlobal0("MaintainSwapSpace", Maintain, 1.0, 1);
 
 }
 
@@ -1225,7 +1225,7 @@ storeLateRelease(void *)
     static int n = 0;
 
     if (Store::Controller::store_dirs_rebuilding) {
-        eventAdd("storeLateRelease", storeLateRelease, NULL, 1.0, 1);
+    	eventAddGlobal0("storeLateRelease", storeLateRelease, 1.0, 1);
         return;
     }
 
@@ -1243,7 +1243,7 @@ storeLateRelease(void *)
         ++n;
     }
 
-    eventAdd("storeLateRelease", storeLateRelease, NULL, 0.0, 1);
+    eventAddGlobal0("storeLateRelease", storeLateRelease, 0.0, 1);
 }
 
 /// whether the base response has all the body bytes we expect
@@ -1308,7 +1308,7 @@ storeInit(void)
     mem_policy = createRemovalPolicy(Config.memPolicy);
     storeDigestInit();
     storeLogOpen();
-    eventAdd("storeLateRelease", storeLateRelease, NULL, 1.0, 1);
+    eventAddGlobal0("storeLateRelease", storeLateRelease, 1.0, 1);
     Store::Root().init();
     storeRebuildStart();
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -331,7 +331,7 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
     if (sc->flags.store_copying) {
         sc->flags.copy_event_pending = true;
         debugs(90, 3, "storeClientCopy2: Queueing storeClientCopyEvent()");
-        eventAdd("storeClientCopyEvent", storeClientCopyEvent, sc, 0.0, 0);
+        eventAddContextual("storeClientCopyEvent", storeClientCopyEvent, sc, 0.0, 0);
         return;
     }
 

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -360,7 +360,7 @@ storeDigestRebuildResume(void)
 
     sd_stats = StoreDigestStats();
 
-    eventAdd("storeDigestRebuildStep", storeDigestRebuildStep, NULL, 0.0, 1);
+    eventAddGlobal0("storeDigestRebuildStep", storeDigestRebuildStep, 0.0, 1);
 }
 
 /* finishes swap out sequence for the digest; schedules next rebuild */
@@ -371,7 +371,7 @@ storeDigestRebuildFinish(void)
     sd_state.rebuild_lock = 0;
     ++sd_state.rebuild_count;
     debugs(71, 2, "storeDigestRebuildFinish: done.");
-    eventAdd("storeDigestRebuildStart", storeDigestRebuildStart, NULL, (double)
+    eventAddGlobal0("storeDigestRebuildStart", storeDigestRebuildStart, (double)
              Config.digest.rebuild_period, 1);
     /* resume pending Rewrite if any */
 
@@ -397,7 +397,7 @@ storeDigestRebuildStep(void *datanotused)
     if (sd_state.theSearch->isDone())
         storeDigestRebuildFinish();
     else
-        eventAdd("storeDigestRebuildStep", storeDigestRebuildStep, NULL, 0.0, 1);
+        eventAddGlobal0("storeDigestRebuildStep", storeDigestRebuildStep, 0.0, 1);
 }
 
 /* starts swap out sequence for the digest */
@@ -466,7 +466,7 @@ storeDigestRewriteResume(void)
     e->replaceHttpReply(rep);
     storeDigestCBlockSwapOut(e);
     e->flush();
-    eventAdd("storeDigestSwapOutStep", storeDigestSwapOutStep, sd_state.rewrite_lock, 0.0, 1, false);
+    eventAddGlobal1("storeDigestSwapOutStep", storeDigestSwapOutStep, sd_state.rewrite_lock, 0.0, 1);
 }
 
 /* finishes swap out sequence for the digest; schedules next rewrite */
@@ -482,7 +482,7 @@ storeDigestRewriteFinish(StoreEntry * e)
     e->mem_obj->unlinkRequest();
     sd_state.rewrite_lock = NULL;
     ++sd_state.rewrite_count;
-    eventAdd("storeDigestRewriteStart", storeDigestRewriteStart, NULL, (double)
+    eventAddGlobal0("storeDigestRewriteStart", storeDigestRewriteStart, (double)
              Config.digest.rewrite_period, 1);
     /* resume pending Rebuild if any */
 
@@ -515,7 +515,7 @@ storeDigestSwapOutStep(void *data)
     if (static_cast<uint32_t>(sd_state.rewrite_offset) >= store_digest->mask_size)
         storeDigestRewriteFinish(e);
     else
-        eventAdd("storeDigestSwapOutStep", storeDigestSwapOutStep, data, 0.0, 1, false);
+        eventAddGlobal1("storeDigestSwapOutStep", storeDigestSwapOutStep, data, 0.0, 1);
 }
 
 static void

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -114,7 +114,7 @@ storeCleanup(void *)
 
         currentSearch = NULL;
     } else
-    	eventAddGlobal0("storeCleanup", storeCleanup, 0.0, 1);
+        eventAddGlobal0("storeCleanup", storeCleanup, 0.0, 1);
 }
 
 /* meta data recreated from disk image in swap directory */

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -114,7 +114,7 @@ storeCleanup(void *)
 
         currentSearch = NULL;
     } else
-        eventAdd("storeCleanup", storeCleanup, NULL, 0.0, 1);
+    	eventAddGlobal0("storeCleanup", storeCleanup, 0.0, 1);
 }
 
 /* meta data recreated from disk image in swap directory */
@@ -157,7 +157,7 @@ storeRebuildComplete(StoreRebuildData *dc)
            ((double) counts.objcount / (dt > 0.0 ? dt : 1.0)) << " objects/sec).");
     debugs(20, DBG_IMPORTANT, "Beginning Validation Procedure");
 
-    eventAdd("storeCleanup", storeCleanup, NULL, 0.0, 1);
+    eventAddGlobal0("storeCleanup", storeCleanup, 0.0, 1);
 
     xfree(RebuildProgress);
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -719,7 +719,7 @@ TunnelStateData::copyRead(Connection &from, IOCB *completion)
     int bw = from.bytesWanted(1, SQUID_TCP_SO_RCVBUF);
     if (bw == 1 && ++from.delayedLoops < 10) {
         from.readPending = this;
-        eventAdd("tunnelDelayedServerRead", from.readPendingFunc, from.readPending, 0.3, true);
+        eventAddContextual("tunnelDelayedServerRead", from.readPendingFunc, from.readPending, 0.3, true);
         return;
     }
 

--- a/src/wccp.cc
+++ b/src/wccp.cc
@@ -101,7 +101,7 @@ wccpInit(void)
 
     if (!Config.Wccp.router.isAnyAddr())
         if (!eventFind(wccpHereIam, NULL))
-            eventAdd("wccpHereIam", wccpHereIam, NULL, 5.0, 1);
+        	eventAddGlobal0("wccpHereIam", wccpHereIam, 5.0, 1);
 }
 
 void
@@ -287,7 +287,7 @@ wccpHereIam(void *)
     }
 
     if (!eventFind(wccpHereIam, NULL))
-        eventAdd("wccpHereIam", wccpHereIam, NULL, interval, 1);
+    	eventAddGlobal0("wccpHereIam", wccpHereIam, interval, 1);
 }
 
 static void

--- a/src/wccp.cc
+++ b/src/wccp.cc
@@ -101,7 +101,7 @@ wccpInit(void)
 
     if (!Config.Wccp.router.isAnyAddr())
         if (!eventFind(wccpHereIam, NULL))
-        	eventAddGlobal0("wccpHereIam", wccpHereIam, 5.0, 1);
+            eventAddGlobal0("wccpHereIam", wccpHereIam, 5.0, 1);
 }
 
 void
@@ -287,7 +287,7 @@ wccpHereIam(void *)
     }
 
     if (!eventFind(wccpHereIam, NULL))
-    	eventAddGlobal0("wccpHereIam", wccpHereIam, interval, 1);
+        eventAddGlobal0("wccpHereIam", wccpHereIam, interval, 1);
 }
 
 static void

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -936,7 +936,7 @@ wccp2Init(void)
         debugs(80,3,"wccp2Init: scheduled 'HERE_I_AM' message to " << wccp2_numrouters << "routers.");
         if (wccp2_numrouters) {
             if (!eventFind(wccp2HereIam, NULL)) {
-            	eventAddGlobal0("wccp2HereIam", wccp2HereIam, 1, 1);
+                eventAddGlobal0("wccp2HereIam", wccp2HereIam, 1, 1);
             } else
                 debugs(80,3,"wccp2Init: skip duplicate 'HERE_I_AM'.");
         }
@@ -1537,7 +1537,7 @@ wccp2HereIam(void *)
 
     /* Wait if store dirs are rebuilding */
     if (StoreController::store_dirs_rebuilding && Config.Wccp2.rebuildwait) {
-    	eventAddGlobal0("wccp2HereIam", wccp2HereIam, 1.0, 1);
+        eventAddGlobal0("wccp2HereIam", wccp2HereIam, 1.0, 1);
         return;
     }
 

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -936,7 +936,7 @@ wccp2Init(void)
         debugs(80,3,"wccp2Init: scheduled 'HERE_I_AM' message to " << wccp2_numrouters << "routers.");
         if (wccp2_numrouters) {
             if (!eventFind(wccp2HereIam, NULL)) {
-                eventAdd("wccp2HereIam", wccp2HereIam, NULL, 1, 1);
+            	eventAddGlobal0("wccp2HereIam", wccp2HereIam, 1, 1);
             } else
                 debugs(80,3,"wccp2Init: skip duplicate 'HERE_I_AM'.");
         }
@@ -1505,7 +1505,7 @@ wccp2HandleUdp(int sock, void *)
             debugs(80, 4, "Change detected - queueing up new assignment");
             router_list_ptr->member_change = ntohl(router_view_header->change_number);
             eventDelete(wccp2AssignBuckets, NULL);
-            eventAdd("wccp2AssignBuckets", wccp2AssignBuckets, NULL, 15.0, 1);
+            eventAddGlobal0("wccp2AssignBuckets", wccp2AssignBuckets, 15.0, 1);
         } else {
             debugs(80, 5, "Change not detected (" << ntohl(router_view_header->change_number) << " = " << router_list_ptr->member_change << ")");
         }
@@ -1537,7 +1537,7 @@ wccp2HereIam(void *)
 
     /* Wait if store dirs are rebuilding */
     if (StoreController::store_dirs_rebuilding && Config.Wccp2.rebuildwait) {
-        eventAdd("wccp2HereIam", wccp2HereIam, NULL, 1.0, 1);
+    	eventAddGlobal0("wccp2HereIam", wccp2HereIam, 1.0, 1);
         return;
     }
 
@@ -1597,7 +1597,7 @@ wccp2HereIam(void *)
         service_list_ptr = service_list_ptr->next;
     }
 
-    eventAdd("wccp2HereIam", wccp2HereIam, NULL, 10.0, 1);
+    eventAddGlobal0("wccp2HereIam", wccp2HereIam, 10.0, 1);
 }
 
 static void


### PR DESCRIPTION
The goal of this PR is to classify eventAdd() calls with respect to code context preservation. It is meant to split all eventAdd() and eventAddIsh() calls into four categories:

1. eventAddGlobal0: event scheduler supplies no callback data at all
2. eventAddGlobal1: event scheduler supplies cbdata-unprotected callback data
3. eventAddGlobal2: event scheduler supplies transaction-agnostic but cbdata-protected calback data
4. eventAddContextual: event scheduler supplies transaction-specific (and, hence, cbdata-protected) callback data

This PR is not meant to be committed (and has not been evaluated for the correctness of the new/renamed interfaces).