### PR TITLE
Ignore SMP queue messages made stale by worker restarts

### DIFF
--- a/src/DiskIO/IpcIo/IpcIoFile.h
+++ b/src/DiskIO/IpcIo/IpcIoFile.h
@@ -51,6 +51,7 @@ public:
     off_t offset;
     size_t len;
     Ipc::Mem::PageId page;
+    pid_t workerPid; ///< the worker process ID
 
     IpcIo::Command command; ///< what disker is supposed to do or did
     struct timeval start; ///< when the I/O request was converted to IpcIoMsg
@@ -126,6 +127,7 @@ private:
     static void DiskerHandleRequests();
     static void DiskerHandleRequest(const int workerId, IpcIoMsg &ipcIo);
     static bool WaitBeforePop();
+    static pid_t getPid();
 
 private:
     const String dbName; ///< the name of the file we are managing

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -484,6 +484,15 @@ peerDigestHandleReply(void *data, StoreIOBuffer receivedData)
 
     } while (cbdataReferenceValid(fetch) && prevstate != fetch->state && fetch->bufofs > 0);
 
+    // Check for EOF here, thus giving the parser one extra run. We could avoid this overhead by
+    // checking at the beginning of this function. However, in this case, we would have to require
+    // that the parser does not regard EOF as a special condition (it is true now but may change
+    // in the future).
+    if (!receivedData.length) { // EOF
+        peerDigestFetchAbort(fetch, fetch->buf, "premature end of digest reply");
+        return;
+    }
+
     /* Update the copy offset */
     fetch->offset += receivedData.length;
 


### PR DESCRIPTION
When a worker restarts (for any reason), the disker-to-worker queue may
contain disker responses to I/O requests sent by the previous
incarnation of the restarted worker (the 'previous generation"
responses). Since the current response identification mechanism
relies on a 32-bit integer counter, there is a little chance that
the restarted worker may see previous generation responses that
accidentally match the current generation transaction ID.

For writing transactions, reacting to such previous generation response
may mean unlocking a cache entry too soon, making not yet written slots
available to other workers that might read stale slot content. For
reading transactions, reacting to the previous generation response may
mean serving a completely different/wrong HTTP response headers or body
(that have been already overwritten on disk with the information
the restarted worker is now waiting for).

To avoid these problems, each disk request now stores the worker process
ID and compares it with the current process ID after receiving the
response. Mismatching responses are considered stale and ignored.