### PR TITLE
Handling missing issuer certificates for TLSv1.3

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -913,7 +913,7 @@ configDoConfigure(void)
             debugs(3, DBG_IMPORTANT, "ERROR: proxying https:// currently still requires --with-openssl");
 #endif
         }
-#if USE_OPENSSL
+#if 0 && USE_OPENSSL
         Ssl::useSquidUntrusted(Config.ssl_client.sslContext.get());
 #endif
     }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -913,7 +913,7 @@ configDoConfigure(void)
             debugs(3, DBG_IMPORTANT, "ERROR: proxying https:// currently still requires --with-openssl");
 #endif
         }
-#if 0 && USE_OPENSSL
+#if USE_OPENSSL
         Ssl::useSquidUntrusted(Config.ssl_client.sslContext.get());
 #endif
     }

--- a/src/globals.h
+++ b/src/globals.h
@@ -105,7 +105,7 @@ extern int ssl_ex_index_ssl_peeked_cert;      /* -1 */
 extern int ssl_ex_index_ssl_errors;   /* -1 */
 extern int ssl_ex_index_ssl_cert_chain;  /* -1 */
 extern int ssl_ex_index_ssl_validation_counter;  /* -1 */
-extern int ssl_ex_index_cert_ignore_issuer;  /* -1 */
+extern int ssl_ex_index_squid_verify;  /* -1 */
 
 extern const char *external_acl_message;      /* NULL */
 extern int opt_send_signal; /* -1 */

--- a/src/globals.h
+++ b/src/globals.h
@@ -105,6 +105,7 @@ extern int ssl_ex_index_ssl_peeked_cert;      /* -1 */
 extern int ssl_ex_index_ssl_errors;   /* -1 */
 extern int ssl_ex_index_ssl_cert_chain;  /* -1 */
 extern int ssl_ex_index_ssl_validation_counter;  /* -1 */
+extern int ssl_ex_index_cert_ignore_issuer;  /* -1 */
 
 extern const char *external_acl_message;      /* NULL */
 extern int opt_send_signal; /* -1 */

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -664,6 +664,7 @@ Security::HandshakeParser::parseHello(const SBuf &data)
     return false; // unreached
 }
 
+#if PARSE_CERTIFICATES
 /// Creates and returns a certificate by parsing a DER-encoded X509 structure.
 /// Throws on failures.
 Security::CertPointer
@@ -685,6 +686,7 @@ Security::HandshakeParser::ParseCertificate(const SBuf &raw)
     assert(pCert);
     return pCert;
 }
+#endif // PARSE_CERTIFICATES
 
 void
 Security::HandshakeParser::parseServerCertificates(const SBuf &raw)
@@ -694,6 +696,7 @@ Security::HandshakeParser::parseServerCertificates(const SBuf &raw)
     const SBuf clist = tkList.pstring24("CertificateList");
     Must(tkList.atEnd()); // no leftovers after all certificates
 
+#if PARSE_CERTIFICATES
     Parser::BinaryTokenizer tkItems(clist);
     while (!tkItems.atEnd()) {
         if (Security::CertPointer cert = ParseCertificate(tkItems.pstring24("Certificate")))
@@ -703,6 +706,7 @@ Security::HandshakeParser::parseServerCertificates(const SBuf &raw)
 #else
     debugs(83, 7, "no support for CertificateList parsing; ignoring " << raw.length() << " bytes");
 #endif
+#endif // PARSE_CERTIFICATES
 }
 
 /// A helper function to create a set of all supported TLS extensions

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -76,7 +76,9 @@ public:
 
     TlsDetails::Pointer details; ///< TLS handshake meta info. Never nil.
 
+#if PARSE_CERTIFICATES
     Security::CertList serverCertificates; ///< parsed certificates chain
+#endif
 
     ParserState state; ///< current parsing state.
 
@@ -112,7 +114,9 @@ private:
     void parseV23Ciphers(const SBuf &raw);
 
     void parseServerCertificates(const SBuf &raw);
+#if PARSE_CERTIFICATES
     static CertPointer ParseCertificate(const SBuf &raw);
+#endif
 
     unsigned int currentContentType; ///< The current TLS/SSL record content type
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -466,25 +466,6 @@ Security::PeerConnector::noteWantRead()
 {
     const int fd = serverConnection()->fd;
     debugs(83, 5, serverConnection());
-#if USE_OPENSSL
-    Security::SessionPointer session(fd_table[fd].ssl);
-    BIO *b = SSL_get_rbio(session.get());
-    Ssl::ServerBio *srvBio = static_cast<Ssl::ServerBio *>(BIO_get_data(b));
-    if (srvBio->holdRead()) {
-        if (srvBio->gotHello()) {
-            srvBio->holdRead(false);
-            // schedule a negotiateSSl to allow openSSL parse received data
-            negotiateSsl();
-            return;
-        } else if (srvBio->gotHelloFailed()) {
-            srvBio->holdRead(false);
-            debugs(83, DBG_IMPORTANT, "Error parsing SSL Server Hello Message on FD " << fd);
-            // schedule a negotiateSSl to allow openSSL parse received data
-            negotiateSsl();
-            return;
-        }
-    }
-#endif
 
     // read timeout to avoid getting stuck while reading from a silent server
     typedef CommCbMemFunT<Security::PeerConnector, CommTimeoutCbParams> TimeoutDialer;

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -224,7 +224,7 @@ Security::PeerConnector::sslFinalized()
         // Issuer certificate is missing. We need to download issuer certificate
         // and re-validate
         SSL_set_ex_data(session.get(), ssl_ex_index_cert_ignore_issuer, (void *)0x03);
-        if (checkForMissingCertificates2())
+        if (checkForMissingCertificates())
             return false;
     }
 
@@ -472,11 +472,6 @@ Security::PeerConnector::noteWantRead()
     Ssl::ServerBio *srvBio = static_cast<Ssl::ServerBio *>(BIO_get_data(b));
     if (srvBio->holdRead()) {
         if (srvBio->gotHello()) {
-#if SSL_OLD_MISSING_ISSUERS
-            if (checkForMissingCertificates())
-                return; // Wait to download certificates before proceed.
-#endif
-
             srvBio->holdRead(false);
             // schedule a negotiateSSl to allow openSSL parse received data
             negotiateSsl();
@@ -676,94 +671,6 @@ Security::PeerConnector::startCertDownloading(SBuf &url)
     AsyncJob::Start(dl);
 }
 
-void
-Security::PeerConnector::certDownloadingDone(SBuf &obj, int downloadStatus)
-{
-    ++certsDownloads;
-    debugs(81, 5, "Certificate downloading status: " << downloadStatus << " certificate size: " << obj.length());
-
-    // get ServerBio from SSL object
-    const int fd = serverConnection()->fd;
-    Security::SessionPointer session(fd_table[fd].ssl);
-    BIO *b = SSL_get_rbio(session.get());
-    Ssl::ServerBio *srvBio = static_cast<Ssl::ServerBio *>(BIO_get_data(b));
-
-    // Parse Certificate. Assume that it is in DER format.
-    // According to RFC 4325:
-    //  The server must provide a DER encoded certificate or a collection
-    // collection of certificates in a "certs-only" CMS message.
-    //  The applications MUST accept DER encoded certificates and SHOULD
-    // be able to accept collection of certificates.
-    // TODO: support collection of certificates
-    const unsigned char *raw = (const unsigned char*)obj.rawContent();
-    if (X509 *cert = d2i_X509(NULL, &raw, obj.length())) {
-        char buffer[1024];
-        debugs(81, 5, "Retrieved certificate: " << X509_NAME_oneline(X509_get_subject_name(cert), buffer, 1024));
-        ContextPointer ctx(getTlsContext());
-        const Security::CertList &certsList = srvBio->serverCertificatesIfAny();
-        if (const char *issuerUri = Ssl::uriOfIssuerIfMissing(cert, certsList, ctx)) {
-            urlsOfMissingCerts.push(SBuf(issuerUri));
-        }
-        Ssl::SSL_add_untrusted_cert(session.get(), cert);
-    }
-
-    // Check if there are URIs to download from and if yes start downloading
-    // the first in queue.
-    if (urlsOfMissingCerts.size() && certsDownloads <= MaxCertsDownloads) {
-        startCertDownloading(urlsOfMissingCerts.front());
-        urlsOfMissingCerts.pop();
-        return;
-    }
-
-    srvBio->holdRead(false);
-    negotiateSsl();
-}
-
-bool
-Security::PeerConnector::checkForMissingCertificates()
-{
-    // Check for nested SSL certificates downloads. For example when the
-    // certificate located in an SSL site which requires to download a
-    // a missing certificate (... from an SSL site which requires to ...).
-
-    const Downloader *csd = (request ? request->downloader.get() : nullptr);
-    if (csd && csd->nestedLevel() >= MaxNestedDownloads)
-        return false;
-
-    const int fd = serverConnection()->fd;
-    Security::SessionPointer session(fd_table[fd].ssl);
-    BIO *b = SSL_get_rbio(session.get());
-    Ssl::ServerBio *srvBio = static_cast<Ssl::ServerBio *>(BIO_get_data(b));
-    const Security::CertList &certs
-        = srvBio->serverCertificatesIfAny();
-
-    if (certs.size()) {
-        debugs(83, 5, "SSL server sent " << certs.size() << " certificates");
-        ContextPointer ctx(getTlsContext());
-        Ssl::missingChainCertificatesUrls(urlsOfMissingCerts, certs, ctx);
-        if (urlsOfMissingCerts.size()) {
-            startCertDownloading(urlsOfMissingCerts.front());
-            urlsOfMissingCerts.pop();
-            return true;
-        }
-    }
-
-    return false;
-}
-
-
-void
-Security::PeerConnector::startCertDownloading2(SBuf &url)
-{
-    AsyncCall::Pointer certCallback = asyncCall(81, 4,
-                                      "Security::PeerConnector::certDownloadingDone2",
-                                      PeerConnectorCertDownloaderDialer(&Security::PeerConnector::certDownloadingDone2, this));
-
-    const Downloader *csd = (request ? dynamic_cast<const Downloader*>(request->downloader.valid()) : nullptr);
-    Downloader *dl = new Downloader(url, certCallback, XactionInitiator::initCertFetcher, csd ? csd->nestedLevel() + 1 : 1);
-    AsyncJob::Start(dl);
-}
-
 static void GetCertsList(Security::SessionPointer &session, Security::CertList &certs)
 {
     STACK_OF(X509) *peerCertificatesChain = SSL_get_peer_cert_chain(session.get());
@@ -775,7 +682,7 @@ static void GetCertsList(Security::SessionPointer &session, Security::CertList &
 }
 
 void
-Security::PeerConnector::certDownloadingDone2(SBuf &obj, int downloadStatus)
+Security::PeerConnector::certDownloadingDone(SBuf &obj, int downloadStatus)
 {
     ++certsDownloads;
     debugs(81, 5, "Certificate downloading status: " << downloadStatus << " certificate size: " << obj.length());
@@ -814,7 +721,7 @@ Security::PeerConnector::certDownloadingDone2(SBuf &obj, int downloadStatus)
 }
 
 bool
-Security::PeerConnector::checkForMissingCertificates2()
+Security::PeerConnector::checkForMissingCertificates()
 {
     // Check for nested SSL certificates downloads. For example when the
     // certificate located in an SSL site which requires to download a
@@ -834,7 +741,7 @@ Security::PeerConnector::checkForMissingCertificates2()
         ContextPointer ctx(getTlsContext());
         Ssl::missingChainCertificatesUrls(urlsOfMissingCerts, certs, ctx);
         if (urlsOfMissingCerts.size()) {
-            startCertDownloading2(urlsOfMissingCerts.front());
+            startCertDownloading(urlsOfMissingCerts.front());
             urlsOfMissingCerts.pop();
             return true;
         }

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -112,10 +112,6 @@ protected:
 
     /// Called by Downloader after a certificate object downloaded.
     void certDownloadingDone(SBuf &object, int status);
-
-    bool checkForMissingCertificates2();
-    void startCertDownloading2(SBuf &url);
-    void certDownloadingDone2(SBuf &object, int status);
 #endif
 
     /// Called when the openSSL SSL_connect function needs to write data to

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -112,6 +112,10 @@ protected:
 
     /// Called by Downloader after a certificate object downloaded.
     void certDownloadingDone(SBuf &object, int status);
+
+    bool checkForMissingCertificates2();
+    void startCertDownloading2(SBuf &url);
+    void certDownloadingDone2(SBuf &object, int status);
 #endif
 
     /// Called when the openSSL SSL_connect function needs to write data to

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -186,6 +186,7 @@ private:
     /// The list of URLs where missing certificates should be downloaded.
     std::queue<SBuf> urlsOfMissingCerts;
     unsigned int certsDownloads; ///< the number of downloaded missing certificates
+    Ssl::X509_STACK_Pointer downloadedCerts;
 };
 
 } // namespace Security

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -292,8 +292,24 @@ Ssl::PeekingPeerConnector::noteWantWrite()
 }
 
 void
+Ssl::PeekingPeerConnector::resumeNegotiationError(NegotiationErrorDetails params)
+{
+    noteNegotiationError(params.sslIoResult, params.ssl_error, params.ssl_lib_error);
+}
+
+void
 Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_error, const int ssl_lib_error)
 {
+    if (needsValidationCallouts()) {
+        typedef UnaryMemFunT<Ssl::PeekingPeerConnector, NegotiationErrorDetails> NegotiationErrorDialer;
+        NegotiationErrorDetails params(result, ssl_error, ssl_lib_error);
+        AsyncCall::Pointer resumeCall = asyncCall(83, 5,
+                                        "Ssl::PeekingPeerConnector::resumeNegotiationError",
+                                        NegotiationErrorDialer(this, &Ssl::PeekingPeerConnector::resumeNegotiationError, params));
+            suspendNegotiation(resumeCall);
+            return;
+    }
+
     const int fd = serverConnection()->fd;
     Security::SessionPointer session(fd_table[fd].ssl);
     BIO *b = SSL_get_rbio(session.get());

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -245,7 +245,6 @@ Ssl::ServerBio::ServerBio(const int anFd):
     allowSplice(false),
     allowBump(false),
     holdWrite_(false),
-    holdRead_(true),
     record_(false),
     parsedHandshake(false),
     parseError(false),
@@ -317,12 +316,6 @@ Ssl::ServerBio::readAndParse(char *buf, const int size, BIO *table)
         debugs(83, 2, "parsing error on FD " << fd_ << ": " << ex.what());
         parsedHandshake = true; // done parsing (due to an error)
         parseError = true;
-    }
-
-    if (holdRead_) {
-        debugs(83, 7, "Hold flag is set, retry latter. (Hold " << size << "bytes)");
-        BIO_set_retry_read(table);
-        return -1;
     }
 
     return giveBuffered(buf, size);

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -151,10 +151,6 @@ public:
     bool holdWrite() const {return holdWrite_;}
     /// Enables or disables the write hold state
     void holdWrite(bool h) {holdWrite_ = h;}
-    /// The read hold state
-    bool holdRead() const {return holdRead_;}
-    /// Enables or disables the read hold state
-    void holdRead(bool h) {holdRead_ = h;}
     /// Enables or disables the input data recording, for internal analysis.
     void recordInput(bool r) {record_ = r;}
     /// Whether we can splice or not the SSL stream
@@ -190,7 +186,6 @@ private:
     bool allowSplice; ///< True if the SSL stream can be spliced
     bool allowBump;  ///< True if the SSL stream can be bumped
     bool holdWrite_;  ///< The write hold state of the bio.
-    bool holdRead_;  ///< The read hold state of the bio.
     bool record_; ///< If true the input data recorded to rbuf for internal use
     bool parsedHandshake; ///< whether we are done parsing TLS Hello
     bool parseError; ///< error while parsing server hello message

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -171,9 +171,6 @@ public:
     /// Return true if the Server Hello parsing failed
     bool gotHelloFailed() const { return (parsedHandshake && parseError); }
 
-    /// \return the server certificates list if received and parsed correctly
-    const Security::CertList &serverCertificatesIfAny() { return parser_.serverCertificates; }
-
     /// \return the TLS Details advertised by TLS server.
     const Security::TlsDetails::Pointer &receivedHelloDetails() const {return parser_.details;}
 

--- a/src/ssl/gadgets.h
+++ b/src/ssl/gadgets.h
@@ -70,6 +70,7 @@ typedef std::unique_ptr<GENERAL_NAME, HardFun<void, GENERAL_NAME*, &GENERAL_NAME
 
 typedef std::unique_ptr<X509_EXTENSION, HardFun<void, X509_EXTENSION*, &X509_EXTENSION_free>> X509_EXTENSION_Pointer;
 
+typedef std::unique_ptr<X509_STORE_CTX, HardFun<void, X509_STORE_CTX *, &X509_STORE_CTX_free>> X509_STORE_CTX_Pointer;
 /**
  \ingroup SslCrtdSslAPI
  * Create 1024 bits rsa key.

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -334,6 +334,7 @@ BIO *BIO_new_SBuf(SBuf *buf);
   \ingroup ServerProtocolSSLAPI
 */
 bool PeerCertificatesVerify(Security::SessionPointer &s);
+
 } //namespace Ssl
 
 #if _SQUID_WINDOWS_

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -333,7 +333,7 @@ BIO *BIO_new_SBuf(SBuf *buf);
 /**
   \ingroup ServerProtocolSSLAPI
 */
-bool PeerCertificatesVerify(Security::SessionPointer &s);
+bool PeerCertificatesVerify(Security::SessionPointer &s,  const Ssl::X509_STACK_Pointer &extraCerts);
 
 } //namespace Ssl
 

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -182,13 +182,13 @@ void SSL_add_untrusted_cert(SSL *ssl, X509 *cert);
  * Searches in serverCertificates list for the cert issuer and if not found
  * and Authority Info Access of cert provides a URI return it.
  */
-const char *uriOfIssuerIfMissing(X509 *cert,  Security::CertList const &serverCertificates, const Security::ContextPointer &context);
+const char *uriOfIssuerIfMissing(X509 *cert, const STACK_OF(X509) *serverCertificates, const Security::ContextPointer &context);
 
 /**
  * Fill URIs queue with the uris of missing certificates from serverCertificate chain
  * if this information provided by Authority Info Access.
  */
-void missingChainCertificatesUrls(std::queue<SBuf> &URIs, Security::CertList const &serverCertificates, const Security::ContextPointer &context);
+void missingChainCertificatesUrls(std::queue<SBuf> &URIs, const STACK_OF(X509) *serverCertificates, const Security::ContextPointer &context);
 
 /**
   \ingroup ServerProtocolSSLAPI

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -329,6 +329,11 @@ void InRamCertificateDbKey(const Ssl::CertificateProperties &certProperties, SBu
   TODO: Add support for reading from `buf`.
  */
 BIO *BIO_new_SBuf(SBuf *buf);
+
+/**
+  \ingroup ServerProtocolSSLAPI
+*/
+bool PeerCertificatesVerify(Security::SessionPointer &s);
 } //namespace Ssl
 
 #if _SQUID_WINDOWS_


### PR DESCRIPTION
This patch try to handle the missing issuer certificate problem
when the TLSv1.3 is used. When TLSv1.3 is used the server certificates
are sent encrypted to the client so existing squid code which parses
server hello, extract server certificates, check for missings
and download missing if required, can not work.

This patch when a missing certificate error is detected and if the
URI of missing certificate exist, ignore the error and schedules a
second certificates verify check just before the SSL_connect try to
send keys or other required info to the remote server to complete
TLS negotiation. At this point squid suspends TLS negotiation,
downloads missing certificates if possible and re-verify
remote server certificates chain.

This is a Measurement Factory project