### PR TITLE
Fix client TLS hello mimicking while connecting to remote TLS server

### DIFF
--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -595,7 +595,7 @@ ACLDestinationASNStrategy::match (ACLData<MatchType> * &data, ACLFilledChecklist
     const ipcache_addrs *ia = ipcache_gethostbyname(checklist->request->url.host(), IP_LOOKUP_IF_MISS);
 
     if (ia) {
-        for (const auto ip: ia->goodAndBad()) {
+        for (const auto &ip: ia->goodAndBad()) {
             if (data->match(ip))
                 return 1;
         }

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -67,7 +67,7 @@ ACLDestinationIP::match(ACLChecklist *cl)
     if (ia) {
         /* Entry in cache found */
 
-        for (const auto ip: ia->goodAndBad()) {
+        for (const auto &ip: ia->goodAndBad()) {
             if (ACLIP::match(ip))
                 return 1;
         }

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -258,16 +258,16 @@ Rock::Rebuild::Stats::Init(const SwapDir &dir)
 }
 
 bool
-Rock::Rebuild::Stats::completed(const SwapDir &sd) const
+Rock::Rebuild::Stats::completed(const SwapDir &dir) const
 {
-    return DoneLoading(counts.scancount, sd.slotLimitActual()) &&
-           DoneValidating(counts.validations, sd.slotLimitActual(), sd.entryLimitActual());
+    return DoneLoading(counts.scancount, dir.slotLimitActual()) &&
+           DoneValidating(counts.validations, dir.slotLimitActual(), dir.entryLimitActual());
 }
 
 /* Rebuild */
 
 bool
-Rock::Rebuild::IsResponsible(const SwapDir &sd)
+Rock::Rebuild::IsResponsible(const SwapDir &dir)
 {
     // in SMP mode, only the disker is responsible for populating the map
     return !UsingSmp() || IamDiskProcess();

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -41,8 +41,8 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 #line 24 "RegisteredHeadersHash.gperf"
-struct HeaderTableRecord;
-        enum
+class HeaderTableRecord;
+    enum
 {
     TOTAL_KEYWORDS = 88,
     MIN_WORD_LENGTH = 2,
@@ -103,7 +103,7 @@ class HttpHeaderHashTable
 private:
     static inline unsigned int HttpHeaderHash (const char *str, size_t len);
 public:
-    static const struct HeaderTableRecord *lookup (const char *str, size_t len);
+    static const class HeaderTableRecord *lookup (const char *str, size_t len);
 };
 
 inline unsigned int
@@ -171,7 +171,7 @@ static const unsigned char lengthtable[] =
     19,  0,  0,  0, 18, 14,  0,  0, 13, 13,  0, 13
 };
 
-static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
+static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
 {
     {""}, {""}, {""}, {""}, {""},
 #line 67 "RegisteredHeadersHash.gperf"
@@ -363,7 +363,7 @@ static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader}
 };
 
-const struct HeaderTableRecord *
+const class HeaderTableRecord *
 HttpHeaderHashTable::lookup (const char *str, size_t len)
 {
     if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -21,7 +21,7 @@
 %global-table
 %ignore-case
 %struct-type 
-struct HeaderTableRecord;
+class HeaderTableRecord;
 %%
 Accept, Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader
 Accept-Charset, Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader

--- a/src/multicast.cc
+++ b/src/multicast.cc
@@ -42,7 +42,7 @@ mcastJoinGroups(const ipcache_addrs *ia, const Dns::LookupDetails &, void *)
         return;
     }
 
-    for (const auto ip: ia->goodAndBad()) { // TODO: Consider using just good().
+    for (const auto &ip: ia->goodAndBad()) { // TODO: Consider using just good().
         debugs(7, 9, "Listening for ICP requests on " << ip);
 
         if (!ip.isIPv4()) {

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -209,7 +209,8 @@ Security::TlsDetails::TlsDetails():
     tlsTicketsExtension(false),
     hasTlsTicket(false),
     tlsStatusRequest(false),
-    unsupportedExtensions(false)
+    unsupportedExtensions(false),
+    tlsPadding(false)
 {
 }
 
@@ -459,6 +460,9 @@ Security::HandshakeParser::parseExtensions(const SBuf &raw)
             details->tlsAppLayerProtoNeg = tkAPN.pstring16("APN");
             break;
         }
+        case 21: // Padding extension RFC 7685
+            details->tlsPadding = true;
+            break;
         case 35: // SessionTicket TLS Extension; RFC 5077
             details->tlsTicketsExtension = true;
             details->hasTlsTicket = !extension.data.isEmpty();
@@ -481,7 +485,7 @@ Security::HandshakeParser::parseCiphers(const SBuf &raw)
     Parser::BinaryTokenizer tk(raw);
     while (!tk.atEnd()) {
         const uint16_t cipher = tk.uint16("cipher");
-        details->ciphers.insert(cipher); // including Squid-unsupported ones
+        details->ciphers.push_back(cipher); // including Squid-unsupported ones
     }
 }
 
@@ -499,7 +503,7 @@ Security::HandshakeParser::parseV23Ciphers(const SBuf &raw)
         const uint8_t prefix = tk.uint8("prefix");
         const uint16_t cipher = tk.uint16("cipher");
         if (prefix == 0)
-            details->ciphers.insert(cipher); // including Squid-unsupported ones
+            details->ciphers.push_back(cipher); // including Squid-unsupported ones
     }
 }
 
@@ -513,7 +517,7 @@ Security::HandshakeParser::parseServerHelloHandshakeMessage(const SBuf &raw)
     tk.skip(HelloRandomSize, ".random");
     details->sessionId = tk.pstring8(".session_id");
     // cipherSuite may be unsupported by a peeking Squid
-    details->ciphers.insert(tk.uint16(".cipher_suite"));
+    details->ciphers.push_back(tk.uint16(".cipher_suite"));
     details->compressionSupported = tk.uint8(".compression_method") != 0; // not null
     if (!tk.atEnd()) // extensions present
         parseExtensions(tk.pstring16(".extensions"));

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -14,7 +14,7 @@
 #include "parser/BinaryTokenizer.h"
 #include "security/forward.h"
 
-#include <unordered_set>
+#include <vector>
 
 namespace Security
 {
@@ -42,11 +42,12 @@ public:
     bool tlsStatusRequest; ///< whether the TLS status request extension is set
     bool unsupportedExtensions; ///< whether any unsupported by Squid extensions are used
     SBuf tlsAppLayerProtoNeg; ///< The value of the TLS application layer protocol extension if it is enabled
+    bool tlsPadding = false;
     /// The client random number
     SBuf clientRandom;
     SBuf sessionId;
 
-    typedef std::unordered_set<uint16_t> Ciphers;
+    typedef std::vector<uint16_t> Ciphers;
     Ciphers ciphers;
 };
 

--- a/src/security/NegotiationHistory.cc
+++ b/src/security/NegotiationHistory.cc
@@ -38,6 +38,10 @@ static AnyP::ProtocolVersion
 toProtocolVersion(const int v)
 {
     switch(v) {
+#if defined(TLS1_3_VERSION)
+    case TLS1_3_VERSION:
+        return AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
+#endif
 #if defined(TLS1_2_VERSION)
     case TLS1_2_VERSION:
         return AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2);

--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -947,7 +947,7 @@ snmpCreateOidFromStr(const char *str, oid **name, int *nl)
     }
 
     // if we aborted before the lst octet was found, return false.
-    safe_free(name);
+    safe_free(*name);
     return false;
 }
 

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -727,6 +727,18 @@ applyTlsDetailsToSSL(SSL *ssl, Security::TlsDetails::Pointer const &details, Ssl
 #if defined(TLSEXT_STATUSTYPE_ocsp)
     if (details->tlsStatusRequest)
         SSL_set_tlsext_status_type(ssl, TLSEXT_STATUSTYPE_ocsp);
+    else
+        SSL_set_tlsext_status_type(ssl, 0);
+#endif
+
+#if defined(SSL_OP_NO_TICKET)
+    if (!details->tlsTicketsExtension)
+        SSL_set_options(ssl, SSL_OP_NO_TICKET);
+#endif
+
+#if defined(SSL_OP_TLSEXT_PADDING)
+    if (details->tlsPadding)
+        SSL_set_options(ssl, SSL_OP_TLSEXT_PADDING);
 #endif
 
 #if defined(TLSEXT_TYPE_application_layer_protocol_negotiation)


### PR DESCRIPTION
When squid bumps TLS connections it tries to mimic the client
hello messages if possible. Between others try to support the
same TLS extensions with the client and support the same
ciphers.
This patch fixes mimicking procedure to:
- preserve the listed ciphers order if possible 
- preserve the TLS padding extension
- do not add the ocsp status extension if client does not support it
- do not add TLS tickets extension if client TLS hello message
  does not include this extension.

This is a Measurement Factory Project