### PR TITLE
Report catastrophic rock cache_dir index rebuild failures and abort

### DIFF
--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -564,6 +564,16 @@ Rock::Rebuild::swanSong()
 }
 
 void
+Rock::Rebuild::callException(const std::exception& e)
+{
+    debugs(47, 5, sd->index << " slot " << loadingPos << " at " <<  dbOffset <<
+           " <= " << dbSize << " " << std::setw(4) << std::setprecision(2) <<
+           100.0*loadingPos/dbSlotLimit << "% complete");
+
+    abort("rock rebuilding exception");
+}
+
+void
 Rock::Rebuild::failure(const char *msg, int errNo)
 {
     debugs(47,5, sd->index << " slot " << loadingPos << " at " <<
@@ -573,6 +583,12 @@ Rock::Rebuild::failure(const char *msg, int errNo)
         debugs(47, DBG_CRITICAL, "ERROR: Rock cache_dir rebuild failure: " << xstrerr(errNo));
     debugs(47, DBG_CRITICAL, "Do you need to run 'squid -z' to initialize storage?");
 
+    abort(msg);
+}
+
+void
+Rock::Rebuild::abort(const char *msg)
+{
     assert(sd);
     fatalf("Rock cache_dir[%d] rebuild of %s failed: %s.",
            sd->index, sd->filePath, msg);

--- a/src/fs/rock/RockRebuild.h
+++ b/src/fs/rock/RockRebuild.h
@@ -31,6 +31,8 @@ class Rebuild: public AsyncJob
 public:
     Rebuild(SwapDir *dir);
     virtual ~Rebuild() override;
+    /* AsyncJob API */
+    virtual void callException(const std::exception &e) override;
 
 protected:
     /* AsyncJob API */
@@ -52,6 +54,7 @@ private:
     bool importEntry(Ipc::StoreMapAnchor &anchor, const sfileno slotId, const DbCellHeader &header);
     void freeBadEntry(const sfileno fileno, const char *eDescription);
 
+    void abort(const char *msg);
     void failure(const char *msg, int errNo = 0);
 
     LoadingEntry loadingEntry(const sfileno fileNo);


### PR DESCRIPTION
These failures were not reported to Squid admins but could result in
an abridged (and probably unusable) cache_dir.