### PR TITLE
Preserve caller context in MemObject::abort callbacks

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -105,9 +105,13 @@ private:
 };
 
 void
-FwdState::abort(void* d)
+FwdState::Abort(CbdataParent *param)
 {
-    FwdState* fwd = (FwdState*)d;
+    auto fwd = dynamic_cast<FwdState *>(param);
+    assert(fwd);
+    if (!cbdataReferenceValid(fwd))
+        return;
+
     Pointer tmp = fwd; // Grab a temporary pointer to keep the object alive during our scope.
 
     if (Comm::IsConnOpen(fwd->serverConnection())) {
@@ -166,7 +170,7 @@ void FwdState::start(Pointer aSelf)
     // Ftp::Relay needs to preserve control connection on data aborts
     // so it registers its own abort handler that calls ours when needed.
     if (!request->flags.ftpNative)
-        entry->registerAbort(FwdState::abort, this);
+        entry->registerAbort(FwdState::Abort, this);
 
     // just in case; should already be initialized to false
     request->flags.pinned = false;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -166,7 +166,7 @@ void FwdState::start(Pointer aSelf)
     // so it registers its own abort handler that calls ours when needed.
     if (!request->flags.ftpNative) {
         AsyncCall::Pointer call = asyncCall(17, 4, "FwdState::Abort", cbdataDialer(&FwdState::Abort, this));
-        entry->registerAbort(call);
+        entry->registerAbortCallback(call);
     }
 
     // just in case; should already be initialized to false

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -107,9 +107,6 @@ private:
 void
 FwdState::Abort(FwdState *fwd)
 {
-    if (!cbdataReferenceValid(fwd))
-        return;
-
     Pointer tmp = fwd; // Grab a temporary pointer to keep the object alive during our scope.
 
     if (Comm::IsConnOpen(fwd->serverConnection())) {

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -105,7 +105,7 @@ private:
 };
 
 void
-FwdState::Abort(FwdState *fwd)
+FwdState::HandleStoreAbort(FwdState *fwd)
 {
     Pointer tmp = fwd; // Grab a temporary pointer to keep the object alive during our scope.
 
@@ -165,7 +165,7 @@ void FwdState::start(Pointer aSelf)
     // Ftp::Relay needs to preserve control connection on data aborts
     // so it registers its own abort handler that calls ours when needed.
     if (!request->flags.ftpNative) {
-        AsyncCall::Pointer call = asyncCall(17, 4, "FwdState::Abort", cbdataDialer(&FwdState::Abort, this));
+        AsyncCall::Pointer call = asyncCall(17, 4, "FwdState::Abort", cbdataDialer(&FwdState::HandleStoreAbort, this));
         entry->registerAbortCallback(call);
     }
 
@@ -306,7 +306,7 @@ FwdState::~FwdState()
 
     delete err;
 
-    entry->unregisterAbort("FwdState object destructed");
+    entry->unregisterAbortCallback("FwdState object destructed");
 
     entry->unlock("FwdState");
 

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -165,7 +165,8 @@ public:
     HttpRequest *request;
     AccessLogEntryPointer al; ///< info for the future access.log entry
 
-    static void abort(void*);
+    /// called by Store if the entry is no longer usable
+    static void Abort(CbdataParent *);
 
 private:
     Pointer self;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -166,7 +166,7 @@ public:
     AccessLogEntryPointer al; ///< info for the future access.log entry
 
     /// called by Store if the entry is no longer usable
-    static void Abort(CbdataParent *);
+    static void Abort(FwdState *);
 
 private:
     Pointer self;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -166,7 +166,7 @@ public:
     AccessLogEntryPointer al; ///< info for the future access.log entry
 
     /// called by Store if the entry is no longer usable
-    static void Abort(FwdState *);
+    static void HandleStoreAbort(FwdState *);
 
 private:
     Pointer self;

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -25,7 +25,7 @@
 #endif
 
 typedef void STMCB (void *data, StoreIOBuffer wroteBuffer);
-typedef void STABH(void *);
+typedef void STABH(CbdataParent *);
 
 class store_client;
 class PeerSelector;
@@ -195,7 +195,7 @@ public:
     struct abort_ {
         abort_() { callback = nullptr; }
         STABH *callback;
-        void *data = nullptr;
+        CbdataParent *data = nullptr;
     } abort;
     RemovalPolicyNode repl;
     int id = 0;

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -25,7 +25,6 @@
 #endif
 
 typedef void STMCB (void *data, StoreIOBuffer wroteBuffer);
-typedef void STABH(CbdataParent *);
 
 class store_client;
 class PeerSelector;

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -192,11 +192,7 @@ public:
     IRCB *ping_reply_callback;
     PeerSelector *ircb_data = nullptr;
 
-    struct abort_ {
-        abort_() { callback = nullptr; }
-        STABH *callback;
-        CbdataParent *data = nullptr;
-    } abort;
+    AsyncCall::Pointer abortCallback;
     RemovalPolicyNode repl;
     int id = 0;
     int64_t object_sz = -1;

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -191,6 +191,7 @@ public:
     IRCB *ping_reply_callback;
     PeerSelector *ircb_data = nullptr;
 
+    /// used for notifying StoreEntry writers about 3rd-party initiated aborts
     AsyncCall::Pointer abortCallback;
     RemovalPolicyNode repl;
     int id = 0;

--- a/src/Store.h
+++ b/src/Store.h
@@ -150,7 +150,8 @@ public:
     void dump(int debug_lvl) const;
     void hashDelete();
     void hashInsert(const cache_key *);
-    void registerAbort(const AsyncCall::Pointer &);
+    /// notify the StoreEntry writer of a 3rd-party initiated StoreEntry abort
+    void registerAbortCallback(const AsyncCall::Pointer &);
     void reset();
     void setMemStatus(mem_status_t);
     bool timestampsSet();

--- a/src/Store.h
+++ b/src/Store.h
@@ -150,11 +150,11 @@ public:
     void dump(int debug_lvl) const;
     void hashDelete();
     void hashInsert(const cache_key *);
-    void registerAbort(STABH *cb, CbdataParent *param);
+    void registerAbort(const AsyncCall::Pointer &);
     void reset();
     void setMemStatus(mem_status_t);
     bool timestampsSet();
-    void unregisterAbort();
+    void unregisterAbort(const char *reason);
     void destroyMemObject();
     int checkTooSmall();
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -150,7 +150,7 @@ public:
     void dump(int debug_lvl) const;
     void hashDelete();
     void hashInsert(const cache_key *);
-    void registerAbort(STABH * cb, void *);
+    void registerAbort(STABH *cb, CbdataParent *param);
     void reset();
     void setMemStatus(mem_status_t);
     bool timestampsSet();

--- a/src/Store.h
+++ b/src/Store.h
@@ -155,7 +155,10 @@ public:
     void reset();
     void setMemStatus(mem_status_t);
     bool timestampsSet();
-    void unregisterAbort(const char *reason);
+    /// Avoid notifying anybody about a 3rd-party initiated StoreEntry abort.
+    /// Calling this method does not cancel the already queued notification.
+    /// TODO: Refactor to represent the end of (shared) ownership by our writer.
+    void unregisterAbortCallback(const char *reason);
     void destroyMemObject();
     int checkTooSmall();
 

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -94,8 +94,8 @@ protected:
 
     /// Inform Ftp::Server that we are done if originWaitInProgress
     void stopOriginWait(int code);
-
-    static void abort(void *d); // TODO: Capitalize this and FwdState::abort().
+    /// called by Store if the entry is no longer usable
+    static void Abort(CbdataParent *);
 
     bool forwardingCompleted; ///< completeForwarding() has been called
 
@@ -162,7 +162,7 @@ Ftp::Relay::Relay(FwdState *const fwdState):
     // uncachable, unfortunately. This prevents "found KEY_PRIVATE" WARNINGs.
     entry->releaseRequest();
     // TODO: Convert registerAbort() to use AsyncCall
-    entry->registerAbort(Ftp::Relay::abort, this);
+    entry->registerAbort(Ftp::Relay::Abort, this);
 }
 
 Ftp::Relay::~Relay()
@@ -784,9 +784,10 @@ Ftp::Relay::stopOriginWait(int code)
 }
 
 void
-Ftp::Relay::abort(void *d)
+Ftp::Relay::Abort(CbdataParent *d)
 {
-    Ftp::Relay *ftpClient = (Ftp::Relay *)d;
+    auto ftpClient = dynamic_cast<Ftp::Relay *>(d);
+    assert(ftpClient);
     debugs(9, 2, "Client Data connection closed!");
     if (!cbdataReferenceValid(ftpClient))
         return;

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -789,8 +789,6 @@ void
 Ftp::Relay::Abort(Relay *ftpClient)
 {
     debugs(9, 2, "Client Data connection closed!");
-    if (!cbdataReferenceValid(ftpClient))
-        return;
     if (Comm::IsConnOpen(ftpClient->data.conn))
         ftpClient->dataComplete();
 }

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -163,7 +163,7 @@ Ftp::Relay::Relay(FwdState *const fwdState):
     // uncachable, unfortunately. This prevents "found KEY_PRIVATE" WARNINGs.
     entry->releaseRequest();
     AsyncCall::Pointer call = asyncCall(9, 4, "Ftp::Relay::Abort", cbdataDialer(&Relay::Abort, this));
-    entry->registerAbort(call);
+    entry->registerAbortCallback(call);
 }
 
 Ftp::Relay::~Relay()

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -96,7 +96,7 @@ protected:
     /// Inform Ftp::Server that we are done if originWaitInProgress
     void stopOriginWait(int code);
     /// called by Store if the entry is no longer usable
-    static void Abort(Relay *);
+    static void HandleStoreAbort(Relay *);
 
     bool forwardingCompleted; ///< completeForwarding() has been called
 
@@ -162,13 +162,17 @@ Ftp::Relay::Relay(FwdState *const fwdState):
     // Nothing we can do at request creation time can mark the response as
     // uncachable, unfortunately. This prevents "found KEY_PRIVATE" WARNINGs.
     entry->releaseRequest();
-    AsyncCall::Pointer call = asyncCall(9, 4, "Ftp::Relay::Abort", cbdataDialer(&Relay::Abort, this));
+    AsyncCall::Pointer call = asyncCall(9, 4, "Ftp::Relay::Abort", cbdataDialer(&Relay::HandleStoreAbort, this));
     entry->registerAbortCallback(call);
 }
 
 Ftp::Relay::~Relay()
 {
-    entry->unregisterAbort("Ftp::Relay object destructed");
+    entry->unregisterAbortCallback("Ftp::Relay object destructed");
+    // Client, our parent, calls entry->unlock().
+    // Client does not currently un/registerAbortCallback() because
+    // FwdState does that for other Client kids; \see FwdState::start().
+
     closeServer(); // TODO: move to clients/Client.cc?
     if (savedReply.message)
         wordlistDestroy(&savedReply.message);
@@ -786,7 +790,7 @@ Ftp::Relay::stopOriginWait(int code)
 }
 
 void
-Ftp::Relay::Abort(Relay *ftpClient)
+Ftp::Relay::HandleStoreAbort(Relay *ftpClient)
 {
     debugs(9, 2, "Client Data connection closed!");
     if (Comm::IsConnOpen(ftpClient->data.conn))

--- a/src/mgr/StoreToCommWriter.cc
+++ b/src/mgr/StoreToCommWriter.cc
@@ -158,9 +158,12 @@ Mgr::StoreToCommWriter::doneAll() const
 }
 
 void
-Mgr::StoreToCommWriter::Abort(void* param)
+Mgr::StoreToCommWriter::Abort(CbdataParent *param)
 {
-    StoreToCommWriter* mgrWriter = static_cast<StoreToCommWriter*>(param);
+    auto mgrWriter = dynamic_cast<StoreToCommWriter *>(param);
+    assert(mgrWriter);
+    if (!cbdataReferenceValid(mgrWriter))
+        return;
     if (Comm::IsConnOpen(mgrWriter->clientConnection))
         mgrWriter->clientConnection->close();
 }

--- a/src/mgr/StoreToCommWriter.cc
+++ b/src/mgr/StoreToCommWriter.cc
@@ -59,7 +59,7 @@ Mgr::StoreToCommWriter::start()
     Must(Comm::IsConnOpen(clientConnection));
     Must(entry != NULL);
     AsyncCall::Pointer call = asyncCall(16, 4, "StoreToCommWriter::Abort", cbdataDialer(&StoreToCommWriter::Abort, this));
-    entry->registerAbort(call);
+    entry->registerAbortCallback(call);
     sc = storeClientListAdd(entry, this);
     Must(sc != NULL);
 
@@ -144,7 +144,7 @@ Mgr::StoreToCommWriter::swanSong()
             storeUnregister(sc, entry, this);
             sc = NULL;
         }
-        entry->unregisterAbort("StoreToCommWriter object destructed");
+        entry->unregisterAbort("StoreToCommWriter done");
         entry->unlock("Mgr::StoreToCommWriter::swanSong");
         entry = NULL;
     }

--- a/src/mgr/StoreToCommWriter.cc
+++ b/src/mgr/StoreToCommWriter.cc
@@ -162,8 +162,6 @@ Mgr::StoreToCommWriter::doneAll() const
 void
 Mgr::StoreToCommWriter::Abort(StoreToCommWriter *mgrWriter)
 {
-    if (!cbdataReferenceValid(mgrWriter))
-        return;
     if (Comm::IsConnOpen(mgrWriter->clientConnection))
         mgrWriter->clientConnection->close();
 }

--- a/src/mgr/StoreToCommWriter.cc
+++ b/src/mgr/StoreToCommWriter.cc
@@ -58,7 +58,7 @@ Mgr::StoreToCommWriter::start()
     debugs(16, 6, HERE);
     Must(Comm::IsConnOpen(clientConnection));
     Must(entry != NULL);
-    AsyncCall::Pointer call = asyncCall(16, 4, "StoreToCommWriter::Abort", cbdataDialer(&StoreToCommWriter::Abort, this));
+    AsyncCall::Pointer call = asyncCall(16, 4, "StoreToCommWriter::Abort", cbdataDialer(&StoreToCommWriter::HandleStoreAbort, this));
     entry->registerAbortCallback(call);
     sc = storeClientListAdd(entry, this);
     Must(sc != NULL);
@@ -144,7 +144,7 @@ Mgr::StoreToCommWriter::swanSong()
             storeUnregister(sc, entry, this);
             sc = NULL;
         }
-        entry->unregisterAbort("StoreToCommWriter done");
+        entry->unregisterAbortCallback("StoreToCommWriter done");
         entry->unlock("Mgr::StoreToCommWriter::swanSong");
         entry = NULL;
     }
@@ -160,7 +160,7 @@ Mgr::StoreToCommWriter::doneAll() const
 }
 
 void
-Mgr::StoreToCommWriter::Abort(StoreToCommWriter *mgrWriter)
+Mgr::StoreToCommWriter::HandleStoreAbort(StoreToCommWriter *mgrWriter)
 {
     if (Comm::IsConnOpen(mgrWriter->clientConnection))
         mgrWriter->clientConnection->close();

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -45,7 +45,7 @@ protected:
     void noteStoreCopied(StoreIOBuffer ioBuf);
     static void NoteStoreCopied(void* data, StoreIOBuffer ioBuf);
     /// called by Store if the entry is no longer usable
-    static void Abort(void* param);
+    static void Abort(CbdataParent *param);
 
     /// tell Comm to write action results
     void scheduleCommWrite(const StoreIOBuffer& ioBuf);

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -45,7 +45,7 @@ protected:
     void noteStoreCopied(StoreIOBuffer ioBuf);
     static void NoteStoreCopied(void* data, StoreIOBuffer ioBuf);
     /// called by Store if the entry is no longer usable
-    static void Abort(CbdataParent *param);
+    static void Abort(StoreToCommWriter *param);
 
     /// tell Comm to write action results
     void scheduleCommWrite(const StoreIOBuffer& ioBuf);

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -45,7 +45,7 @@ protected:
     void noteStoreCopied(StoreIOBuffer ioBuf);
     static void NoteStoreCopied(void* data, StoreIOBuffer ioBuf);
     /// called by Store if the entry is no longer usable
-    static void Abort(StoreToCommWriter *param);
+    static void HandleStoreAbort(StoreToCommWriter *param);
 
     /// tell Comm to write action results
     void scheduleCommWrite(const StoreIOBuffer& ioBuf);

--- a/src/store.cc
+++ b/src/store.cc
@@ -1130,9 +1130,10 @@ StoreEntry::abort()
 
     /* Notify the server side */
 
-    if (mem_obj->abortCallback && !mem_obj->abortCallback->canceled())
+    if (mem_obj->abortCallback) {
         ScheduleCallHere(mem_obj->abortCallback);
-    mem_obj->abortCallback = nullptr;
+        mem_obj->abortCallback = nullptr;
+    }
 
     /* XXX Should we reverse these two, so that there is no
      * unneeded disk swapping triggered?
@@ -1515,7 +1516,7 @@ StoreEntry::updateOnNotModified(const StoreEntry &e304)
 }
 
 void
-StoreEntry::registerAbort(const AsyncCall::Pointer &handler)
+StoreEntry::registerAbortCallback(const AsyncCall::Pointer &handler)
 {
     assert(mem_obj);
     assert(!mem_obj->abortCallback);

--- a/src/store.cc
+++ b/src/store.cc
@@ -1524,7 +1524,7 @@ StoreEntry::registerAbortCallback(const AsyncCall::Pointer &handler)
 }
 
 void
-StoreEntry::unregisterAbort(const char *reason)
+StoreEntry::unregisterAbortCallback(const char *reason)
 {
     assert(mem_obj);
     if (mem_obj->abortCallback) {

--- a/src/tests/stub_libmgr.cc
+++ b/src/tests/stub_libmgr.cc
@@ -233,7 +233,7 @@ bool Mgr::StoreToCommWriter::doneAll() const STUB_RETVAL(false)
 void Mgr::StoreToCommWriter::scheduleStoreCopy() STUB
 void Mgr::StoreToCommWriter::noteStoreCopied(StoreIOBuffer ioBuf) STUB
 void Mgr::StoreToCommWriter::NoteStoreCopied(void* data, StoreIOBuffer ioBuf) STUB
-void Mgr::StoreToCommWriter::Abort(void* param) STUB
+void Mgr::StoreToCommWriter::HandleStoreAbort(void* param) STUB
 void Mgr::StoreToCommWriter::scheduleCommWrite(const StoreIOBuffer& ioBuf) STUB
 void Mgr::StoreToCommWriter::noteCommWrote(const CommIoCbParams& params) STUB
 void Mgr::StoreToCommWriter::noteCommClosed(const CommCloseCbParams& params) STUB

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -57,7 +57,7 @@ void StoreEntry::ensureMemObject(const char *, const char *, const HttpRequestMe
 void StoreEntry::dump(int debug_lvl) const STUB
 void StoreEntry::hashDelete() STUB
 void StoreEntry::hashInsert(const cache_key *) STUB
-void StoreEntry::registerAbort(STABH * cb, void *) STUB
+void StoreEntry::registerAbortCallback(const AsyncCall::Pointer &) STUB
 void StoreEntry::reset() STUB
 void StoreEntry::setMemStatus(mem_status_t) STUB
 bool StoreEntry::timestampsSet() STUB_RETVAL(false)

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -61,7 +61,7 @@ void StoreEntry::registerAbortCallback(const AsyncCall::Pointer &) STUB
 void StoreEntry::reset() STUB
 void StoreEntry::setMemStatus(mem_status_t) STUB
 bool StoreEntry::timestampsSet() STUB_RETVAL(false)
-void StoreEntry::unregisterAbort() STUB
+void StoreEntry::unregisterAbortCallback() STUB
 void StoreEntry::destroyMemObject() STUB
 int StoreEntry::checkTooSmall() STUB_RETVAL(0)
 void StoreEntry::delayAwareRead(const Comm::ConnectionPointer&, char *buf, int len, AsyncCall::Pointer callback) STUB


### PR DESCRIPTION
Store abused time-based event API to deliver abort notifications, losing
transaction context in the process. Further refactoring may crystallize
the currently vague/obscured "store writer" concept. Such refactoring is
outside this project scope but will benefit from these changes.