### PR TITLE
Fix chained certificates list

### DIFF
--- a/src/adaptation/ecap/XactionRep.cc
+++ b/src/adaptation/ecap/XactionRep.cc
@@ -163,12 +163,12 @@ Adaptation::Ecap::XactionRep::usernameValue() const
 }
 
 const libecap::Area
-Adaptation::Ecap::XactionRep::masterxSharedValue(const libecap::Name &name) const
+Adaptation::Ecap::XactionRep::masterxSharedValue(const libecap::Name &sharedName) const
 {
     const HttpRequest *request = dynamic_cast<const HttpRequest*>(theCauseRep ?
                                  theCauseRep->raw().header : theVirginRep.raw().header);
     Must(request);
-    if (name.known()) { // must check to avoid empty names matching unset cfg
+    if (sharedName.known()) { // must check to avoid empty names matching unset cfg
         Adaptation::History::Pointer ah = request->adaptHistory(false);
         if (ah != NULL) {
             String name, value;
@@ -482,7 +482,6 @@ Adaptation::Ecap::XactionRep::updateHistory(Http::Message *adapted)
 
     // update the adaptation plan if needed
     if (service().cfg().routing) {
-        String services;
         if (const libecap::Area services = theMaster->option(libecap::metaNextServices)) {
             Adaptation::History::Pointer ah = request->adaptHistory(true);
             if (ah != NULL)

--- a/src/security/CertGadgets.cc
+++ b/src/security/CertGadgets.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "Debug.h"
+#include "sbuf/SBuf.h"
+#include "security/CertGadgets.h"
+
+#include <iostream>
+#if USE_OPENSSL
+#if HAVE_OPENSSL_X509V3_H
+#include <openssl/x509v3.h>
+#endif
+#endif
+
+inline
+const char *
+MissingLibraryError()
+{
+    return "[need OpenSSL or GnuTLS]";
+}
+
+SBuf
+Security::CertIssuerName(Certificate &cert)
+{
+    SBuf out;
+#if USE_OPENSSL
+    const auto s = X509_NAME_oneline(X509_get_issuer_name(&cert), nullptr, 0);
+    if (!s) {
+        const auto x = ERR_get_error();
+        debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot get certificate Issuer: " << Security::ErrorString(x));
+        return out;
+    }
+    out.append(s);
+    OPENSSL_free(s);
+
+#elif USE_GNUTLS
+    gnutls_x509_dn_t dn;
+    auto x = gnutls_x509_crt_get_issuer(&cert, &dn);
+    if (x != GNUTLS_E_SUCCESS) {
+        debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot get certificate Issuer: " << Security::ErrorString(x));
+        return out;
+    }
+
+    gnutls_datum_t str;
+    x = gnutls_x509_dn_get_str(dn, &str);
+    if (x != GNUTLS_E_SUCCESS) {
+        debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot describe certificate Issuer: " << Security::ErrorString(x));
+        return out;
+    }
+    out.append(reinterpret_cast<const char *>(str.data), str.size);
+    gnutls_free(str.data);
+
+#else
+    debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot get certificate Issuer: " << MissingLibraryError());
+    return out;
+#endif
+
+    debugs(83, DBG_PARSE_NOTE(3), "found cert issuer=" << out);
+    return out;
+}
+
+SBuf
+Security::CertSubjectName(Certificate &cert)
+{
+    SBuf out;
+#if USE_OPENSSL
+    auto s = X509_NAME_oneline(X509_get_subject_name(&cert), nullptr, 0);
+    if (!s) {
+        const auto x = ERR_get_error();
+        debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot get certificate SubjectName: " << Security::ErrorString(x));
+        return out;
+    }
+    out.append(s);
+    OPENSSL_free(s);
+
+#elif USE_GNUTLS
+    gnutls_x509_dn_t dn;
+    auto x = gnutls_x509_crt_get_subject(&cert, &dn);
+    if (x != GNUTLS_E_SUCCESS) {
+        debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot get certificate SubjectName: " << Security::ErrorString(x));
+        return out;
+    }
+
+    gnutls_datum_t str;
+    x = gnutls_x509_dn_get_str(dn, &str);
+    if (x != GNUTLS_E_SUCCESS) {
+        debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot describe certificate SubjectName: " << Security::ErrorString(x));
+        return out;
+    }
+    out.append(reinterpret_cast<const char *>(str.data), str.size);
+    gnutls_free(str.data);
+
+#else
+    debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot get certificate SubjectName: " << MissingLibraryError());
+    return out;
+#endif
+
+    debugs(83, DBG_PARSE_NOTE(3), "found cert subject=" << out);
+    return out;
+}
+
+bool
+Security::CertIsIssuedBy(Certificate &cert, Certificate &issuer)
+{
+#if USE_OPENSSL
+    const auto result = X509_check_issued(&issuer, &cert);
+    if (result == X509_V_OK)
+        return true;
+    debugs(83, DBG_PARSE_NOTE(3), issuer << " did not sign " << cert << ": " <<
+           X509_verify_cert_error_string(result) << " (" << result << ")");
+#elif USE_GNUTLS
+    const auto result = gnutls_x509_crt_check_issuer(&cert, &issuer);
+    if (result == 1)
+        return true;
+    debugs(83, DBG_PARSE_NOTE(3), issuer << " did not sign " << cert);
+#else
+    debugs(83, DBG_PARSE_NOTE(2), "WARNING: cannot determine certificates relationship: " << MissingLibraryError());
+#endif
+    return false;
+}
+
+std::ostream &
+operator <<(std::ostream &os, Security::Certificate &cert)
+{
+    // TODO: Optimize by avoiding memory allocation for this written temporary
+    const auto name = Security::CertSubjectName(cert);
+    if (name.isEmpty())
+        os << "[no subject name]";
+    else
+        os << name;
+    return os;
+}
+

--- a/src/security/CertGadgets.h
+++ b/src/security/CertGadgets.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_SECURITY_CERTGADGETS_H
+#define SQUID_SRC_SECURITY_CERTGADGETS_H
+
+#include "security/forward.h"
+
+namespace Security
+{
+
+// The accessing/testing functions below require a non-constant Certificate when
+// it is modified by an underlying library implementation (e.g., GnuTLS).
+
+/// The SubjectName field of the given certificate (if found) or an empty SBuf.
+SBuf CertSubjectName(Certificate &);
+
+/// The Issuer field of the given certificate (if found) or an empty SBuf.
+/// Some implementations modify the argument while searching (e.g., GnuTLS).
+SBuf CertIssuerName(Certificate &);
+
+/// \returns whether cert was (correctly) issued by the given issuer
+/// Due to complexity of the underlying checks, it is impossible to clearly
+/// distinguish pure negative answers (e.g., two independent certificates)
+/// from errors (e.g., the issuer certificate lacks the right CA extension).
+bool CertIsIssuedBy(Certificate &cert, Certificate &issuer);
+
+/// convenience wrapper for checking self-signed certificates
+inline bool CertIsSelfSigned(Certificate &c) { return CertIsIssuedBy(c, c); }
+
+} // namespace Security
+
+#endif /* SQUID_SRC_SECURITY_CERTGADGETS_H */
+

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -9,6 +9,8 @@
 #include "squid.h"
 #include "anyp/PortCfg.h"
 #include "fatal.h"
+#include "security/CertGadgets.h"
+#include "security/Io.h"
 #include "security/KeyData.h"
 #include "SquidConfig.h"
 #include "ssl/bio.h"
@@ -93,44 +95,41 @@ Security::KeyData::loadX509ChainFromFile()
         return;
     }
 
-#if TLS_CHAIN_NO_SELFSIGNED // ignore self-signed certs in the chain
-    if (X509_check_issued(cert.get(), cert.get()) == X509_V_OK) {
-        char *nameStr = X509_NAME_oneline(X509_get_subject_name(cert.get()), nullptr, 0);
-        debugs(83, DBG_PARSE_NOTE(2), "Certificate is self-signed, will not be chained: " << nameStr);
-        OPENSSL_free(nameStr);
-    } else
-#endif
-    {
-        debugs(83, DBG_PARSE_NOTE(3), "Using certificate chain in " << certFile);
-        // and add to the chain any other certificate exist in the file
-        CertPointer latestCert = cert;
-
-        while (const auto ca = Ssl::ReadX509Certificate(bio)) {
-            // get Issuer name of the cert for debug display
-            char *nameStr = X509_NAME_oneline(X509_get_subject_name(ca.get()), nullptr, 0);
-
-#if TLS_CHAIN_NO_SELFSIGNED // ignore self-signed certs in the chain
-            // self-signed certificates are not valid in a sent chain
-            if (X509_check_issued(ca.get(), ca.get()) == X509_V_OK) {
-                debugs(83, DBG_PARSE_NOTE(2), "CA " << nameStr << " is self-signed, will not be chained: " << nameStr);
-                OPENSSL_free(nameStr);
-                continue;
-            }
-#endif
-            // checks that the chained certs are actually part of a chain for validating cert
-            const auto checkCode = X509_check_issued(ca.get(), latestCert.get());
-            if (checkCode == X509_V_OK) {
-                debugs(83, DBG_PARSE_NOTE(3), "Adding issuer CA: " << nameStr);
-                // OpenSSL API requires that we order certificates such that the
-                // chain can be appended directly into the on-wire traffic.
-                latestCert = CertPointer(ca);
-                chain.emplace_back(latestCert);
-            } else {
-                debugs(83, DBG_PARSE_NOTE(2), certFile << ": Ignoring non-issuer CA " << nameStr << ": " << X509_verify_cert_error_string(checkCode) << " (" << checkCode << ")");
-            }
-            OPENSSL_free(nameStr);
+    CertList intermediates;
+    debugs(83, DBG_PARSE_NOTE(3), "Building certificate chain from " << certFile);
+    while (const auto ca = Ssl::ReadX509Certificate(bio)) {
+        // We ignore a self-signed certificate because it should not be sent:
+        // The recipients that do not already have it should not trust it.
+        if (CertIsSelfSigned(*ca)) {
+            debugs(83, DBG_PARSE_NOTE(2), "Ignoring a self-signed CA " << *ca);
+            continue;
         }
+
+        intermediates.emplace_back(ca);
     }
+
+    // OpenSSL sends `cert` first. After that, OpenSSL sends certificates in the
+    // order they are stored in the chain, so we must push them in on-the-wire
+    // order, as defined by RFC 8446 Section 4.4.2: "The sender's certificate
+    // MUST come in the first CertificateEntry in the list. Each following
+    // certificate SHOULD directly certify the one immediately preceding it."
+    for (auto precedingCert = cert; precedingCert;) {
+        CertPointer issuer; // the issuer of the "preceding" certificate
+        for (auto i = intermediates.begin(); i != intermediates.end(); ++i) {
+            const auto &candidateIssuer = *i;
+            if (CertIsIssuedBy(*precedingCert, *candidateIssuer)) {
+                issuer = candidateIssuer;
+                debugs(83, DBG_PARSE_NOTE(3), "Adding intermediate CA: " << *issuer);
+                chain.emplace_back(issuer);
+                intermediates.erase(i); // cannot match again
+                break;
+            }
+        }
+        precedingCert = issuer; // may be nil
+    }
+
+    for (const auto &ic: intermediates)
+        debugs(83, DBG_IMPORTANT, "WARNING: Unused intermediate certificate: " << *ic);
 
 #elif USE_GNUTLS
     // XXX: implement chain loading

--- a/src/security/LockingPointer.h
+++ b/src/security/LockingPointer.h
@@ -100,6 +100,7 @@ public:
     bool operator ==(const SelfType &o) const { return (o.get() == raw); }
     bool operator !=(const SelfType &o) const { return (o.get() != raw); }
 
+    T &operator *() const { return *raw; } // TODO: assert(raw)?
     T *operator ->() const { return raw; }
 
     /// Returns raw and possibly nullptr pointer

--- a/src/security/Makefile.am
+++ b/src/security/Makefile.am
@@ -16,6 +16,8 @@ libsecurity_la_SOURCES = \
 	BlindPeerConnector.cc \
 	BlindPeerConnector.h \
 	CertError.h \
+	CertGadgets.cc \
+	CertGadgets.h \
 	CommunicationSecrets.cc \
 	CommunicationSecrets.h \
 	Context.h \

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -11,6 +11,7 @@
 
 #include "base/CbDataList.h"
 #include "base/forward.h"
+#include "sbuf/forward.h"
 #include "security/Context.h"
 #include "security/Session.h"
 
@@ -29,6 +30,9 @@
 #endif
 #if HAVE_OPENSSL_RSA_H
 #include <openssl/rsa.h>
+#endif
+#if HAVE_OPENSSL_X509V3_H
+#include <openssl/x509v3.h>
 #endif
 #endif /* USE_OPENSSL */
 #include <unordered_set>
@@ -53,6 +57,14 @@
 #define SSL_FLAG_VERIFY_CRL_ALL     (1<<6)
 #define SSL_FLAG_CONDITIONAL_AUTH   (1<<7)
 
+#if !USE_OPENSSL && !USE_GNUTLS
+/// A helper type to keep all three possible underlying types of the
+/// Security::Certificate typedef below inside global namespace, so that
+/// argument-dependent lookup for operator "<<" (Certificate) works inside
+/// functions declared in Security and global namespaces.
+struct notls_x509 {};
+#endif
+
 /// Network/connection security abstraction layer
 namespace Security
 {
@@ -66,7 +78,7 @@ typedef X509 Certificate;
 #elif USE_GNUTLS
 typedef struct gnutls_x509_crt_int Certificate;
 #else
-typedef class {} Certificate;
+typedef struct notls_x509 Certificate;
 #endif
 
 #if USE_OPENSSL
@@ -200,6 +212,11 @@ void CloseLogs(); ///< closes logs opened by OpenLogs()
 
 } // namespace Security
 
+// Declared outside Security because all underlying Security::Certificate types
+// are declared inside global namespace.
+/// reports a one-line gist of the Certificate Subject Name (for debugging)
+std::ostream &operator <<(std::ostream &, Security::Certificate &);
+
 /// Squid-specific TLS handling errors (a subset of ErrorCode)
 /// These errors either distinguish high-level library calls/contexts or
 /// supplement official certificate validation errors to cover special cases.
@@ -220,4 +237,3 @@ enum {
 };
 
 #endif /* SQUID_SRC_SECURITY_FORWARD_H */
-

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -24,6 +24,7 @@
 #include "globals.h"
 #include "ipc/MemMap.h"
 #include "security/CertError.h"
+#include "security/CertGadgets.h"
 #include "security/ErrorDetail.h"
 #include "security/Session.h"
 #include "SquidConfig.h"
@@ -962,6 +963,10 @@ void
 Ssl::chainCertificatesToSSLContext(Security::ContextPointer &ctx, Security::ServerOptions &options)
 {
     assert(ctx);
+
+    if (Security::CertIsSelfSigned(*options.signingCa.cert))
+        return;
+
     // Add signing certificate to the certificates chain
     X509 *signingCert = options.signingCa.cert.get();
     if (SSL_CTX_add_extra_chain_cert(ctx.get(), signingCert)) {

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -28,6 +28,12 @@ void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB
 Security::EncryptorAnswer::~EncryptorAnswer() {}
 std::ostream &Security::operator <<(std::ostream &os, const Security::EncryptorAnswer &) STUB_RETVAL(os)
 
+#include "security/CertGadgets.h"
+SBuf Security::CertSubjectName(Certificate &) STUB_RETVAL(SBuf())
+SBuf Security::CertIssuerName(Certificate &) STUB_RETVAL(SBuf())
+bool Security::CertIsIssuedBy(Certificate &, Certificate &) STUB_RETVAL(false)
+std::ostream &operator <<(std::ostream &os, Security::Certificate &) STUB_RETVAL(os)
+
 #include "security/Handshake.h"
 Security::HandshakeParser::HandshakeParser(MessageSource) STUB
 bool Security::HandshakeParser::parseHello(const SBuf &) STUB_RETVAL(false)


### PR DESCRIPTION
This patch:
- Fixes squid to not send self signed certificates to the remote end 
   if exists in ertificates files or used as signing certificates
- Also fixes the chained certificates order to follow RFC8446
  Section 4.4.2:
  " The sender's certificate MUST come in the first CertificateEntry
    in the list. Each following certificate SHOULD directly certify
    the one immediately preceding it."

This is a Measurement Factory project