### PR TITLE
Fix X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY handling

### DIFF
--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -118,6 +118,10 @@ protected:
     /// Resumes TLS negotiation paused by suspendNegotiation()
     void resumeNegotiation();
 
+    /// Revalidate TLS server certificates and continue with negotiation
+    /// \param lastError the last io error/state
+    void negotiateAfterRevalidateCertificates(const Security::IoResult &lastError);
+
     /// Either initiates fetching of missing certificates or bails with an error
     void handleMissingCertificates(const Security::IoResult &lastError);
 


### PR DESCRIPTION
If Squid failed to download the missing certificates, it
resumes TLS negotiation without reporting any error.

This patch fixes squid to re-validate certificates, without
disabling the missing issuer certificate error reporting,
to give the chance to squid TLS certificates validation
code to report the error.

This is a Measurement Factory project