### PR TITLE
Use a new PeekingPeerConnector::currentBumpingMode member

### DIFF
--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -70,6 +70,7 @@ private:
     AsyncCall::Pointer closeHandler; ///< we call this when the connection closed
     bool splice; ///< whether we are going to splice or not
     bool serverCertificateHandled; ///< whether handleServerCertificate() succeeded
+    Ssl::BumpMode currentBumpMode = Ssl::bumpNone;
 };
 
 } // namespace Ssl


### PR DESCRIPTION
... to store the current bumping mode for use by PeekingPeerConnector
code. 
Currently in most cases the ConnStateData::sslBumpMode is used,
but this is can be buggy: the PeekingPeerConnector updates the
ConnStateData::sslBumpMode while checks ssl_bump access list.
If the PeekingPeerConnector fails and squid retry next IP address
starting a new PeekingPeerConnector job, the ConnStateData::sslBumpMode
will have wrong value.

This patch uses the new PeekingPeerConnector::currentBumpingMode
member where it stores the step2 bumping decision which is the
real value we are actually interested for.

This is a Measurement Factory project