### PR TITLE
Do not stall while debugging a scan of an empty store_table

### DIFF
--- a/src/store/LocalSearch.cc
+++ b/src/store/LocalSearch.cc
@@ -91,7 +91,6 @@ Store::LocalSearch::copyBucket()
 {
     /* probably need to lock the store entries...
      * we copy them all to prevent races on the links. */
-    debugs(47, 3, "Store::LocalSearch::copyBucket #" << bucket);
     assert (!entries.size());
     hash_link *link_ptr = NULL;
     hash_link *link_next = NULL;
@@ -105,6 +104,7 @@ Store::LocalSearch::copyBucket()
     }
 
     ++bucket;
-    debugs(47,3, "got entries: " << entries.size());
+    if (entries.size())
+        debugs(47, 3, "bucket #" << bucket << ", got entries: " << entries.size());
 }
 


### PR DESCRIPTION
Non-SMP Squid allocates an in-memory uber-index called "store_table".
SMP Squid kids inherit this SMP-unaware code even though they only need
a local index for active cachable transactions. Each SMP kid creates its
own store_table of various sizes.

Recently we discovered that it is almost impossible to debug SMP Squid
with a large but mostly empty disk cache because the disker registration
times out while store_table is being built – the disker process is
essentially blocked on a very long debugging loop.

The fact that the code suspends the loop every 500 entries (to take
care of other tasks, including kid registration) does not
prevent from scanning millions of empty table slots without pausing and
printing two debug lines for every 20 slots.

With this fix applied, we stop reporting empty store_table buckets. The
debugged worker process will still be blocked for a few hundred
milliseconds (instead of many seconds) while scanning the entire (mostly
empty) store_table.