### PR TITLE
doCallouts before checking ssl_bump step2 rules

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3105,7 +3105,6 @@ ConnStateData::startPeekAndSpliceStep2()
     assert(http->calloutContext == nullptr);
     http->calloutContext = new ClientRequestContext(http);
     http->calloutContext->sslBumpCheckDone = true;
-    // http->calloutContext->callUsBack = This;
     http->doCallouts();
     return;
 }

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -237,8 +237,13 @@ public:
     void postHttpsAccept();
 
 #if USE_OPENSSL
+    /// Initializes the Step2 bumping step
+    void startPeekAndSpliceStep2();
+
+    void resumePeekAndSpliceStep2();
+
     /// Initializes and starts a peek-and-splice negotiation with the SSL client
-    void startPeekAndSplice();
+    void finalizePeekAndSpliceStep2();
 
     /// Called when a peek-and-splice step finished. For example after
     /// server SSL certificates received and fake server SSL certificates

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -315,10 +315,10 @@ public:
 
     /// generate a fake CONNECT request with the given payload
     /// at the beginning of the client I/O buffer
-    bool fakeAConnectRequest(const char *reason, const SBuf &payload);
+    bool fakeAConnectRequest(const char *reason, const SBuf &payload, bool doCallouts = true);
 
     /// generates and sends to tunnel.cc a fake request with a given payload
-    bool initiateTunneledRequest(HttpRequest::Pointer const &cause, Http::MethodType const method, const char *reason, const SBuf &payload);
+    bool initiateTunneledRequest(HttpRequest::Pointer const &cause, Http::MethodType const method, const char *reason, const SBuf &payload, bool doCallouts = true);
 
     /// whether we should start saving inBuf client bytes in anticipation of
     /// tunneling them to the server later (on_unsupported_protocol)

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1404,53 +1404,61 @@ ClientRequestContext::sslBumpAccessCheck()
         return false;
     }
 
-    const Ssl::BumpMode bumpMode = http->getConn()->sslBumpMode;
-    if (http->request->flags.forceTunnel) {
-        debugs(85, 5, "not needed; already decided to tunnel " << http->getConn());
-        if (bumpMode != Ssl::bumpEnd)
-            http->al->ssl.bumpMode = bumpMode; // inherited from bumped connection
-        return false;
-    }
+    auto srvBump = http->getConn()->serverBump();
+    if (srvBump && !srvBump->at(XactionStep::tlsBump2)) {
+        const Ssl::BumpMode bumpMode = http->getConn()->sslBumpMode;
+        if (http->request->flags.forceTunnel) {
+            debugs(85, 5, "not needed; already decided to tunnel " << http->getConn());
+            if (bumpMode != Ssl::bumpEnd)
+                http->al->ssl.bumpMode = bumpMode; // inherited from bumped connection
+            return false;
+        }
 
-    // If SSL connection tunneling or bumping decision has been made, obey it.
-    if (bumpMode != Ssl::bumpEnd) {
-        debugs(85, 5, HERE << "SslBump already decided (" << bumpMode <<
-               "), " << "ignoring ssl_bump for " << http->getConn());
+        // If SSL connection tunneling or bumping decision has been made, obey it.
+        if (bumpMode != Ssl::bumpEnd) {
+            debugs(85, 5, HERE << "SslBump already decided (" << bumpMode <<
+                   "), " << "ignoring ssl_bump for " << http->getConn());
 
-        // We need the following "if" for transparently bumped TLS connection,
-        // because in this case we are running ssl_bump access list before
-        // the doCallouts runs. It can be removed after the bug #4340 fixed.
-        // We do not want to proceed to bumping steps:
-        //  - if the TLS connection with the client is already established
-        //    because we are accepting normal HTTP requests on TLS port,
-        //    or because of the client-first bumping mode
-        //  - When the bumping is already started
-        if (!http->getConn()->switchedToHttps() &&
+            // We need the following "if" for transparently bumped TLS connection,
+            // because in this case we are running ssl_bump access list before
+            // the doCallouts runs. It can be removed after the bug #4340 fixed.
+            // We do not want to proceed to bumping steps:
+            //  - if the TLS connection with the client is already established
+            //    because we are accepting normal HTTP requests on TLS port,
+            //    or because of the client-first bumping mode
+            //  - When the bumping is already started
+            if (!http->getConn()->switchedToHttps() &&
                 !http->getConn()->serverBump())
-            http->sslBumpNeed(bumpMode); // for processRequest() to bump if needed and not already bumped
-        http->al->ssl.bumpMode = bumpMode; // inherited from bumped connection
-        return false;
-    }
+                http->sslBumpNeed(bumpMode); // for processRequest() to bump if needed and not already bumped
+            http->al->ssl.bumpMode = bumpMode; // inherited from bumped connection
+            return false;
+        }
 
-    // If we have not decided yet, decide whether to bump now.
+        // If we have not decided yet, decide whether to bump now.
 
-    // Bumping here can only start with a CONNECT request on a bumping port
-    // (bumping of intercepted SSL conns is decided before we get 1st request).
-    // We also do not bump redirected CONNECT requests.
-    if (http->request->method != Http::METHOD_CONNECT || http->redirect.status ||
+        // Bumping here can only start with a CONNECT request on a bumping port
+        // (bumping of intercepted SSL conns is decided before we get 1st request).
+        // We also do not bump redirected CONNECT requests.
+        if (http->request->method != Http::METHOD_CONNECT || http->redirect.status ||
             !Config.accessList.ssl_bump ||
             !http->getConn()->port->flags.tunnelSslBumping) {
-        http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
-        debugs(85, 5, HERE << "cannot SslBump this request");
-        return false;
-    }
+            http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
+            debugs(85, 5, HERE << "cannot SslBump this request");
+            return false;
+        }
 
-    // Do not bump during authentication: clients would not proxy-authenticate
-    // if we delay a 407 response and respond with 200 OK to CONNECT.
-    if (error && error->httpStatus == Http::scProxyAuthenticationRequired) {
-        http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
-        debugs(85, 5, HERE << "no SslBump during proxy authentication");
-        return false;
+        // Do not bump during authentication: clients would not proxy-authenticate
+        // if we delay a 407 response and respond with 200 OK to CONNECT.
+        if (error && error->httpStatus == Http::scProxyAuthenticationRequired) {
+            http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
+            debugs(85, 5, HERE << "no SslBump during proxy authentication");
+            return false;
+        }
+    } else {
+        // The following must be "srvBump&&srvBump->at(XactionStep::tlsBump2)"
+        // after the bug #4340 be fixed.
+        assert(!srvBump || srvBump->at(XactionStep::tlsBump2));
+        assert(http->request->method == Http::METHOD_CONNECT);
     }
 
     if (error) {
@@ -1463,6 +1471,12 @@ ClientRequestContext::sslBumpAccessCheck()
     debugs(85, 5, HERE << "SslBump possible, checking ACL");
 
     ACLFilledChecklist *aclChecklist = clientAclChecklistCreate(Config.accessList.ssl_bump, http);
+    if (srvBump && srvBump->at(XactionStep::tlsBump2)) {
+        aclChecklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpNone));
+        aclChecklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpClientFirst));
+        aclChecklist->banAction(Acl::Answer(ACCESS_ALLOWED, Ssl::bumpServerFirst));
+    }
+
     aclChecklist->nonBlockingCheck(sslBumpAccessCheckDoneWrapper, this);
     return true;
 }
@@ -1518,17 +1532,21 @@ ClientHttpRequest::processRequest()
     const bool untouchedConnect = request->method == Http::METHOD_CONNECT && !redirect.status;
 
 #if USE_OPENSSL
+    auto srvBump = getConn()->serverBump();
+    // XXX: The following "if" works however the bumping step is not updated
+    // correctly by peek-and-splice code.
+    if (srvBump && srvBump->at(XactionStep::tlsBump2)) {
+        // Update request object
+        srvBump->request = request;
+        srvBump->act.step2 = sslBumpNeed_;
+        CallJobHere(85, 4, getConn(), ConnStateData, resumePeekAndSpliceStep2);
+        return;
+    }
+
     if (untouchedConnect && sslBumpNeeded()) {
-        auto srvBump = getConn()->serverBump();
-        if (srvBump && srvBump->at(XactionStep::tlsBump2)) {
-            // Update request object
-            srvBump->request = request;
-            CallJobHere(85, 4, getConn(), ConnStateData, resumePeekAndSpliceStep2);
-        } else {
-            assert(!request->flags.forceTunnel);
-            sslBumpStart();
-        }
-            return;
+        assert(!request->flags.forceTunnel);
+        sslBumpStart();
+        return;
     }
 #endif
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1405,7 +1405,7 @@ ClientRequestContext::sslBumpAccessCheck()
     }
 
     auto srvBump = http->getConn()->serverBump();
-    if (srvBump && !srvBump->at(XactionStep::tlsBump2)) {
+    if (!srvBump || !srvBump->at(XactionStep::tlsBump2)) {
         const Ssl::BumpMode bumpMode = http->getConn()->sslBumpMode;
         if (http->request->flags.forceTunnel) {
             debugs(85, 5, "not needed; already decided to tunnel " << http->getConn());

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1523,7 +1523,7 @@ ClientHttpRequest::processRequest()
         if (srvBump && srvBump->at(XactionStep::tlsBump2)) {
             // Update request object
             srvBump->request = request;
-            getConn()->resumePeekAndSpliceStep2();
+            CallJobHere(85, 4, getConn(), ConnStateData, resumePeekAndSpliceStep2);
         } else {
             assert(!request->flags.forceTunnel);
             sslBumpStart();

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -169,7 +169,10 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
         if (hostName)
             SSL_set_ex_data(serverSession.get(), ssl_ex_index_server, (void*)hostName);
 
-        Must(!csd->serverBump() || csd->serverBump()->at(XactionStep::tlsBump1, XactionStep::tlsBump2));
+        // XXX: The serverBump step should never be tlsBump1 here however
+        // for now the serverBump->step is not update correctly when
+        // bump is decided at step1.
+        Must(!csd->serverBump() || csd->serverBump()->at(XactionStep::tlsBump1, XactionStep::tlsBump3));
         if (csd->sslBumpMode == Ssl::bumpPeek || csd->sslBumpMode == Ssl::bumpStare) {
             auto clientSession = fd_table[clientConn->fd].ssl.get();
             Must(clientSession);

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -75,3 +75,18 @@ Ssl::ServerBump::sslErrors() const
     return errs;
 }
 
+void
+Ssl::ServerBump::storeEntryError(StoreEntry *e)
+{
+    if (entry) {
+        assert(sc);
+        storeUnregister(sc, entry, this);
+        entry->unlock("Ssl::ServerBump");
+    }
+    entry = e;
+    entry->lock("Ssl::ServerBump");
+    sc = storeClientListAdd(entry, this);
+#if USE_DELAY_POOLS
+    sc->setDelayId(DelayId::DelayClient(http));
+#endif
+}

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -49,6 +49,8 @@ public:
     /// whether we are currently performing one of the given processing steps
     bool at(const BumpStep step1, const BumpStep step2) const { return at(step1) || at(step2); }
 
+    void storeEntryError(StoreEntry *r);
+
     /// faked, minimal request; required by Client API
     HttpRequest::Pointer request;
     StoreEntry *entry; ///< for receiving Squid-generated error messages


### PR DESCRIPTION
During step2, our documentation promises a doCallouts() call
(step 2.2) after TLS ClientHello is parsed (step 2.1) and before
ssl_bump is revisited (step 2.3):

    2.1: Get TLS Client Hello info from the client, including SNI
           where available. Adjust the CONNECT request from step1 to
           reflect SNI.

     2.2: Go through the Callout Sequence with the adjusted CONNECT
             request mentioned above.

     2.3: Evaluate again all ssl_bump rules and perform the first 
            matching action (splice, bump, peek, stare, or terminate).

However currently in Squid v5 (at least), step 2.3 happens immediately
after step 2.1, breaking essential step2-blocking-with-an-error-message
use cases.

This patch fixes master/v6 code to match the documentation.

This is a Measurement Factory project
