### PR TITLE
Preserve caller context across deferred reads

### DIFF
--- a/src/CommRead.h
+++ b/src/CommRead.h
@@ -41,6 +41,7 @@ public:
     CommRead theRead;
     bool cancelled;
     AsyncCall::Pointer closer; ///< internal close handler used by Comm
+    CodeContext::Pointer codeContext; ///< creator's context
 
 private:
 };

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1745,9 +1745,13 @@ CommRead::CommRead() : conn(NULL), buf(NULL), len(0), callback(NULL) {}
 CommRead::CommRead(const Comm::ConnectionPointer &c, char *buf_, int len_, AsyncCall::Pointer &callback_)
     : conn(c), buf(buf_), len(len_), callback(callback_) {}
 
-DeferredRead::DeferredRead () : theReader(NULL), theContext(NULL), theRead(), cancelled(false) {}
+DeferredRead::DeferredRead() :
+    theReader(nullptr), theContext(nullptr), theRead(), cancelled(false), codeContext(CodeContext::Current())
+{}
 
-DeferredRead::DeferredRead (DeferrableRead *aReader, void *data, CommRead const &aRead) : theReader(aReader), theContext (data), theRead(aRead), cancelled(false) {}
+DeferredRead::DeferredRead(DeferrableRead *aReader, void *data, CommRead const &aRead) :
+    theReader(aReader), theContext (data), theRead(aRead), cancelled(false), codeContext(CodeContext::Current())
+{}
 
 DeferredReadManager::~DeferredReadManager()
 {
@@ -1865,7 +1869,9 @@ DeferredReadManager::kickARead(DeferredRead const &aRead)
 
     debugs(5, 3, "Kicking deferred read on " << aRead.theRead.conn);
 
-    aRead.theReader(aRead.theContext, aRead.theRead);
+    CallBack(aRead.codeContext, [&aRead] {
+        aRead.theReader(aRead.theContext, aRead.theRead);
+    });
 }
 
 void


### PR DESCRIPTION
Before this fix, the transaction context was not saved/restored when
dealing with deferred reads initiated by events, such as
DelayPools::Update() event.