### PR TITLE
Purge misses generate "O Init" replies instead of "404 Not Found"

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1047,9 +1047,6 @@ clientReplyContext::purgeDoMissPurge()
 void
 clientReplyContext::purgeDoPurgeGet(StoreEntry *newEntry)
 {
-    /* Move to new() when that is created */
-    purgeStatus = Http::scNotFound;
-
     if (newEntry) {
         /* Release the cached URI */
         debugs(88, 4, "clientPurgeRequest: GET '" << newEntry->url() << "'" );
@@ -1103,6 +1100,9 @@ clientReplyContext::purgeDoPurgeHead(StoreEntry *newEntry)
             purgeStatus = Http::scOkay;
         }
     }
+
+    if (purgeStatus == Http::scNone)
+        purgeStatus = Http::scNotFound;
 
     /*
      * Make a new entry to hold the reply to be written

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1047,9 +1047,10 @@ clientReplyContext::purgeDoMissPurge()
 void
 clientReplyContext::purgeDoPurgeGet(StoreEntry *newEntry)
 {
+    /* Move to new() when that is created */
+    purgeStatus = Http::scNotFound;
+
     if (newEntry) {
-        /* Move to new() when that is created */
-        purgeStatus = Http::scNotFound;
         /* Release the cached URI */
         debugs(88, 4, "clientPurgeRequest: GET '" << newEntry->url() << "'" );
 #if USE_HTCP

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -47,6 +47,21 @@ Http::StatusLine::packInto(Packable * p) const
 {
     assert(p);
 
+    Http::StatusCode useStatus;
+    const char *useReason;
+
+    if (!status()) {
+        static int zeroStatusCount = 0;
+        if (++zeroStatusCount < 100) {
+            debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
+        }
+        useStatus = Http::scInternalServerError;
+        useReason = Http::StatusCodeString(useStatus);
+    } else {
+        useStatus = status();
+        useReason = reason();
+    }
+
     /* local constants */
     /* AYJ: see bug 2469 - RFC2616 confirms stating 'SP characters' plural! */
     static const char *Http1StatusLineFormat = "HTTP/%d.%d %3d %s\r\n";
@@ -56,15 +71,15 @@ Http::StatusLine::packInto(Packable * p) const
     if (protocol == AnyP::PROTO_ICY) {
         debugs(57, 9, "packing sline " << this << " using " << p << ":");
         debugs(57, 9, "FORMAT=" << IcyStatusLineFormat );
-        debugs(57, 9, "ICY " << status() << " " << reason());
-        p->appendf(IcyStatusLineFormat, status(), reason());
+        debugs(57, 9, "ICY " << useStatus << " " << useReason);
+        p->appendf(IcyStatusLineFormat, useStatus, useReason);
         return;
     }
 
     debugs(57, 9, "packing sline " << this << " using " << p << ":");
     debugs(57, 9, "FORMAT=" << Http1StatusLineFormat );
-    debugs(57, 9, "HTTP/" << version.major << "." << version.minor << " " << status() << " " << reason());
-    p->appendf(Http1StatusLineFormat, version.major, version.minor, status(), reason());
+    debugs(57, 9, "HTTP/" << version.major << "." << version.minor << " " << useStatus << " " << useReason);
+    p->appendf(Http1StatusLineFormat, version.major, version.minor, useStatus, useReason);
 }
 
 /*


### PR DESCRIPTION
The related clientReplyContext code leaves unset the
clientReplyContext::purgeStatus member if none of the stored
GET or HEAD entries matches the given URL.

This is a Measurement Factory project.