### PR TITLE
Break long storeClientCopy2() call chains with an asyncCall

### DIFF
--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -187,8 +187,7 @@ struct LowestMemReader : public unary_function<store_client, void> {
     LowestMemReader(int64_t seed):current(seed) {}
 
     void operator() (store_client const &x) {
-        if (x.memReaderHasLowerOffset(current))
-            current = x.copyInto.offset;
+        current = x.memHeaderOffsetLowerThan(current);
     }
 
     int64_t current;
@@ -497,7 +496,7 @@ MemObject::mostBytesAllowed() const
 
 #endif
 
-        j = sc->delayId.bytesWanted(0, sc->copyInto.length);
+        j = sc->bytesWanted();
 
         if (j > jmax) {
             jmax = j;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -68,7 +68,8 @@ class store_client
 public:
     store_client(StoreEntry *);
     ~store_client();
-    bool memReaderHasLowerOffset(int64_t) const;
+    /// returns the smallest of the passed value and the memory offset of the client
+    int memHeaderOffsetLowerThan(const int64_t offset) const;
     int getType() const;
     void fail();
     void callback(ssize_t len, bool error = false);
@@ -92,18 +93,14 @@ public:
         bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
-    AsyncCall::Pointer clientSideCaller;
-
 #if USE_DELAY_POOLS
+    int bytesWanted() const { return delayId.bytesWanted(0, copyInto.length); }
     DelayId delayId;
     void setDelayId(DelayId delay_id);
 #endif
 
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
-    StoreIOBuffer copyInto;
-    /// the number of bytes effectively copied from Store into the I/O buffer
-    size_t copiedSize;
 
 private:
     bool moreToSend() const;
@@ -117,6 +114,11 @@ private:
 
     int type;
     bool object_ok;
+
+    StoreIOBuffer copyInto;
+    /// the number of bytes effectively copied from Store into the I/O buffer
+    size_t copiedSize;
+    AsyncCall::Pointer clientSideCaller;
 
     /* Until we finish stuffing code into store_client */
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -88,8 +88,7 @@ public:
 
     struct {
         bool disk_io_pending;
-        bool store_copying;
-        bool copy_event_pending;
+        bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
 #if USE_DELAY_POOLS

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -79,6 +79,7 @@ public:
     void readBody(const char *buf, ssize_t len);
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
+    bool canCopy() const { return _callback.pending() && !clientSideCaller && !flags.disk_io_pending; }
 
 #if STORE_CLIENT_LIST_DEBUG
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_STORECLIENT_H
 #define SQUID_STORECLIENT_H
 
-#include "base/AsyncCbdataCalls.h"
+#include "base/AsyncCall.h"
 #include "base/forward.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
@@ -68,7 +68,7 @@ class store_client
 public:
     store_client(StoreEntry *);
     ~store_client();
-    /// returns the smallest of the passed value and the memory offset of the client
+    /// \returns the smallest of the passed value and the memory offset of the client
     int memHeaderOffsetLowerThan(const int64_t offset) const;
     int getType() const;
     void fail();

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -79,7 +79,6 @@ public:
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
 
-    int64_t cmp_offset;
 #if STORE_CLIENT_LIST_DEBUG
 
     void *owner;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -90,7 +90,6 @@ public:
 
     struct {
         bool disk_io_pending;
-        bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
 #if USE_DELAY_POOLS

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -79,7 +79,11 @@ public:
     void readBody(const char *buf, ssize_t len);
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
-    bool canCopy() const { return _callback.pending() && !clientSideCaller && !flags.disk_io_pending; }
+    /// whether doCopy() can be called
+    bool canCopy() const { return canScheduleCallback() && !flags.disk_io_pending; }
+    /// TODO: revise/verify all usages
+    /// whether callback() can be called
+    bool canScheduleCallback() const { return _callback.pending() && !clientSideCaller; }
 
 #if STORE_CLIENT_LIST_DEBUG
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_STORECLIENT_H
 #define SQUID_STORECLIENT_H
 
+#include "base/AsyncCbdataCalls.h"
 #include "base/forward.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
@@ -71,6 +72,7 @@ public:
     int getType() const;
     void fail();
     void callback(ssize_t len, bool error = false);
+    void callbackClientSide();
     void doCopy (StoreEntry *e);
     void readHeader(const char *buf, ssize_t len);
     void readBody(const char *buf, ssize_t len);
@@ -91,6 +93,8 @@ public:
         bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
+    AsyncCall::Pointer clientSideCaller;
+
 #if USE_DELAY_POOLS
     DelayId delayId;
     void setDelayId(DelayId delay_id);
@@ -99,6 +103,8 @@ public:
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
     StoreIOBuffer copyInto;
+    /// the number of bytes effectively copied from Store into the I/O buffer
+    size_t copiedSize;
 
 private:
     bool moreToSend() const;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -255,6 +255,7 @@ store_client::copy(StoreEntry * anEntry,
     copyInto.data = copyRequest.data;
     copyInto.length = copyRequest.length;
     copyInto.offset = copyRequest.offset;
+    // copyInto.flags.error should persist between the calls, do not modify it.
 
     static bool copying (false);
     assert (!copying);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -167,7 +167,6 @@ store_client::callbackClientSide()
     clientSideCaller = nullptr;
     StoreIOBuffer result(copiedSize, copyInto.offset, copyInto.data);
     result.flags.error = copyInto.flags.error;
-    cmp_offset = copyInto.offset + copiedSize;
 
     auto temphandler = _callback.callback_handler;
     void *cbdata = _callback.callback_data;
@@ -201,7 +200,6 @@ store_client::callback(ssize_t sz, bool error)
 }
 
 store_client::store_client(StoreEntry *e) :
-    cmp_offset(0),
 #if STORE_CLIENT_LIST_DEBUG
     owner(cbdataReference(data)),
 #endif
@@ -256,12 +254,7 @@ store_client::copy(StoreEntry * anEntry,
 #endif
 
     assert(!_callback.pending());
-#if ONLYCONTIGUOUSREQUESTS
-
-    assert(cmp_offset == copyRequest.offset);
-#endif
     /* range requests will skip into the body */
-    cmp_offset = copyRequest.offset;
     _callback = Callback (callback_fn, cbdataReference(data));
     copyInto.data = copyRequest.data;
     copyInto.length = copyRequest.length;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -739,15 +739,11 @@ StoreEntry::invokeHandlers()
         nx = node->next;
         ++i;
 
-        if (!sc->_callback.pending())
-            continue;
-
-        if (sc->flags.disk_io_pending)
-            continue;
-
-        CodeContext::Reset(sc->_callback.codeContext);
-        debugs(90, 3, "checking client #" << i);
-        storeClientCopy2(this, sc);
+        if (sc->canCopy()) {
+            CodeContext::Reset(sc->_callback.codeContext);
+            debugs(90, 3, "checking client #" << i);
+            storeClientCopy2(this, sc);
+        }
     }
     CodeContext::Reset(savedContext);
     PROF_stop(InvokeHandlers);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -326,8 +326,6 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
      * everything we got before the abort condition occurred.
      */
 
-    // TODO: optimize, immediately returning if is no data yet
-
     sc->doCopy(sc->entry);
 }
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -195,6 +195,8 @@ store_client::callback(ssize_t sz, bool error)
         clientSideCaller->cancel("failed"); // TODO: provide a meaningful reason
     }
 
+    /// XXX: do not schedule if the object is going to be deleted,
+    /// see storeUnregister().
     clientSideCaller = asyncCall(17, 4, "Callback", cbdataDialer(CallbackClientSide, this));
     ScheduleCallHere(clientSideCaller);
 }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -93,10 +93,12 @@ StoreClient::fillChecklist(ACLFilledChecklist &checklist) const
 
 /* store_client */
 
-bool
-store_client::memReaderHasLowerOffset(int64_t anOffset) const
+int
+store_client::memHeaderOffsetLowerThan(const int64_t anOffset) const
 {
-    return getType() == STORE_MEM_CLIENT && copyInto.offset < anOffset;
+    if (getType() == STORE_MEM_CLIENT && copyInto.offset < anOffset)
+        return copyInto.offset;
+    return anOffset;
 }
 
 int
@@ -200,9 +202,9 @@ store_client::store_client(StoreEntry *e) :
     owner(cbdataReference(data)),
 #endif
     entry(e),
-    copiedSize(0),
     type(e->storeClientType()),
-    object_ok(true)
+    object_ok(true),
+    copiedSize(0)
 {
     flags.disk_io_pending = false;
     ++ entry->refcount;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -341,6 +341,8 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
      * everything we got before the abort condition occurred.
      */
 
+    // TODO: optimize, immediately returning if is no data yet
+
     AsyncCall::Pointer call = asyncCall(17, 4, "DoCopy", cbdataDialer(DoCopy, sc));
     ScheduleCallHere(call);
     sc->flags.copy_pending = true;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "acl/FilledChecklist.h"
+#include "base/AsyncCbdataCalls.h"
 #include "base/CodeContext.h"
 #include "event.h"
 #include "globals.h"
@@ -41,7 +42,6 @@
 static StoreIOState::STRCB storeClientReadBody;
 static StoreIOState::STRCB storeClientReadHeader;
 static void storeClientCopy2(StoreEntry * e, store_client * sc);
-static EVH storeClientCopyEvent;
 static bool CheckQuickAbortIsReasonable(StoreEntry * entry);
 
 CBDATA_CLASS_INIT(store_client);
@@ -180,20 +180,6 @@ store_client::callback(ssize_t sz, bool error)
     cbdataReferenceDone(cbdata);
 }
 
-static void
-storeClientCopyEvent(void *data)
-{
-    store_client *sc = (store_client *)data;
-    debugs(90, 3, "storeClientCopyEvent: Running");
-    assert (sc->flags.copy_event_pending);
-    sc->flags.copy_event_pending = false;
-
-    if (!sc->_callback.pending())
-        return;
-
-    storeClientCopy2(sc->entry, sc);
-}
-
 store_client::store_client(StoreEntry *e) :
     cmp_offset(0),
 #if STORE_CLIENT_LIST_DEBUG
@@ -204,8 +190,7 @@ store_client::store_client(StoreEntry *e) :
     object_ok(true)
 {
     flags.disk_io_pending = false;
-    flags.store_copying = false;
-    flags.copy_event_pending = false;
+    flags.copy_pending = false;
     ++ entry->refcount;
 
     if (getType() == STORE_DISK_CLIENT) {
@@ -318,25 +303,36 @@ store_client::moreToSend() const
 }
 
 static void
-storeClientCopy2(StoreEntry * e, store_client * sc)
+DoCopy(store_client *sc)
 {
-    /* reentrancy not allowed  - note this could lead to
-     * dropped events
+    if (!cbdataReferenceValid(sc)) {
+        debugs(33, 2, "invalid store_client " << sc);
+        return;
+    }
+
+    assert(sc->_callback.pending());
+
+    sc->flags.copy_pending = false;
+
+    /* Warning: doCopy may indirectly free itself in callbacks,
+     * hence the lock to keep it active for the duration of
+     * this function
+     * XXX: Locking does not prevent calling sc destructor (it only prevents
+     * freeing sc memory) so sc may become invalid from C++ p.o.v.
      */
 
-    if (sc->flags.copy_event_pending) {
-        return;
-    }
+    CbcPointer<store_client> tmpLock = sc;
 
-    if (sc->flags.store_copying) {
-        sc->flags.copy_event_pending = true;
-        debugs(90, 3, "storeClientCopy2: Queueing storeClientCopyEvent()");
-        eventAdd("storeClientCopyEvent", storeClientCopyEvent, sc, 0.0, 0);
+    sc->doCopy(sc->entry);
+}
+
+static void
+storeClientCopy2(StoreEntry * e, store_client * sc)
+{
+    if (sc->flags.copy_pending)
         return;
-    }
 
     debugs(90, 3, "storeClientCopy2: " << e->getMD5Text());
-    assert(sc->_callback.pending());
     /*
      * We used to check for ENTRY_ABORTED here.  But there were some
      * problems.  For example, we might have a slow client (or two) and
@@ -344,23 +340,16 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
      * if the peer aborts, we want to give the client(s)
      * everything we got before the abort condition occurred.
      */
-    /* Warning: doCopy may indirectly free itself in callbacks,
-     * hence the lock to keep it active for the duration of
-     * this function
-     * XXX: Locking does not prevent calling sc destructor (it only prevents
-     * freeing sc memory) so sc may become invalid from C++ p.o.v.
-     */
-    CbcPointer<store_client> tmpLock = sc;
-    assert (!sc->flags.store_copying);
-    sc->doCopy(e);
-    assert(!sc->flags.store_copying);
+
+    AsyncCall::Pointer call = asyncCall(17, 4, "DoCopy", cbdataDialer(DoCopy, sc));
+    ScheduleCallHere(call);
+    sc->flags.copy_pending = true;
 }
 
 void
 store_client::doCopy(StoreEntry *anEntry)
 {
     assert (anEntry == entry);
-    flags.store_copying = true;
     MemObject *mem = entry->mem_obj;
 
     debugs(33, 5, "store_client::doCopy: co: " <<
@@ -371,14 +360,12 @@ store_client::doCopy(StoreEntry *anEntry)
         /* There is no more to send! */
         debugs(33, 3, HERE << "There is no more to send!");
         callback(0);
-        flags.store_copying = false;
         return;
     }
 
     /* Check that we actually have data */
     if (anEntry->store_status == STORE_PENDING && copyInto.offset >= mem->endOffset()) {
         debugs(90, 3, "store_client::doCopy: Waiting for more");
-        flags.store_copying = false;
         return;
     }
 
@@ -411,7 +398,6 @@ store_client::startSwapin()
     if (storeTooManyDiskFilesOpen()) {
         /* yuck -- this causes a TCP_SWAPFAIL_MISS on the client side */
         fail();
-        flags.store_copying = false;
         return false;
     } else if (!flags.disk_io_pending) {
         /* Don't set store_io_pending here */
@@ -419,14 +405,12 @@ store_client::startSwapin()
 
         if (swapin_sio == NULL) {
             fail();
-            flags.store_copying = false;
             return false;
         }
 
         return true;
     } else {
         debugs(90, DBG_IMPORTANT, "WARNING: Averted multiple fd operation (1)");
-        flags.store_copying = false;
         return false;
     }
 }
@@ -451,7 +435,6 @@ store_client::scheduleDiskRead()
         assert(swapin_sio != NULL);
     } else if (!swapin_sio && !startSwapin()) {
         debugs(90, 3, "bailing after swapin start failure for " << *entry);
-        assert(!flags.store_copying);
         return;
     }
 
@@ -460,8 +443,6 @@ store_client::scheduleDiskRead()
     debugs(90, 3, "reading " << *entry << " from disk");
 
     fileRead();
-
-    flags.store_copying = false;
 }
 
 void
@@ -472,7 +453,6 @@ store_client::scheduleMemRead()
     debugs(90, 3, "store_client::doCopy: Copying normal from memory");
     size_t sz = entry->mem_obj->data_hdr.copy(copyInto);
     callback(sz);
-    flags.store_copying = false;
 }
 
 void
@@ -920,11 +900,8 @@ store_client::dumpStats(MemBuf * output, int clientNumber) const
     if (flags.disk_io_pending)
         output->append(" disk_io_pending", 16);
 
-    if (flags.store_copying)
-        output->append(" store_copying", 14);
-
-    if (flags.copy_event_pending)
-        output->append(" copy_event_pending", 19);
+    if (flags.copy_pending)
+        output->append(" copy_pending", 19);
 
     output->append("\n",1);
 }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -191,8 +191,6 @@ store_client::callback(ssize_t sz, bool error)
     if (clientSideCaller)
         return;
 
-    /// XXX: do not schedule if the object is going to be deleted,
-    /// see storeUnregister().
     clientSideCaller = asyncCall(17, 4, "Callback", cbdataDialer(CallbackClientSide, this));
     ScheduleCallHere(clientSideCaller);
 }
@@ -682,12 +680,6 @@ storeUnregister(store_client * sc, StoreEntry * e, void *data)
         storeClose(sc->swapin_sio, StoreIOState::readerDone);
         sc->swapin_sio = NULL;
         ++statCounter.swap.ins;
-    }
-
-    if (sc->_callback.pending()) {
-        /* callback with ssize = -1 to indicate unexpected termination */
-        debugs(90, 3, "store_client for " << *e << " has a callback");
-        sc->fail();
     }
 
 #if STORE_CLIENT_LIST_DEBUG

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -183,17 +183,13 @@ store_client::callbackClientSide()
 void
 store_client::callback(ssize_t sz, bool error)
 {
-    if (sz >= 0 && !error)
-        copiedSize = sz;
+    copiedSize = (sz > 0 && !error) ? sz : 0;
+
     if (sz < 0 || error)
         copyInto.flags.error = 1;
 
-    if (clientSideCaller) {
-        if (!copyInto.flags.error)
-            return;
-        // reschedule with error
-        clientSideCaller->cancel("failed"); // TODO: provide a meaningful reason
-    }
+    if (clientSideCaller)
+        return;
 
     /// XXX: do not schedule if the object is going to be deleted,
     /// see storeUnregister().

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -56,6 +56,7 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
 
     if (sc->canScheduleCallback()) {
         assert (errflag <= 0);
+        // TODO: should we sc->fail() on error instead?
         sc->callback(0, errflag ? true : false);
     }
 

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -54,7 +54,7 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
     debugs(20, 3, "storeSwapInFileClosed: sio=" << sc->swapin_sio.getRaw() << ", errflag=" << errflag);
     sc->swapin_sio = NULL;
 
-    if (sc->_callback.pending()) {
+    if (sc->canScheduleCallback()) {
         assert (errflag <= 0);
         sc->callback(0, errflag ? true : false);
     }


### PR DESCRIPTION
This approach has some advantages over the synchronous one:

* AsyncCall has the right code context set, while storeClientCopyEvent
  lacks the context because eventAdd*() API does not support it (yet).

* callback.callback_handler became not re-entrant and its logic simplified
  (by eliminating protection flags).

* De-synchronizing allowed to reduce call stacks (especially when one
  copy operation spawns another one, due to revalidation or error), thus
  making this area easier to debug.