### PR TITLE
Recognize squid.conf explicit-type-values: regex and logformat

### DIFF
--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -27,7 +27,7 @@ const char *ConfigParser::CfgPos = NULL;
 std::queue<char *> ConfigParser::CfgLineTokens_;
 bool ConfigParser::AllowMacros_ = false;
 bool ConfigParser::ParseQuotedOrToEol_ = false;
-Configuration::ExplicitTypeValueParser ConfigParser::ParseEtv_ = nullptr;
+SBuf ConfigParser::ParseEtv_;
 bool ConfigParser::ParseKvPair_ = false;
 ConfigParser::ParsingStates ConfigParser::KvPairState_ = ConfigParser::atParseKey;
 bool ConfigParser::RecognizeQuotedPair_ = false;
@@ -219,8 +219,34 @@ ConfigParser::CurrentLocation()
     return ToSBuf(SourceLocation(cfg_directive, cfg_filename, config_lineno));
 }
 
+namespace Configuration {
+
+/// explicit-type-value structure (as defined in the configuration grammar)
+class ExplicitTypeValue
+{
+public:
+    SBuf typeName; ///< explicit value type
+    SBuf options; ///< value construction/application options (may be empty)
+    SBuf body; ///< unwrapped raw-string contents (may be empty)
+};
+
+/// the results of parsing explicit-type-value structure
+class ParsedExplicitTypeValue
+{
+public:
+    ExplicitTypeValue value; ///< information extracted from the input
+    size_t rawSize = 0; ///< the number of parsed input bytes
+};
+
+SBuf ParseRawString(Parser::Tokenizer &);
+static bool ShouldParseExplicitTypeValue(const char *buffer, const SBuf &typeName);
+static ParsedExplicitTypeValue ParseExplicitTypeValue(const char *buffer, const SBuf &typeName);
+
+} // namespace Configuration
+
+/// extracts raw-string and returns its value
 SBuf
-ParseRawString(Parser::Tokenizer &tok)
+Configuration::ParseRawString(Parser::Tokenizer &tok)
 {
     // raw-string = prefix <"> value <"> suffix
     // prefix = [A-Z_a-z]*
@@ -236,44 +262,25 @@ ParseRawString(Parser::Tokenizer &tok)
     if (!tok.skip('"'))
         throw TextException("raw-string is missing an opening quote (\")", Here());
 
-    SBuf rawString;
-    if (!tok.prefixUpTo(rawString, '"', guard))
+    SBuf value;
+    if (!tok.prefixUpTo(value, '"', guard))
         throw TextException("raw-string is missing a closing guard", Here());
 
-    return rawString; // may be empty
+    return value; // may be empty
 }
 
-namespace Configuration {
-
-class ExplicitTypeValue
-{
-    SBuf options; ///< value construction/application options (may be empty)
-    SBuf body; ///< unwrapped raw-string contents (may be empty)
-};
-
-class ExplicitTypeValueParser
-{
-    /// \returns explicit-type-value (if we successfully parsed rawInput) or nil
-    const ExplicitTypeValue *parsed(const void *rawInput);
-
-private:
-    /// the last interpreted explicit-type-value parts
-    ExplicitTypeValue parsed_; // safely exported by parsed()
-
-    /// the last successfully parsed raw explicit-type-value "token" image
-    const void *doneParsing_ = nullptr;
-};
-
-} // namespace Configuration
-
+/// whether the buffer starts with an explicit-type-value of a given type
 bool
-Configuration::ExplicitTypeValueParser::applicable(const char * const buffer)
+Configuration::ShouldParseExplicitTypeValue(const char * const buffer, const SBuf &typeName)
 {
-    return strncmp(buffer, typeName.rawContent(), typeName.length()) == 0;
+    if (const auto typeNameLength = typeName.length())
+        return strncmp(buffer, typeName.rawContent(), typeNameLength) == 0;
+    return false;
 }
 
-void
-Configuration::ExplicitTypeValueParser::parse(const char * const start)
+/// explicit-type-value (of a given type)
+Configuration::ParsedExplicitTypeValue
+Configuration::ParseExplicitTypeValue(const char * const start, const SBuf &typeName)
 {
     // explicit-type-value = type ["(" options ")"] "::" raw-string
     // options = ; a comma-separated list of option names
@@ -282,19 +289,22 @@ Configuration::ExplicitTypeValueParser::parse(const char * const start)
     // storing preprocessed configuration text.
     Parser::Tokenizer tok{SBuf(start)};
 
-    // until our caller can get rid of applicable():
+    ParsedExplicitTypeValue result;
+
+    // until our caller can get rid of ShouldParseExplicitTypeValue():
     const auto startConfirmed = tok.skip(typeName);
     assert(startConfirmed);
+    result.value.typeName = typeName;
 
-    if (tok.skip('(') && !tok.prefixUpTo(parsed_.options, ')/')
+    if (tok.skip('(') && !tok.prefixUpTo(result.value.options, ')'))
         throw TextException("missing closing parenthesis after explicit-type-value options", Here());
 
     if (!(tok.skip(':') && tok.skip(':')))
         throw TextException("missing :: delimiter after explicit-type-value type/options", Here());
 
-    parsed_.body = ParseRawString(tok/);
-    doneParsing_ = start;
-    return tok.parsedSize();
+    result.value.body = ParseRawString(tok);
+    result.rawSize = tok.parsedSize();
+    return result;
 }
 
 char *
@@ -308,19 +318,19 @@ ConfigParser::TokenParse(const char * &nextToken, ConfigParser::TokenType &type)
     if (*nextToken == '#')
         return NULL;
 
-    if (ParseEtv_ && ParseEtv_->applicable(nextToken)) {
-        // XXX: type = ConfigParser::EtvToken;?
-        ParseEtv_->parse(nextToken);
-        const auto tokenLength = ParseEtv_->length();
-        const auto token = xstrndup(nextToken, tokenLength);
+    if (Configuration::ShouldParseExplicitTypeValue(nextToken, ParseEtv_)) {
+        // this->type is only used for quoted values and parameters() detection
+        // so we leave it as is, like ParseQuotedOrToEol_ values do.
+        const auto parsedEtv = Configuration::ParseExplicitTypeValue(nextToken, ParseEtv_);
+        assert(parsedEtv.rawSize);
+        const auto token = xstrndup(nextToken, parsedEtv.rawSize);
         CfgLineTokens_.push(token);
         return token;
     }
     // else: When ParseEtv_ is set: We might still find explicit-type-value
-    // after loading parameters(). TODO: Move parameters() handling at a higher
-    // level and then _require_ explicit-type-value here. This method should
-    // only parse grammar "values", as defined in the "Configuration syntax"
-    // section of cf.data.pre.
+    // after loading parameters(). TODO: Separate handling of "internal"
+    // external-parameters-spec from extracting "external" grammar values, as
+    // those terms are defined in cf.data.pre "Configuration syntax" section.
 
     if (ConfigParser::RecognizeQuotedValues && (*nextToken == '"' || *nextToken == '\'')) {
         type = ConfigParser::QuotedToken;
@@ -509,6 +519,24 @@ ConfigParser::NextQuotedOrToEol()
     }
 
     return token;
+}
+
+::RegexPattern *
+ConfigParser::regex(const char *parameterDescription)
+{
+    try {
+        static const SBuf regexTypeName("re");
+        ParseEtv_ = regexTypeName;
+        const auto token = NextToken();
+        const auto parsedEtv = Configuration::ParseExplicitTypeValue(token, regexTypeName);
+        // TODO: convert parsedEtv.value to RegexPattern and use parameterDescription
+        ParseEtv_.clear();
+        return nullptr; // XXX
+    } catch (...) {
+        // TODO: Add scope_guard; do not wait until it is in the C++ standard.
+        ParseEtv_.clear();
+        throw;
+    }
 }
 
 bool

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -17,11 +17,8 @@
 #include <stack>
 #include <string>
 
+class RegexPattern;
 class wordlist;
-
-namespace Configuration {
-    class ExplicitTypeValueParser;
-}
 
 /**
  * Limit to how long any given config line may be.
@@ -74,6 +71,9 @@ public:
 
     /// parses an [if [!]<acl>...] construct
     Acl::Tree *optionalAclList();
+
+    /// a re(flags)::"pattern" explicit-type-value construct
+    ::RegexPattern *regex(const char *parameterDescription);
 
     static void ParseUShort(unsigned short *var);
     static void ParseBool(bool *var);
@@ -240,7 +240,7 @@ protected:
     static bool ParseQuotedOrToEol_; ///< The next tokens will be handled as quoted or to_eol token
     static bool RecognizeQuotedPair_; ///< The next tokens may contain quoted-pair (\-escaped) characters
     static bool PreviewMode_; ///< The next token will not popped from cfg files, will just previewd.
-    static Configuration::ExplicitTypeValueParser *ParseEtv_; ///< Require an explicit-type-value element of the given type
+    static SBuf ParseEtv_; ///< Require an explicit-type-value element of the given type
     static bool ParseKvPair_; ///<The next token will be handled as kv-pair token
     static enum ParsingStates {atParseKey, atParseValue} KvPairState_; ///< Parsing state while parsing kv-pair tokens
 };

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -199,6 +199,17 @@ protected:
         int lineNo; ///< Current line number
     };
 
+    /// the length of raw-string at the beginning of the given buffer
+    static size_t RawStringLength(const SBuf &buffer);
+
+    /// whether an explicit-type-value has been requested by ParseEtv_ and the
+    /// input looks like the beginning of that requested value
+    static bool MaybeAtEtvStart(const char *buffer);
+
+    /// The length of explicit-type-value at the beginning of the given buffer.
+    /// The value is assumed to have been requested by ParseEtv_.
+    static size_t EtvLength(const char *buffer);
+
     /**
      * Unquotes the token, which must be quoted.
      * \param next if it is not NULL, it is set after the end of token.
@@ -225,6 +236,7 @@ protected:
     static bool ParseQuotedOrToEol_; ///< The next tokens will be handled as quoted or to_eol token
     static bool RecognizeQuotedPair_; ///< The next tokens may contain quoted-pair (\-escaped) characters
     static bool PreviewMode_; ///< The next token will not popped from cfg files, will just previewd.
+    static SBuf ParseEtv_; ///< Require an explicit-type-value element of the given type
     static bool ParseKvPair_; ///<The next token will be handled as kv-pair token
     static enum ParsingStates {atParseKey, atParseValue} KvPairState_; ///< Parsing state while parsing kv-pair tokens
 };

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -19,6 +19,10 @@
 
 class wordlist;
 
+namespace Configuration {
+    class ExplicitTypeValueParser;
+}
+
 /**
  * Limit to how long any given config line may be.
  * This affects squid.conf and all included files.
@@ -236,7 +240,7 @@ protected:
     static bool ParseQuotedOrToEol_; ///< The next tokens will be handled as quoted or to_eol token
     static bool RecognizeQuotedPair_; ///< The next tokens may contain quoted-pair (\-escaped) characters
     static bool PreviewMode_; ///< The next token will not popped from cfg files, will just previewd.
-    static SBuf ParseEtv_; ///< Require an explicit-type-value element of the given type
+    static Configuration::ExplicitTypeValueParser *ParseEtv_; ///< Require an explicit-type-value element of the given type
     static bool ParseKvPair_; ///<The next token will be handled as kv-pair token
     static enum ParsingStates {atParseKey, atParseValue} KvPairState_; ///< Parsing state while parsing kv-pair tokens
 };

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2830,6 +2830,7 @@ nodist_tests_testConfigParser_SOURCES = \
 	tests/stub_SBuf.cc
 tests_testConfigParser_LDADD = \
 	base/libbase.la \
+	parser/libparser.la \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \
 	$(XTRA_LIBS)

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -73,12 +73,156 @@ COMMENT_START
 		year - 31557790080 milliseconds (just over 365 days)
 		decade
 
-  Values with spaces, quotes, and other special characters
+  Quoted values
 
-	Squid supports directive parameters with spaces, quotes, and other
-	special characters. Surround such parameters with "double quotes". Use
-	the configuration_includes_quoted_values directive to enable or
-	disable that support.
+	After configuration_includes_quoted_values directive is turned on, most
+	directive parameters may be surrounded by double quotes. Such a "quoted
+	parameter" is interpreted as a single parameter value even if it contains
+	whitespace. The parameter value does not include its surrounding quotes.
+	For example, the following adds a header field with a "one two" value
+	(when the ACL named "three" matches):
+
+		# Adds an "X-My-Ids: one two" field when ACL named "three" matches:
+	    request_header_add X-My-Ids "one two" three
+
+		# Adds an "X-My-Ids: one" field when ACLs "two" and "three" match:
+		request_header_add X-My-Ids one two three
+
+	The following two-character escape sequences are recognized inside quoted
+	strings:
+
+		* \t -- an ASCII HT character (i.e. horizontal tab)
+		* \n -- an ASCII LF character (i.e. new line)
+		* \r -- an ASCII CR character (i.e. carriage return)
+		* \" -- a double quote character (")
+		* \\ -- a backslash character (\)
+
+	Other two-character escape sequences formed by a backslash followed by
+	some byte X are treated as follows:
+
+		* If X is an ASCII NUL character (i.e. null): Syntax error.
+		* If X is an alphanumeric character: Syntax error.
+		* If X is any other byte: The whole sequence is replaced with X (i.e.
+		  the backslash is removed).
+
+	Quoted strings must be followed by whitespace or the end of the line/file.
+
+		configuration_includes_quoted_values on
+		# OK: Specifying two ext_user parameters, one with a space.
+		acl friend ext_user "John Doe" "Alice"
+		# FATAL: Expecting space after the end of quoted token
+		acl friend ext_user "John "Doe
+
+	Some directives support quoted strings as parameters regardless of the
+	configuration_includes_quoted_values setting.
+
+	Legacy regular expressions cannot be specified using quoted strings
+	regardless of the configuration_includes_quoted_values setting. Use modern
+	regular expressions instead.
+
+  Values with raw strings
+
+	Some configuration options support raw strings that eliminate the need to
+	guess and escape spaces, quotes, backslashes, and other "special"
+	characters. A raw string expression starts with an admin-specified prefix
+	that is then reused as a string value terminator:
+
+		raw-string = prefix <"> value <"> suffix
+		prefix = [A-Z_a-z]*
+		value = ; zero or more bytes that do not include a <"> suffix sequence
+		suffix = prefix; exactly the same sequence of characters as the prefix
+
+	To distinguish raw strings with an empty prefix (and, hence, an empty
+	suffix) from quoted strings, empty prefixes in raw strings are only
+	allowed in namespace-prefixed parameter values like regular expressions
+	and log formats.
+	TODO: Alternatively, we can avoid this dangerous ambiguity if
+
+		1. Raw strings use `backticks` instead of "quotes".
+		2. Raw strings require a prefix/suffix even in typed strings.
+		3. We remove (undocumented!) support for 'singly quoted strings' and
+		   give the freed single quote exclusively to 'raw strings'.
+
+		The key in this decision is not which quoting character looks better,
+		but how to avoid admins expecting one escaping mechanism but silently
+		getting another:
+			acl example1 type1 re::"Since this value keeps its backslash\..."
+			acl example2 type2 "Some will expect a backslash here as well\..."
+
+	For example:
+
+		* "" is an empty string (with an empty prefix/suffix sequence)
+		* foo""foo is also an empty string (with "foo" as the prefix/suffix)
+		* "a" is a single character "a"
+		* "\" is a single backslash character
+		* quote"\"quote is also a single backslash character
+		* "a b" is a 3-character sequence containing "a", space, and "b"
+		* x"ax"b"x is a 4-character sequence containing "a", "x", quote, "b"
+		* quoted"Escaping "quotes" is easy!"quoted is 26 chars from "E" to "!"
+		* quoted"Escaping "quoted text" is hard!"quoted is probably a
+		  configuration error: Squid will use the first 9 characters as the
+		  string value and then, depending on the context, will probably
+		  complain about the remaining garbage, starting with "text...".
+
+  Values with explicit types (a.k.a. typed parameter values)
+
+	All directives know what parameter types they require. For example, the
+	"browser" ACL expects a regular expression. In many cases, legacy syntax
+	does not allow the admin to express what parameter type they think they
+	are giving (and they think the directive needs). For example, an admin may
+	give the "browser" ACL a "Bat?" parameter and incorrectly expect the ACL
+	to only match agents named using those four characters. Typeless parameter
+	values also lead to directive proliferation: We have both proxy_auth and
+	proxy_auth_regex although the two ACLs differ only in parameter types.
+
+	Typed parameters solve these problems by specifying the value type as a
+	parameter prefix:
+
+		typed-parameter-value = type ["(" options ")"] "::" raw-string
+		options = ; a comma-separated list of option names
+
+	If a directive parameter value is not a typed-parameter-value, but starts
+	with a character sequence matching one of the typed-parameter-values, then
+	it should be wrapped using a raw string expression. This is especially
+	useful in generated configuration files that do not control parameter
+	value sources and might get values that look like typed-parameter-values.
+
+		acl example type raw"re::"this is not a regex""raw
+
+	Currently, two parameter value types are supported: regular expressions
+	and log formats. They are documented below.
+
+  Regular expression values
+
+	There are two ways to specify a regular expression:
+
+	* Modern regular expressions use typed-parameter-values with "re" as the
+	  value type.
+
+	* Legacy regular expressions end either at the first unescaped space
+	  character (ASCII SP or HT) or at the end of the line, whichever comes
+	  first. Spaces are escaped using backslashes. All backslashes are
+	  preserved in the regex. If a regex-using directive does not specify
+	  which regex style it supports, then it supports the legacy style.
+
+	The following options are supported for modern regular expressions:
+
+		* i: case-insensitive match (see POSIX REG_ICASE)
+		* s: treat input is a single line (this is the default)
+		* m: treat input as multiple lines (see POSIX REG_NEWLINE)
+
+	For example, given a multiline input, the following modern regular
+	expression matches the lines containing the specified single-valued
+	Transfer-Encoding header field, disregarding any letter case differences:
+
+		re(i,m)::"^Transfer-Encoding: *chunked$"
+
+  Log format values
+
+	Modern log format expressions use typed-parameter-values with "lf" as the
+	value type. Log format expressions do not support any options (yet).
+
+  Importing directive parameter values
 
 	Squid supports reading configuration option parameters from external
 	files using the syntax:

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -30,6 +30,71 @@ COMMENT_START
 COMMENT_END
 
 COMMENT_START
+
+  Configuration syntax
+
+	The following summary approximates Squid configuration processing and
+	grammar. The current implementation deviates from this documentation in
+	certain details, but those low-level discrepancies can usually be ignored
+	when writing high-quality configuration files.
+
+	Squid configuration is processed in three primary stages:
+
+		* Preprocessing: This stage is applied to the primary configuration
+		  file and any files included using the preprocessor "include"
+		  directive. This stage does _not_ apply to directive parameter files.
+		  The line-based preprocessor handles "#line" directives, removes
+		  comment lines ("#"), trims leading/trailing whitespace, ignores
+		  empty lines, unwraps line continuations ("\"), expands macros (see
+		  "Preprocessor macros"), applies conditionals (see "Conditional
+		  configuration"), and handles include directives (see "Including
+		  other configuration files").
+
+		* Parsing: This stage is applied to the concatenation of built-in
+		  "early default" directives, preprocessor output (detailed in the
+		  previous bullet), and built-in "late default" directives. The
+		  line-based parser interprets individual configuration directives,
+		  including handling of directive parameter files. Most directives
+		  follow the general syntax detailed after this bulleted list.
+
+		* Application: Today, most directives become effective immediately
+		  after being parsed, but that will eventually change to defer
+		  application after the entire configuration has been parsed.
+
+	directive = name [ space... parameter ]...
+
+	name = ; a non-empty sequence of alphanumeric characters, "-", and "_"
+
+	parameter = value | name "=" value | external-parameters-spec
+
+	value = simple-value | quoted-value | raw-string | regex | logformat
+
+	external-parameters-spec = "parameters(" file-name ")" | file-name
+
+	file-name = quoted-string
+
+	quoted-value = quoted-string ; See "Quoted values"
+
+	raw-string = ; See "Values with raw strings"
+
+	regex = explicit-type-value ; See "Regular expression values"
+
+	logformat = explicit-type-value ; See "Log format values"
+
+	simple-value = ; a non-empty sequence of alphanumeric characters and
+	               ; a few special number- or address-forming characters
+	               ; such as ".", "-", "_", "/", ":", "+", and "%"
+
+	space = SP | HT
+
+	Each directive places its own restrictions on directive parameters
+	which, along with parsing-controlling directives, help resolve
+	parameter grammar ambiguities. For example, a directive expecting a
+	regular expression will not interpret "a=b" as a key-value pair.
+
+
+  Including other configuration files
+
   Configuration options can be included using the "include" directive.
   Include takes a list of files to include. Quoting and wildcards are
   supported.
@@ -146,8 +211,13 @@ COMMENT_START
 		The key in this decision is not which quoting character looks better,
 		but how to avoid admins expecting one escaping mechanism but silently
 		getting another:
-			acl example1 type1 re::"Since this value keeps its backslash\..."
-			acl example2 type2 "Some will expect a backslash here as well\..."
+			# regex vs. quoted-string:
+			acl example1 type1 re::"Since this value keeps its backslash\,"
+			acl example2 type2 "will some expect it to be kept here as well\?"
+
+			# quoted-string vs. raw-string:
+			acl example type "Since this quoted backslash is removed\,"
+			acl example type x"will some expect it to be gone here\?"x
 
 	For example:
 
@@ -164,7 +234,7 @@ COMMENT_START
 		  string value and then, depending on the context, will probably
 		  complain about the remaining garbage, starting with "text...".
 
-  Values with explicit types (a.k.a. typed parameter values)
+  Values with explicit types (a.k.a. explicit-type-value)
 
 	All directives know what parameter types they require. For example, the
 	"browser" ACL expects a regular expression. In many cases, legacy syntax
@@ -178,14 +248,14 @@ COMMENT_START
 	Typed parameters solve these problems by specifying the value type as a
 	parameter prefix:
 
-		typed-parameter-value = type ["(" options ")"] "::" raw-string
+		explicit-type-value = type ["(" options ")"] "::" raw-string
 		options = ; a comma-separated list of option names
 
-	If a directive parameter value is not a typed-parameter-value, but starts
-	with a character sequence matching one of the typed-parameter-values, then
+	If a directive parameter value is not a explicit-type-value, but starts
+	with a character sequence matching one of the explicit-type-values, then
 	it should be wrapped using a raw string expression. This is especially
 	useful in generated configuration files that do not control parameter
-	value sources and might get values that look like typed-parameter-values.
+	value sources and might get values that look like explicit-type-values.
 
 		acl example type raw"re::"this is not a regex""raw
 
@@ -196,7 +266,7 @@ COMMENT_START
 
 	There are two ways to specify a regular expression:
 
-	* Modern regular expressions use typed-parameter-values with "re" as the
+	* Modern regular expressions use explicit-type-values with "re" as the
 	  value type.
 
 	* Legacy regular expressions end either at the first unescaped space
@@ -219,7 +289,7 @@ COMMENT_START
 
   Log format values
 
-	Modern log format expressions use typed-parameter-values with "lf" as the
+	Modern log format expressions use explicit-type-values with "lf" as the
 	value type. Log format expressions do not support any options (yet).
 
   Importing directive parameter values
@@ -257,9 +327,7 @@ COMMENT_START
 	        Equality comparison of two integer numbers.
 
 
-  SMP-Related Macros
-
-	The following SMP-related preprocessor macros can be used.
+  Preprocessor macros
 
 	${process_name} expands to the current Squid process "name"
 	(e.g., squid1, squid2, or cache1).

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -197,6 +197,40 @@ Parser::Tokenizer::skip(const char tokenChar)
     return false;
 }
 
+SBuf::size_type
+Parser::Tokenizer::skipUpTo(const char a, const SBuf &b)
+{
+    SBuf::size_type offset = 0;
+    while (buf_.length() - offset > b.length()) {
+        const auto posOfA = buf_.find(a, offset);
+        if (posOfA == SBuf::npos) {
+            debugs(24, 8, "cannot find the beginning of " << a << b);
+            return 0;
+        }
+        const auto posAfterA = posOfA + 1;
+        if (buf_.substr(posAfterA) == b) {
+            debugs(24, 8, "skipping " << posOfA << ": " << a << b);
+            return success(posOfA);
+        }
+        offset = posAfterA; // keep looking after skipping a
+    }
+    debugs(24, 8, "cannot find " << a << b);
+    return 0;
+}
+
+SBuf::size_type
+Parser::Tokenizer::skipUpTo(const SBuf &terminator)
+{
+    const auto offset = buf_.find(terminator);
+    if (offset == SBuf::npos) {
+        debugs(24, 8, "cannot find " << terminator);
+        return 0;
+    } else {
+        debugs(24, 8, "skipping " << offset << ": " << terminator);
+        return success(offset);
+    }
+}
+
 bool
 Parser::Tokenizer::skipOneTrailing(const CharacterSet &skippable)
 {

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -116,6 +116,59 @@ Parser::Tokenizer::prefix(const char *description, const CharacterSet &tokenChar
 }
 
 bool
+Parser::Tokenizer::prefixUpTo(SBuf &returnedToken, const char terminator)
+{
+    const auto tokenLength = buf_.find(terminator);
+    if (tokenLength == SBuf::npos) {
+        debugs(24, 8, "no " << terminator);
+        return false;
+    } else {
+        debugs(24, 8, "got " << tokenLength << " before " << terminator);
+        returnedToken = consume(tokenLength);
+        (void)consume(1u);
+        return true;
+    }
+}
+
+bool
+Parser::Tokenizer::prefixUpTo(SBuf &returnedToken, const SBuf &terminator)
+{
+    const auto tokenLength = buf_.find(terminator);
+    if (tokenLength == SBuf::npos) {
+        debugs(24, 8, "no " << terminator);
+        return false;
+    } else {
+        debugs(24, 8, "got " << tokenLength << " before " << terminator);
+        returnedToken = consume(tokenLength);
+        (void)consume(terminator.length());
+        return true;
+    }
+}
+
+bool
+Parser::Tokenizer::prefixUpTo(SBuf &returnedToken, const char a, const SBuf &b)
+{
+    SBuf::size_type offset = 0;
+    while (buf_.length() - offset > b.length()) {
+        const auto posOfA = buf_.find(a, offset);
+        if (posOfA == SBuf::npos) {
+            debugs(24, 8, "no " << a);
+            return false;
+        }
+        const auto posAfterA = posOfA + 1;
+        if (buf_.substr(posAfterA) == b) {
+            debugs(24, 8, "got " << posOfA << " before " << a << b);
+            returnedToken = consume(posOfA);
+            (void)consume(1u + b.length()); // a + b
+            return true;
+        }
+        offset = posAfterA; // keep looking after skipping a
+    }
+    debugs(24, 8, "no " << a << b);
+    return false;
+}
+
+bool
 Parser::Tokenizer::suffix(SBuf &returnedToken, const CharacterSet &tokenChars, const SBuf::size_type limit)
 {
     SBuf span = buf_;
@@ -195,40 +248,6 @@ Parser::Tokenizer::skip(const char tokenChar)
     }
     debugs(24, 8, "no match, not skipping char '" << tokenChar << '\'');
     return false;
-}
-
-SBuf::size_type
-Parser::Tokenizer::skipUpTo(const char a, const SBuf &b)
-{
-    SBuf::size_type offset = 0;
-    while (buf_.length() - offset > b.length()) {
-        const auto posOfA = buf_.find(a, offset);
-        if (posOfA == SBuf::npos) {
-            debugs(24, 8, "cannot find the beginning of " << a << b);
-            return 0;
-        }
-        const auto posAfterA = posOfA + 1;
-        if (buf_.substr(posAfterA) == b) {
-            debugs(24, 8, "skipping " << posOfA << ": " << a << b);
-            return success(posOfA);
-        }
-        offset = posAfterA; // keep looking after skipping a
-    }
-    debugs(24, 8, "cannot find " << a << b);
-    return 0;
-}
-
-SBuf::size_type
-Parser::Tokenizer::skipUpTo(const SBuf &terminator)
-{
-    const auto offset = buf_.find(terminator);
-    if (offset == SBuf::npos) {
-        debugs(24, 8, "cannot find " << terminator);
-        return 0;
-    } else {
-        debugs(24, 8, "skipping " << offset << ": " << terminator);
-        return success(offset);
-    }
 }
 
 bool

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -115,6 +115,23 @@ public:
      */
     SBuf::size_type skipAll(const CharacterSet &discardables);
 
+    /** Skips all sequential characters until the first terminator occurrence.
+     * Skips nothing if the entire terminator is not present.
+     * Does not skip the terminator itself.
+     *
+     * \returns the number of skipped characters
+     */
+    SBuf::size_type skipUpTo(const SBuf &terminator);
+
+    /** Skips all sequential characters until the first (a, b) sequence.
+     * Skips nothing if the entire sequence is not present.
+     * Does not skip the sequence itself.
+     * This is a faster version of skipUpTo(a+b) when you have not computed a+b.
+     *
+     * \returns the number of skipped characters
+     */
+    SBuf::size_type skipUpTo(char a, const SBuf &b);
+
     /** Removes a single trailing character from the set.
      *
      * \return whether a character was removed

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -70,6 +70,30 @@ public:
      */
     bool prefix(SBuf &returnedToken, const CharacterSet &tokenChars, SBuf::size_type limit = SBuf::npos);
 
+    /** Extracts all sequential characters until the first terminator occurrence.
+     *
+     * If the terminator is found, skips it without adding it to returnedToken.
+     * Otherwise, extracts or skips nothing.
+     *
+     * \returns whether the terminator was found
+     */
+    bool prefixUpTo(SBuf &returnedToken, char terminator);
+
+    /// \copydoc prefixUpTo(SBuf &, char)
+    bool prefixUpTo(SBuf &returnedToken, const SBuf &terminator);
+
+    /** Skips all sequential characters until the first (a, b) sequence.
+     *
+     * If the sequence is found, skips it without adding it to returnedToken.
+     * Otherwise, extracts or skips nothing.
+     *
+     * Use this method instead of prefixUpTo(a+b) when you have not computed a+b
+     * already. The b part of the sequence may be empty.
+     *
+     * \returns whether the sequence was found
+     */
+    bool prefixUpTo(SBuf &returnedToken, const char a, const SBuf &b);
+
     /** Extracts all sequential permitted characters up to an optional length limit.
      * Operates on the trailing end of the buffer.
      *
@@ -84,6 +108,8 @@ public:
     /** skips a given suffix character sequence (string)
      * Operates on the trailing end of the buffer.
      *
+     * If tokenToSkip is empty, skips nothing and returns false.
+     *
      *  Note that Tokenizer cannot tell whether the buffer will
      *  gain more data when/if more input becomes available later.
      *
@@ -92,6 +118,8 @@ public:
     bool skipSuffix(const SBuf &tokenToSkip);
 
     /** skips a given character sequence (string)
+     *
+     * If tokenToSkip is empty, skips nothing and returns false.
      *
      * \return whether the exact character sequence was found and skipped
      */
@@ -114,23 +142,6 @@ public:
      * \returns the number of skipped characters
      */
     SBuf::size_type skipAll(const CharacterSet &discardables);
-
-    /** Skips all sequential characters until the first terminator occurrence.
-     * Skips nothing if the entire terminator is not present.
-     * Does not skip the terminator itself.
-     *
-     * \returns the number of skipped characters
-     */
-    SBuf::size_type skipUpTo(const SBuf &terminator);
-
-    /** Skips all sequential characters until the first (a, b) sequence.
-     * Skips nothing if the entire sequence is not present.
-     * Does not skip the sequence itself.
-     * This is a faster version of skipUpTo(a+b) when you have not computed a+b.
-     *
-     * \returns the number of skipped characters
-     */
-    SBuf::size_type skipUpTo(char a, const SBuf &b);
 
     /** Removes a single trailing character from the set.
      *


### PR DESCRIPTION
Squid configuration syntax is built on several low-level elements:

* space-delimited tokens (with virtually no other syntax restrictions)
* space-delimited regexes (with set A of recognized escape sequences)
* "everything until the end of the line" sequences (logformat and such)
* quoted strings (with set B of recognized escape sequences)

Weak structure and syntax overlaps make configuration mistakes easy and
their detection difficult or impossible. For example:

1. It is trivial to misconfigure an exact-match ACL with a regex.

2. It is trivial to misconfigure a regex ACL with an exact-match string
   when the ACL type does have a "regex" suffix.

3. It is trivial to misconfigure an ACL with a line option it does not
   recognize when that option is hidden between ACL parameters.

4. It is trivial to forget to escape a space, turning a single regex
   into two very different ones, especially in contexts where multiple
   regexes are expected (e.g., ACL parameters).

Weak structure also cripples design and increases implementation costs:

5. We need two types/directives for most string-matching ACLs/tasks, one
   to cover an exact match and one for a regex match. And if a directive
   needs several different matching parameters, the number of
   permutations explodes, forcing the designer to either go the
   expensive regex route for all such parameters or split the directive
   into several ones (which requires addition parameters for "linking").

6. It is difficult to introduce new regex and logformat flags/options.

7. Squid-specific escape sequences are fed to regex compilers.

8. Reading/maintaining regexes/logformats are harder than necessary.

9. It is impossible to improve this syntax without either breaking old
   configurations or introducing special directives/options that tell
   Squid how to resolve ambiguities, complicating/delaying upgrades.

We add a new low-level syntax element to help solve many of these
problems: explicit-type-value. The new syntax requires specifying the
value type (regex or logformat), accepts optional value flags/options,
and uses an excellent mechanism for handling special characters.

While collisions ought to be very rare, it is possible that existing
configurations contain explicit-type-values. New regex- and
logformat-based directives/parameters should use explicit-type-values.
Old directives/parameters should continue to use the legacy style until
we add special upgrade controls as discussed in problem 9.

This change does not introduce any new configuration directives and does
not change Squid functionality. It (partially) documents Squid
configuration syntax and adds APIs for using explicit-type-values in new
directives/parameters (to be added in future feature-specific changes).
