### PR TITLE
malformed_request_header_edit directive

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -484,7 +484,20 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             break;      /* terminating blank line */
         }
 
-        const auto e = HttpHeaderEntry::parse(field_start, field_end, owner);
+        auto e = HttpHeaderEntry::parse(field_start, field_end, owner);
+
+        if (!e && Config.malformed_request_header_edit) {
+            debugs(55, 3, "attempting to adjust the unparsable HTTP header field {" <<
+                    getStringPrefix(field_start, field_end-field_start) << "}");
+            const auto action = Config.malformed_request_header_edit->fix(&field_start, &field_end);
+            if (action == Http::HeaderEditor::Action::remove)
+                continue;
+            else if (action == Http::HeaderEditor::Action::apply)
+                e = HttpHeaderEntry::parse(field_start, field_end, owner);
+            else
+                assert(action == Http::HeaderEditor::Action::ignore);
+        }
+
         if (!e) {
             debugs(55, warnOnError, "WARNING: unparsable HTTP header field {" <<
                    getStringPrefix(field_start, field_end-field_start) << "}");

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -17,6 +17,7 @@
 #include "DelayConfig.h"
 #endif
 #include "helper/ChildConfig.h"
+#include "http/HeaderEditor.h"
 #include "HttpHeaderTools.h"
 #include "ip/Address.h"
 #if USE_DELAY_POOLS
@@ -484,6 +485,7 @@ public:
     HttpUpgradeProtocolAccess *http_upgrade_request_protocols;
     ///note
     Notes notes;
+    Http::HeaderEditor *malformed_request_header_edit;
     char *coredump_dir;
     char *chroot_dir;
 #if USE_CACHE_DIGESTS

--- a/src/base/RegexPattern.cc
+++ b/src/base/RegexPattern.cc
@@ -32,6 +32,21 @@ RegexPattern::~RegexPattern()
     regfree(&regex);
 }
 
+bool
+RegexPattern::match(const char *str, const int maxGroups)
+{
+    // Must((flags & REG_NOSUB) == 0);
+    groups.resize(maxGroups);
+    groups.clear();
+    return regexec(&regex, str, maxGroups, &groups[0], 0) == 0;
+}
+
+SBuf
+RegexPattern::capture(const uint64_t captureNum) const {
+    Must(captureNum < groups.size());
+    return SBuf(&pattern[groups[captureNum].rm_so], groups[captureNum].rm_eo - groups[captureNum].rm_so);
+}
+
 RegexPattern &
 RegexPattern::operator =(RegexPattern &&o)
 {

--- a/src/base/RegexPattern.h
+++ b/src/base/RegexPattern.h
@@ -11,6 +11,9 @@
 
 #include "compat/GnuRegex.h"
 #include "mem/forward.h"
+#include "sbuf/SBuf.h"
+
+#include <vector>
 
 /**
  * A regular expression,
@@ -35,9 +38,18 @@ public:
     const char * c_str() const {return pattern;}
     bool match(const char *str) const {return regexec(&regex,str,0,NULL,0)==0;}
 
+    /// Match str against the expression with maximum maxGroups sub-expressions.
+    /// The result is stored in the groups array.
+    bool match(const char *str, const int maxGroups);
+
+    /// the matched sub-expression an captureNum position
+    SBuf capture(const uint64_t captureNum) const;
+
 public:
     int flags;
     regex_t regex;
+    /// matched sub-expression list after the last match(str, maxGroups) call
+    std::vector<regmatch_t> groups;
 
 private:
     char *pattern;

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -98,3 +98,4 @@ sslproxy_cert_sign	acl
 sslproxy_cert_adapt	acl
 ftp_epsv                acl
 cache_log_message
+Http::HeaderEditor* acl

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7013,6 +7013,78 @@ DOC_START
 	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 DOC_END
 
+NAME: malformed_request_header_edit
+IFDEF: USE_HTTP_VIOLATIONS
+TYPE: Http::HeaderEditor*
+LOC: Config.malformed_request_header_edit
+DEFAULT: none
+DOC_START
+	Controls adjustments of received HTTP request headers that Squid considers
+	so malformed that they have to be rejected. These optional adjustments are
+	performed once per request, as a last resort measure. If no adjustments
+	apply or if Squid still rejects the adjusted header, the whole request is
+	rejected.
+
+	Usage: malformed_request_header_edit <command> if [!]acl...
+
+	Editing commands with mismatching ACL(s) are ignored.
+
+	Multiple commands with matching ACL(s) are applied in configuration order.
+
+	The command part has the following syntax:
+
+		replace <how> <what>... with <replacement>
+
+	Supported <how> values:
+
+		first	Replaces the first match and stops processing the command.
+		each	Replaces each match.
+		all	Replaces the first match and removes other matches.
+
+	The <what> parameter specifies a POSIX regular expression to search for:
+
+		re(flags)::delimiter"PATTERN"delimiter    The repeated delimiter is
+		a possibly empty sequence of ASCII alphanumeric characters and "_".
+		The PATTERN itself must not contain the `"delimiter` sequence. If no
+		matching flags are necessary, the "(flags)" sequence can be omitted.
+		TODO: Document supported flags. TODO: Move this reusable documentation
+		to document preface?
+
+	If multiple <what> parameters are specified, they are interpreted as if
+	individual patterns were ORed together. However, Squid preserves
+	configured pattern evaluation order (which is important for some <how>
+	values) and each replacement pattern may carry distinct flags.
+
+	The <replacement> parameter is a logformat format specification. TODO:
+	Add/document %regex_match{n} logformat %code. TODO: Add/document
+	lf::"FORMAT" support to allow multiline format specifications with
+	comments.
+
+	The adjustments are applied to multiline input buffer containing request
+	headers without the request-line and without the terminating CRLF CRLF
+	sequence (or equivalent).
+	TODO: Apply to request-line as well?
+
+	TODO: Add malformed_reply_header_edit.
+
+	TODO: Add a "malformed_request" or similar ACL and apply to all received
+	requests despite performance costs of checking at least that ACL??
+
+	Examples:
+
+		# fix broken Cache-Control headers sent by a trusted user Foo
+		malformed_request_header_edit \
+			replace each re::"^Cache Control No-store:(.*)$" \
+			with lf::"Cache-Control: no-store, %regex_match{1}" \
+			if fromFoo
+
+		# fix repeated Transfer-Encoding headers sent by a trusted app Bar
+		malformed_request_header_edit \
+			replace all re::"^Transfer-Encoding:.*chunked.*$" \
+			with lf::"Transfer-Encoding: chunked" \
+			if fromBar
+DOC_END
+
 NAME: relaxed_header_parser
 COMMENT: on|off|warn
 TYPE: tristate

--- a/src/format/ByteCode.h
+++ b/src/format/ByteCode.h
@@ -252,7 +252,9 @@ typedef enum {
     /* PROXY protocol details */
     LFT_PROXY_PROTOCOL_RECEIVED_HEADER,
     LFT_PROXY_PROTOCOL_RECEIVED_HEADER_ELEM,
-    LFT_PROXY_PROTOCOL_RECEIVED_ALL_HEADERS
+    LFT_PROXY_PROTOCOL_RECEIVED_ALL_HEADERS,
+
+    LFT_REGEX_HEADER_EDIT
 } ByteCode_t;
 
 /// Quoting style for a format output.

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "AccessLogEntry.h"
 #include "base64.h"
+#include "base/RegexPattern.h"
 #include "client_side.h"
 #include "comm/Connection.h"
 #include "error/Detail.h"
@@ -374,7 +375,7 @@ actualRequestHeader(const AccessLogEntry::Pointer &al)
 }
 
 void
-Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logSequenceNumber) const
+Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logSequenceNumber, const RegexPattern *pattern) const
 {
     static char tmp[1024];
     SBuf sb;
@@ -864,6 +865,13 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
                 sb = al->proxyProtocolHeader->getElem(fmt->data.headerId, fmt->data.header.element, fmt->data.header.separator);
                 out = sb.c_str();
                 quote = 1;
+            }
+            break;
+
+        case LFT_REGEX_HEADER_EDIT:
+            if (pattern) {
+                sb = pattern->capture(fmt->data.reCaptureId);
+                out = sb.c_str();
             }
             break;
 

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -29,6 +29,7 @@ class AccessLogEntry;
 typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
 class MemBuf;
 class StoreEntry;
+class RegexPattern;
 
 namespace Format
 {
@@ -51,7 +52,7 @@ public:
     bool parse(const char *def);
 
     /// assemble the state information into a formatted line.
-    void assemble(MemBuf &mb, const AccessLogEntryPointer &al, int logSequenceNumber) const;
+    void assemble(MemBuf &mb, const AccessLogEntryPointer &al, int logSequenceNumber, const RegexPattern *pattern = nullptr) const;
 
     /// dump this whole list of formats into the provided StoreEntry
     void dump(StoreEntry * entry, const char *directiveName, bool eol = true) const;

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -149,6 +149,7 @@ static TokenTableEntry TokenTableMisc[] = {
     TokenTableEntry("note", LFT_NOTE ),
     TokenTableEntry("credentials", LFT_CREDENTIALS),
     TokenTableEntry("master_xaction", LFT_MASTER_XACTION),
+    TokenTableEntry("regex_match", LFT_REGEX_HEADER_EDIT),
     /*
      * Legacy external_acl_type format tokens
      */
@@ -494,6 +495,8 @@ Format::Token::parse(const char *def, Quoting *quoting)
 
     case LFT_PROXY_PROTOCOL_RECEIVED_HEADER:
 
+    case LFT_REGEX_HEADER_EDIT:
+
         if (data.string) {
             char *header = data.string;
             const auto initialType = type;
@@ -552,6 +555,8 @@ Format::Token::parse(const char *def, Quoting *quoting)
 
             if (initialType == LFT_PROXY_PROTOCOL_RECEIVED_HEADER)
                 data.headerId = ProxyProtocol::FieldNameToFieldType(SBuf(header));
+            else if (initialType == LFT_REGEX_HEADER_EDIT)
+                data.reCaptureId = Http::HeaderEditor::ParseReGroupId(header);
             else if (pseudoHeader)
                 throw TexcHere(ToSBuf("Pseudo headers are not supported in this context; got: '", def, "'"));
 
@@ -684,6 +689,7 @@ Format::Token::Token() : type(LFT_NONE),
     data.header.element = NULL;
     data.header.separator = ',';
     data.headerId = ProxyProtocol::Two::htUnknown;
+    data.reCaptureId = 0;
 }
 
 Format::Token::~Token()

--- a/src/format/Token.h
+++ b/src/format/Token.h
@@ -54,6 +54,8 @@ public:
         // TODO: Add ID caching for protocols other than PROXY protocol.
         /// the cached ID of the parsed header or zero
         ProxyProtocol::Two::FieldType headerId;
+        /// the specified regular expression's capture number (zero stands for the entire string match)
+        uint64_t reCaptureId;
 
         struct {
             char *header;

--- a/src/http/HeaderEditor.cc
+++ b/src/http/HeaderEditor.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "AccessLogEntry.h"
+#include "acl/Gadgets.h"
+#include "acl/Tree.h"
+#include "base/RegexPattern.h"
+#include "ConfigOption.h"
+#include "format/Format.h"
+#include "http/HeaderEditor.h"
+#include "MemBuf.h"
+#include "parser/Tokenizer.h"
+#include "sbuf/Stream.h"
+
+#include <map>
+
+static const int ReGroupMax = 10;
+
+typedef std::map<SBuf, Http::HeaderEditor::Command> CommandMap;
+static const CommandMap Commands =
+{
+    {SBuf("replace"), Http::HeaderEditor::Command::replace}
+};
+
+typedef std::map<SBuf, Http::HeaderEditor::CommandArgument> CommandArgumentMap;
+static const CommandArgumentMap CommandArguments =
+{
+    {SBuf("first"), Http::HeaderEditor::CommandArgument::first},
+    {SBuf("all"), Http::HeaderEditor::CommandArgument::all},
+    {SBuf("each"), Http::HeaderEditor::CommandArgument::each}
+};
+
+static SBuf
+CommandString(const Http::HeaderEditor::Command command)
+{
+    for (const auto p: Commands) {
+        if (p.second == command)
+            return p.first;
+    }
+    return SBuf();
+}
+
+static SBuf
+CommandArgumentString(const Http::HeaderEditor::CommandArgument commandArgument)
+{
+    for (const auto p: CommandArguments) {
+        if (p.second == commandArgument)
+            return p.first;
+    }
+    return SBuf();
+}
+    
+Http::HeaderEditor::HeaderEditor(ConfigParser &parser, const char *desc):
+    description_(desc)
+{
+    parseOptions(parser);
+}
+
+Http::HeaderEditor::~HeaderEditor()
+{
+    aclDestroyAclList(&aclList);
+    delete format_;
+}
+
+bool
+Http::HeaderEditor::compileRE(SBuf &str, const int flags)
+{
+    // TODO: removeUnnecessaryWildcards()
+    regex_t comp;
+    if (const auto errcode = regcomp(&comp, str.c_str(), flags)) {
+        char errbuf[256];
+        regerror(errcode, &comp, errbuf, sizeof errbuf);
+        throw TextException(ToSBuf("Invalid regular expression: ", errbuf), Here());
+    }
+    patterns_.emplace_back(flags, str.c_str());
+    patterns_.back().regex = comp;
+    return true;
+}
+
+Http::HeaderEditor::Action
+Http::HeaderEditor::fix(const char **fieldStart, const char **fieldEnd)
+{
+    assert(fieldStart && *fieldStart);
+    assert(fieldEnd && *fieldEnd);
+
+    if (matchedCount_ && commandArgument_ == CommandArgument::first)
+        return Action::ignore;
+
+    SBuf input(*fieldStart, *fieldEnd - *fieldStart);
+    for (auto &pattern : patterns_) {
+        if (pattern.match(input.c_str(), ReGroupMax)) {
+            matchedCount_++;
+            static MemBuf mb;
+            mb.reset();
+            // XXX: pass ALE here
+            format_->assemble(mb, AccessLogEntryPointer(), 0, &pattern);
+            *fieldStart = mb.content();
+            *fieldEnd = mb.space();
+            switch (commandArgument_) {
+                case CommandArgument::first:
+                    assert(matchedCount_ == 1);
+                    return Action::apply;
+                case CommandArgument::all:
+                    return (matchedCount_ == 1) ? Action::apply : Action::remove;
+                case CommandArgument::each:
+                    return Action::apply;
+            }
+        }
+    }
+    return Action::ignore;
+}
+
+uint64_t
+Http::HeaderEditor::ParseReGroupId(const char *str)
+{
+    auto tok = Parser::Tokenizer(SBuf(str));
+    int64_t id = 0;
+    if (!tok.int64(id, 10, false))
+        throw TexcHere("malformed regex group ID");
+    return static_cast<uint64_t>(id);
+}
+
+void
+Http::HeaderEditor::parseOptions(ConfigParser &parser)
+{
+    auto currentToken = parser.token("command");
+
+    Must(currentToken.cmp("replace") == 0);
+    command_ = Command::replace;
+        
+    currentToken = parser.token("command argument");
+    commandArgument_ = CommandArguments.at(SBuf(currentToken));
+
+    // TODO: add lf::"FORMAT" support to allow multiline format specifications with comments
+    static const SBuf rePrefix("re::");
+    static const SBuf lfPrefix("lf::");
+    static const SBuf withToken("with");
+
+    while (const auto t = ConfigParser::NextToken()) {
+    	const SBuf token(t);
+        Parser::Tokenizer tok(token);
+        if (!tok.skip(rePrefix)) {
+            Must(tok.remaining() == withToken);
+            break;
+        }
+        auto flags = REG_EXTENDED;
+        const auto rawFlags = tok.prefix("flags", CharacterSet::ALPHA);
+        for (auto f: rawFlags) {
+            if (f == 'i')
+                flags |= REG_ICASE;
+            // TODO: parse other flags
+        }
+        Must(tok.skip('"'));
+        auto regEx = tok.prefix("regex", CharacterSet::DQUOTE.complement("non-dquote"));
+        compileRE(regEx, flags);
+    }
+
+    if (patterns_.empty())
+        throw TextException("missing regular expression(s)", Here());
+
+    currentToken = parser.token("replacement expression");
+
+    Parser::Tokenizer tok(currentToken);
+    Must(!tok.skip(lfPrefix));
+    Must(tok.skip('"'));
+    formatString_ = tok.prefix("format string", CharacterSet::DQUOTE.complement("non-dquote"));
+
+    assert(!format_);
+    format_ = new Format::Format(description_);
+    if (!format_->parse(formatString_.c_str())) {
+        delete format_;
+        throw TextException(ToSBuf("invalid format line:", formatString_), Here());
+    }
+
+    aclList = parser.optionalAclList();
+}
+
+void
+Http::HeaderEditor::dump(std::ostream &os) const
+{
+    os << "command: " << CommandString(command_);
+    os << " command argument: " << CommandArgumentString(commandArgument_) << "\n";
+    os << " regex patterns: \n";
+    for (const auto &p: patterns_)
+        os << p.c_str() << "\n";
+    os << " format: " << formatString_ << "\n";
+    if (aclList) {
+        for (const auto &acl: aclList->treeDump("if", &Acl::AllowOrDeny))
+            os << ' ' << acl;
+    }
+}
+
+namespace Configuration {
+
+template <>
+Http::HeaderEditor *
+Configuration::Component<Http::HeaderEditor*>::Parse(ConfigParser &parser)
+{
+    return new Http::HeaderEditor(parser, "malformed_reply_header_edit");
+}
+
+template <>
+void
+Configuration::Component<Http::HeaderEditor*>::Print(std::ostream &os, Http::HeaderEditor* const &editor)
+{
+    assert(editor);
+    editor->dump(os);
+}
+
+template <>
+void
+Configuration::Component<Http::HeaderEditor*>::Free(Http::HeaderEditor * const editor)
+{
+    delete editor;
+}
+
+} // namespace Configuration
+

--- a/src/http/HeaderEditor.h
+++ b/src/http/HeaderEditor.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_HTTP_HEADEREDITOR_H
+#define SQUID_HTTP_HEADEREDITOR_H
+
+#include "base/RefCount.h"
+#include "format/Format.h"
+
+class RegexPattern;
+class SBuf;
+
+namespace Http
+{
+
+/// represents an editor for malformed request headers
+class HeaderEditor : public RefCountable
+{
+public:
+    /// TODO: consider adding other commands (e.g., 'remove')
+    enum class Command { replace };
+
+    /// what fix() should do with the input string:
+    ///	first: fix only the first matched string (and ignore any further matches)
+    /// each: fix each matched string
+    /// all: fix only the first matched string (and signal the caller to delete any further matches)
+    enum class CommandArgument { first, all, each };
+
+    /// How the caller should interpret the fix() results:
+    /// ignore: discard the returned string (and use the original string)
+    /// apply: use the returned string (instead of the original string)
+    /// remove: discard the returned string (and do not use the original string)
+    enum class Action { ignore, apply, remove };
+
+    explicit HeaderEditor(ConfigParser &parser, const char *description);
+
+    ~HeaderEditor();
+
+    void parseOptions(ConfigParser &parser);
+
+    /// Attempts to match the input string and returns a new string on success.
+    /// \param fieldStart the start of the input string. On successful match,
+    /// the address of the new string begginning is copied to the location referenced by fieldStart.
+    /// \param fieldEnd the end of the input string. On successful match,
+    /// the address of the new string ending (the termination character) is copied to the
+    /// location referenced by fieldEnd.
+    /// The returned values point to an internal storage whose contents
+    /// remain unchanged only until the next call.
+    Action fix(const char **fieldStart, const char **fieldEnd);
+
+    /// parses the regex group number
+    static uint64_t ParseReGroupId(const char *);
+
+    /// reproduces the configured squid.conf settings
+    void dump(std::ostream &os) const;
+
+private:
+    bool compileRE(SBuf &, const int flags);
+
+    const char *description_;
+    Command command_;
+    CommandArgument commandArgument_;
+    std::list<RegexPattern> patterns_;
+    Format::Format *format_ = nullptr;
+    ACLList *aclList = nullptr;
+    int matchedCount_ = 0;
+    // for debugging only
+    SBuf formatString_;
+};
+
+} // namespace Http
+
+#endif
+

--- a/src/http/Makefile.am
+++ b/src/http/Makefile.am
@@ -16,6 +16,8 @@ noinst_LTLIBRARIES = libhttp.la
 libhttp_la_SOURCES = \
 	ContentLengthInterpreter.cc \
 	ContentLengthInterpreter.h \
+	HeaderEditor.cc \
+	HeaderEditor.h \
 	Message.cc \
 	Message.h \
 	MethodType.cc \

--- a/src/http/forward.h
+++ b/src/http/forward.h
@@ -47,5 +47,7 @@ typedef RefCount<HttpRequest> HttpRequestPointer;
 class HttpReply;
 typedef RefCount<HttpReply> HttpReplyPointer;
 
+class HeaderEditor;
+
 #endif /* SQUID_SRC_HTTP_FORWARD_H */
 


### PR DESCRIPTION
This directive allows to adjust the received HTTP request headers that
Squid considers so malformed that they have to be rejected.  These
optional adjustments are performed once per request, as a last resort
measure. If no adjustments apply or if Squid still rejects the adjusted
header, the whole request is rejected.