### PR TITLE
Apply indirect client IP to tunneled requests

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -224,6 +224,9 @@ static void free_sslproxy_cert_adapt(sslproxy_cert_adapt **cert_adapt);
 static void parse_sslproxy_ssl_bump(acl_access **ssl_bump);
 static void dump_sslproxy_ssl_bump(StoreEntry *entry, const char *name, acl_access *ssl_bump);
 static void free_sslproxy_ssl_bump(acl_access **ssl_bump);
+static void parse_bumped_traffic_indirect_client_address(Ssl::Config::BumpedXFFMode *value);
+static void dump_bumped_traffic_indirect_client_address(StoreEntry *entry, const char *name, Ssl::Config::BumpedXFFMode value);
+static void free_bumped_traffic_indirect_client_address(Ssl::Config::BumpedXFFMode *value);
 #endif /* USE_OPENSSL */
 
 static void parse_ftp_epsv(acl_access **ftp_epsv);
@@ -5052,3 +5055,36 @@ free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuardsPtr)
     protoGuards = nullptr;
 }
 
+#if USE_OPENSSL
+static std::vector<std::string> BumpedXFFMode_str = {
+    std::string("none"),
+    std::string("tunnel"),
+    std::string("follow_x_forwarded_for")
+};
+
+static void parse_bumped_traffic_indirect_client_address(Ssl::Config::BumpedXFFMode *value)
+{
+    std::string token(ConfigParser::NextToken());
+    if (token.empty()) {
+        self_destruct();
+        return;
+    }
+
+    auto it = std::find(BumpedXFFMode_str.begin(), BumpedXFFMode_str.end(), token);
+    if (it == BumpedXFFMode_str.end()) {
+        self_destruct();
+        return;
+    }
+    *value = static_cast<Ssl::Config::BumpedXFFMode>(it - BumpedXFFMode_str.begin());
+}
+
+static void dump_bumped_traffic_indirect_client_address(StoreEntry *entry, const char *name, Ssl::Config::BumpedXFFMode value)
+{
+    storeAppendPrintf(entry, "%s %s\n", name, BumpedXFFMode_str.at(value).c_str());
+}
+
+static void free_bumped_traffic_indirect_client_address(Ssl::Config::BumpedXFFMode *value)
+{
+    *value = Ssl::Config::xffNone;
+}
+#endif

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -20,6 +20,7 @@ AuthSchemes		acl auth_param
 b_int64_t
 b_size_t
 b_ssize_t
+bumped_traffic_indirect_client_address
 cachedir		cache_replacement_policy
 cachemgrpasswd
 ConfigAclTos

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1795,6 +1795,15 @@ DOC_START
 	sources is required to prevent abuse of your proxy.
 DOC_END
 
+NAME: bumped_traffic_indirect_client_address
+TYPE: bumped_traffic_indirect_client_address
+COMMENT: none|tunnel|follow_x_forwarded_for
+IFDEF: FOLLOW_X_FORWARDED_FOR&&USE_OPENSSL
+DEFAULT: none
+LOC: Ssl::TheConfig.bumped_traffic_indirect_client_address
+DOC_START
+DOC_END
+
 NAME: spoof_client_ip
 TYPE: acl_access
 LOC: Config.accessList.spoof_client_ip

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1802,6 +1802,22 @@ IFDEF: FOLLOW_X_FORWARDED_FOR&&USE_OPENSSL
 DEFAULT: none
 LOC: Ssl::TheConfig.bumped_traffic_indirect_client_address
 DOC_START
+	Controls which address will be used as indirect client address
+	for the HTTP requests tunneled through a bumped connection.
+
+		bumped_traffic_indirect_client_address <mode>
+
+	Supported modes are:
+
+	none	Use the direct client IP address as indirect
+		client address
+
+	tunnel	Use the indirect client address of the bumped CONNECT
+		request
+
+	follow_x_forwarded_for
+		The indirect client address computed for each tunneled
+		HTTP request from its XFF headers
 DOC_END
 
 NAME: spoof_client_ip

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3236,6 +3236,8 @@ ConnStateData::initiateTunneledRequest(HttpRequest::Pointer const &cause, Http::
     debugs(33, 2, "Request tunneling for " << reason);
     ClientHttpRequest *http = buildFakeRequest(method, connectHost, connectPort, payload);
     HttpRequest::Pointer request = http->request;
+    if (cause)
+        request->indirect_client_addr = cause->indirect_client_addr;
     request->flags.forceTunnel = true;
     http->calloutContext = new ClientRequestContext(http);
     http->doCallouts();

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2904,14 +2904,15 @@ ConnStateData::switchToHttps(ClientHttpRequest *http, Ssl::BumpMode bumpServerMo
     // but we are now performing the HTTPS handshake traffic
     transferProtocol.protocol = AnyP::PROTO_HTTPS;
 
+    // XXX: The following statement is (probably) wrong, the sslServerBump
+    // is always nil here:
     // If sslServerBump is set, then we have decided to deny CONNECT
     // and now want to switch to SSL to send the error to the client
     // without even peeking at the origin server certificate.
-    if (bumpServerMode == Ssl::bumpServerFirst && !sslServerBump) {
-        request->flags.sslPeek = true;
-        sslServerBump = new Ssl::ServerBump(http);
-    } else if (bumpServerMode == Ssl::bumpPeek || bumpServerMode == Ssl::bumpStare) {
-        request->flags.sslPeek = true;
+    if (!sslServerBump) {
+        request->flags.sslPeek = bumpServerMode == Ssl::bumpServerFirst ||
+                                 bumpServerMode == Ssl::bumpPeek ||
+                                 bumpServerMode == Ssl::bumpStare;
         sslServerBump = new Ssl::ServerBump(http, nullptr, bumpServerMode);
     }
 
@@ -2991,7 +2992,8 @@ ConnStateData::parseTlsHandshake()
         return;
     }
 
-    if (!sslServerBump || sslServerBump->act.step1 == Ssl::bumpClientFirst) { // Either means client-first.
+    Must(sslServerBump);
+    if (sslServerBump->act.step1 == Ssl::bumpBump || sslServerBump->act.step1 == Ssl::bumpClientFirst) { // Either means client-first.
         getSslContextStart();
         return;
     } else if (sslServerBump->act.step1 == Ssl::bumpServerFirst) {

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -70,6 +70,7 @@
 #endif
 #endif
 #if USE_OPENSSL
+#include "ssl/Config.h"
 #include "ssl/ServerBump.h"
 #include "ssl/support.h"
 #endif
@@ -681,9 +682,13 @@ void
 ClientRequestContext::clientAccessCheck()
 {
 #if FOLLOW_X_FORWARDED_FOR
-    if (!http->request->flags.doneFollowXff() &&
-            Config.accessList.followXFF &&
-            http->request->header.has(Http::HdrType::X_FORWARDED_FOR)) {
+    if (http->request->flags.sslBumped && Ssl::TheConfig.bumped_traffic_indirect_client_address == Ssl::Config::xffTunnel) {
+        http->request->indirect_client_addr = http->getConn()->serverBump()->indirectClient;
+    } else if (http->request->flags.sslBumped && Ssl::TheConfig.bumped_traffic_indirect_client_address == Ssl::Config::xffNone) {
+        // let the default indirect client which is the client ip address
+    } else if (!http->request->flags.doneFollowXff() &&
+               Config.accessList.followXFF &&
+               http->request->header.has(Http::HdrType::X_FORWARDED_FOR)) {
 
         /* we always trust the direct client address for actual use */
         http->request->indirect_client_addr = http->request->client_addr;

--- a/src/ssl/Config.h
+++ b/src/ssl/Config.h
@@ -17,6 +17,8 @@ namespace Ssl
 class Config
 {
 public:
+    enum BumpedXFFMode {xffNone = 0, xffTunnel, xffFollowXForwaredFor};
+
 #if USE_SSL_CRTD
     char *ssl_crtd; ///< Name of external ssl_crtd application.
     /// The number of processes spawn for ssl_crtd.
@@ -24,6 +26,10 @@ public:
 #endif
     char *ssl_crt_validator;
     ::Helper::ChildConfig ssl_crt_validator_Children;
+#if FOLLOW_X_FORWARDED_FOR
+    BumpedXFFMode bumped_traffic_indirect_client_address;
+#endif
+
     Config();
     ~Config();
 private:

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -44,6 +44,9 @@ Ssl::ServerBump::ServerBump(ClientHttpRequest *http, StoreEntry *e, Ssl::BumpMod
 #if USE_DELAY_POOLS
     sc->setDelayId(DelayId::DelayClient(http));
 #endif
+#if FOLLOW_X_FORWARDED_FOR
+    indirectClient = request->indirect_client_addr;
+#endif
 }
 
 Ssl::ServerBump::~ServerBump()

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -62,6 +62,10 @@ public:
     } act; ///< bumping actions at various bumping steps
     Ssl::BumpStep step; ///< The SSL bumping step
 
+#if FOLLOW_X_FORWARDED_FOR
+    Ip::Address indirectClient;
+#endif
+
 private:
     Security::SessionPointer serverSession; ///< The TLS session object on server side.
     store_client *sc; ///< dummy client to prevent entry trimming


### PR DESCRIPTION
This patch adjusts Squid to use the trusted "indirect" client IP
for all HTTP requests inside a bumped CONNECT tunnel, ignoring any
XFF headers already present in those tunneled requests.

The exact behaviour is configured using the
bumped_traffic_indirect_client_address configuration parameter.

The new parameter can take one of the following values:
  "none": As indirect client address of the tunneled HTTP requests
              always used the direct client ip address.
  "tunnel": As indirect client address used the indirect client
              address of the parent CONNECT request.
 "follow_x_forwarded_for": This is the current behavior. The
              indirect client address computed for each HTTP
              tunneled request from its XFF headers if exist any.
    
Also fixes Squid to use as indirect client IP address for the the
fake CONNECT request, which is currently build and logged
in the case of splicing at step2, the same value used for the
original CONNECT request.

This is a Measurement Factory project