### PR TITLE
Do not stop listening after "ERROR: NAT/TPROXY lookup failed..."

### DIFF
--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -95,6 +95,7 @@ Ftp::Channel::opened(const Comm::ConnectionPointer &newConn,
     assert(aCloser != NULL);
 
     conn = newConn;
+    conn->leaveOrphanage();
     closer = aCloser;
     comm_add_close_handler(conn->fd, closer);
 }

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -388,6 +388,7 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
     // so we end up with a uniform "(HTTP|FTP-data|HTTPS|...) remote-ip:remote-port"
     fd_open(sock, FD_SOCKET, "HTTP Request");
     details->fd = sock;
+    details->enterOrphanage(); // nobody owns this connection yet
 
     details->remote = *gai;
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -382,7 +382,13 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
     }
 
     Must(sock >= 0);
+
+    // Sync with Comm ASAP so that abandoned details can properly close().
+    // XXX : these are not all HTTP requests. use a note about type and ip:port details->
+    // so we end up with a uniform "(HTTP|FTP-data|HTTPS|...) remote-ip:remote-port"
+    fd_open(sock, FD_SOCKET, "HTTP Request");
     details->fd = sock;
+
     details->remote = *gai;
 
     // lookup the local-end details of this new connection
@@ -425,11 +431,6 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
             return Comm::NOMESSAGE;
         }
     }
-
-    /* fdstat update */
-    // XXX : these are not all HTTP requests. use a note about type and ip:port details->
-    // so we end up with a uniform "(HTTP|FTP-data|HTTPS|...) remote-ip:remote-port"
-    fd_open(sock, FD_SOCKET, "HTTP Request");
 
     fde *F = &fd_table[sock];
     details->remote.toStr(F->ipaddr,MAX_IPSTRLEN);

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -408,9 +408,8 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
     // Perform NAT or TPROXY operations to retrieve the real client/dest IP addresses
     if (conn->flags&(COMM_TRANSPARENT|COMM_INTERCEPTION) && !Ip::Interceptor.Lookup(details, conn)) {
         debugs(50, DBG_IMPORTANT, "ERROR: NAT/TPROXY lookup failed to locate original IPs on " << details);
-        // Failed.
         PROF_stop(comm_accept);
-        return Comm::COMM_ERROR;
+        return Comm::NOMESSAGE;
     }
 
 #if USE_SQUID_EUI

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -54,6 +54,7 @@ public:
     TcpAcceptor(const Comm::ConnectionPointer &conn, const char *note, const Subscription::Pointer &aSub);
     TcpAcceptor(const AnyP::PortCfgPointer &listenPort, const char *note, const Subscription::Pointer &aSub);
 
+protected:
     /** Subscribe a handler to receive calls back about new connections.
      * Unsubscribes any existing subscribed handler.
      */
@@ -80,7 +81,6 @@ public:
     /// if not the accept() will be postponed
     static bool okToAccept();
 
-protected:
     friend class AcceptLimiter;
 
 private:

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -418,6 +418,7 @@ Ftp::Server::acceptDataConnection(const CommAcceptCbParams &params)
     } else {
         closeDataConnection();
         dataConn = params.conn;
+        dataConn->leaveOrphanage();
         uploadAvailSize = 0;
         debugs(33, 7, "ready for data");
         if (onDataAcceptCall != NULL) {

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -29,7 +29,9 @@ Server::Server(const MasterXaction::Pointer &xact) :
     transferProtocol(xact->squidPort->transport),
     port(xact->squidPort),
     receivedFirstByte_(false)
-{}
+{
+    clientConnection->leaveOrphanage();
+}
 
 bool
 Server::doneAll() const


### PR DESCRIPTION
Do not stop listening after "ERROR: NAT/TPROXY lookup failed..."

_Intermittent_ NAT/TPROXY lookup failures can happen for several reasons
outside Squid control. For example, flushing conntrack tables under load
is likely to trigger such errors. Squid should not stop listening if
there is a good change that the next accept(2) will be fully successful.

We already apply the same logic to several other accept problems today.
Moreover, AFAICT, Squid did not stop listening after any accept errors
until commit cbff89b dated 2011, and that undocumented change could have
been an accident (bugs and confusion started earlier).

----

Avoid "BUG #3329: Lost orphan ..." during accept problems

Comm::TcpAcceptor creates a Comm::Connection with an open FD. Lots of
things could go wrong while that connection object travels to its
intended owner (e.g. Ftp::Server). A Connection object abandoned during
that travel will auto-close, triggering level-4 "BUG #3329" messages.

TODO: The manual enter/leaveOrphanage() tracking is unreliable. We need
to design and implement a true connection ownership concept that does
not require such tracking. These changes highlight handover spots.

Also made a few TcpAcceptor members protected to reduce the chance of
missing a Connection recipient (i.e. TcpAcceptor subscriber). Most of
these members should be (at least) protected for other reasons as well.

----

Fix "BUG 3556: FD ... is not an open socket" for accept problems

Many things could go wrong after Squid successfully accept(2)ed a socket
and before that socket was registered with Comm. During that window, the
socket is stored in a refcounted Connection object. When that object was
auto-destroyed on the error handling path, its attempt to auto-close the
socket would trigger level-1 BUG 3556 errors because the socket was not
yet opened from Comm point of view. This change eliminates that "already
in Connection but not yet in Comm" window.

The fixed BUG 3556 errors stalled affected clients and leaked their FDs.

TODO: Keeping that window closed should not require a human effort, but
achieving that goal probably requires serious changes.
