### PR TITLE
Allow "file" syntax for 'squid_error' and 'has' ACLs

### DIFF
--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -23,7 +23,7 @@ ACLHasComponentData::ACLHasComponentData()
 void
 ACLHasComponentData::parse()
 {
-    const char *tok = ConfigParser::NextToken();
+    const char *tok = ConfigParser::strtokFile();
     if (!tok) {
         debugs(28, DBG_CRITICAL, "FATAL: \"has\" acl argument missing");
         self_destruct();

--- a/src/acl/SquidErrorData.cc
+++ b/src/acl/SquidErrorData.cc
@@ -47,7 +47,7 @@ ACLSquidErrorData::dump() const
 void
 ACLSquidErrorData::parse()
 {
-    while (char *token = ConfigParser::NextToken()) {
+    while (char *token = ConfigParser::strtokFile()) {
         err_type err = errorTypeByName(token);
 
         if (err < ERR_MAX)


### PR DESCRIPTION
By default, these two ACLs(unlike all other ones) do not support loading
from a file. They can use parameters("/path/filename") setting for this
purpose, but it works only if configuration_includes_quoted_values is
on.  There seems nothing special about these two ACLs, justifying their
different behavior: I assume that it was just an unfortunate choice of
the ConfigParser method (NextToken() instead of strtokFile()) during
their implementation.