### PR TITLE
Proxy protocol support for https port

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3881,25 +3881,30 @@ parsePortCfg(AnyP::PortCfgPointer *head, const char *optionName)
 
     if (s->transport.protocol == AnyP::PROTO_HTTPS) {
         s->secure.encryptTransport = true;
+        const auto hijacked = s->flags.isIntercepted();
 #if USE_OPENSSL
-        /* ssl-bump on https_port configuration requires either tproxy or intercept, and vice versa */
-        const bool hijacked = s->flags.isIntercepted();
-        if (s->flags.tunnelSslBumping && !hijacked) {
-            debugs(3, DBG_CRITICAL, "FATAL: ssl-bump on https_port requires tproxy/intercept which is missing.");
+        /* ssl-bump on https_port configuration requires one of tproxy, intercept or require-proxy-header and vice versa */
+        const auto sslBumpRequiredOption = hijacked || s->flags.proxySurrogate;
+        if (s->flags.tunnelSslBumping && !sslBumpRequiredOption) {
+            debugs(3, DBG_CRITICAL, "FATAL: ssl-bump on https_port requires tproxy/intercept/require-proxy-header which is missing.");
             self_destruct();
             return;
         }
-        if (hijacked && !s->flags.tunnelSslBumping) {
-            debugs(3, DBG_CRITICAL, "FATAL: tproxy/intercept on https_port requires ssl-bump which is missing.");
+        if (sslBumpRequiredOption && !s->flags.tunnelSslBumping) {
+            debugs(3, DBG_CRITICAL, "FATAL: tproxy/intercept/require-proxy-header on https_port requires ssl-bump which is missing.");
             self_destruct();
             return;
         }
 #endif
-        if (s->flags.proxySurrogate) {
-            debugs(3,DBG_CRITICAL, "FATAL: https_port: require-proxy-header option is not supported on HTTPS ports.");
+        if (s->flags.proxySurrogate && (hijacked || s->flags.accelSurrogate)) {
+            debugs(3, DBG_CRITICAL, "FATAL: https_port: require-proxy-header option and tproxy/intercept/accel are incompatible on HTTPS ports.");
             self_destruct();
             return;
         }
+
+        if (s->flags.tunnelSslBumping && s->flags.proxySurrogate)
+            s->flags.natIntercept = true; // emulate interception for PROXY protocol
+
     } else if (protoName.cmp("FTP") == 0) {
         /* ftp_port does not support ssl-bump */
         if (s->flags.tunnelSslBumping) {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1860,6 +1860,15 @@ ConnStateData::parseProxyProtocolHeader()
         if (proxyProtocolHeader_->hasForwardedAddresses()) {
             clientConnection->local = proxyProtocolHeader_->destinationAddress;
             clientConnection->remote = proxyProtocolHeader_->sourceAddress;
+
+            Http::StreamPointer context = pipeline.front();
+            Must(context && context->http);
+            HttpRequest::Pointer request = context->http->request;
+            // TODO: place this common code into a method
+            static char ip[MAX_IPSTRLEN];
+            request->url.host(clientConnection->local.toStr(ip, sizeof(ip)));
+            request->url.port(clientConnection->local.port());
+
             if ((clientConnection->flags & COMM_TRANSPARENT))
                 clientConnection->flags ^= COMM_TRANSPARENT; // prevent TPROXY spoofing of this new IP.
             debugs(33, 5, "PROXY/" << proxyProtocolHeader_->version() << " upgrade: " << clientConnection);

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -398,13 +398,16 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
     details->local = *gai;
     Ip::Address::FreeAddr(gai);
 
-    // Perform NAT or TPROXY operations to retrieve the real client/dest IP addresses
-    if (conn->flags&(COMM_TRANSPARENT|COMM_INTERCEPTION) && !Ip::Interceptor.Lookup(details, conn)) {
-        debugs(50, DBG_IMPORTANT, "ERROR: NAT/TPROXY lookup failed to locate original IPs on " << details);
-        // Failed.
-        PROF_stop(comm_accept);
-        return Comm::COMM_ERROR;
-    }
+    details->flags |= (conn->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION));
+    if (!listenPort_->flags.proxySurrogate) {
+        // Perform NAT or TPROXY operations to retrieve the real client/dest IP addresses
+        if (conn->flags&(COMM_TRANSPARENT|COMM_INTERCEPTION) && !Ip::Interceptor.Lookup(details, conn)) {
+            debugs(50, DBG_IMPORTANT, "ERROR: NAT/TPROXY lookup failed to locate original IPs on " << details);
+            // Failed.
+            PROF_stop(comm_accept);
+            return Comm::COMM_ERROR;
+        }
+    } // else the real client/dest IP addresses will be filled from PROXY protocol message
 
 #if USE_SQUID_EUI
     if (Eui::TheConfig.euiLookup) {

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -404,8 +404,6 @@ Ip::Intercept::Lookup(const Comm::ConnectionPointer &newConn, const Comm::Connec
 
     debugs(89, 5, HERE << "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
 
-    newConn->flags |= (listenConn->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION));
-
     /* NP: try TPROXY first, its much quieter than NAT when non-matching */
     if (transparentActive_ && listenConn->flags&COMM_TRANSPARENT) {
         if (TproxyTransparent(newConn, silent)) return true;


### PR DESCRIPTION
The PROXY protocol is now supported on https_port with SslBump:

https_port ... ssl-bump ... require-proxy-header

For now, https_port only supports require-proxy-header in combination
with pure ssl-bump mode. In other words, the configurations listed
below are rejected:
* containing require-proxy-header and at least one of the 
  https_port modes: intercept, tproxy, and accel
* containing require-proxy-header without ssl-bump mode