### PR TITLE
Fix squid crash while submitting request to helper

### DIFF
--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1286,6 +1286,9 @@ GetFirstAvailable(const helper * hlp)
         if (srv->flags.shutdown)
             continue;
 
+        if (srv->flags.closing)
+            continue;
+
         if (!srv->stats.pending)
             return srv;
 
@@ -1340,6 +1343,9 @@ StatefulGetFirstAvailable(statefulhelper * hlp)
         }
 
         if (srv->flags.shutdown)
+            continue;
+
+        if (srv->flags.closing)
             continue;
 
         debugs(84, 5, "StatefulGetFirstAvailable: returning srv-" << srv->index);


### PR DESCRIPTION
This is occurs inside Comm::Write function called from helperDispatch
function, while trying to write on an already closed pipe.
This is the sequence which causes this crash:
  - A helper server died for a reason
  - Squid side waiting for a response and read zero bytes (means end of
    connection), and calls helperHandleRead function
  - The helperHandleRead calls the HelperServerBase::closePipesSafely for the
    helper server which closes the pipes and marks the
    HelperServerBase::flags.closing to true. The comm_close handlers will
    cleanup latter
  - One of the next asyncCalls calls helper::submitRequest which uses
    the GetFirstAvailable function to retrieve a helper server to use
  - The GetFirstAvailable runs the servers list but it does not check
    the flags.closing flag and return the helper which is closed
  - Squid tries to write to a closed pipe and crashes.