### PR TITLE
The selected ciphers must affect certificates loading and use

### DIFF
--- a/src/adaptation/ecap/XactionRep.cc
+++ b/src/adaptation/ecap/XactionRep.cc
@@ -163,12 +163,12 @@ Adaptation::Ecap::XactionRep::usernameValue() const
 }
 
 const libecap::Area
-Adaptation::Ecap::XactionRep::masterxSharedValue(const libecap::Name &name) const
+Adaptation::Ecap::XactionRep::masterxSharedValue(const libecap::Name &sharedName) const
 {
     const HttpRequest *request = dynamic_cast<const HttpRequest*>(theCauseRep ?
                                  theCauseRep->raw().header : theVirginRep.raw().header);
     Must(request);
-    if (name.known()) { // must check to avoid empty names matching unset cfg
+    if (sharedName.known()) { // must check to avoid empty names matching unset cfg
         Adaptation::History::Pointer ah = request->adaptHistory(false);
         if (ah != NULL) {
             String name, value;
@@ -482,7 +482,6 @@ Adaptation::Ecap::XactionRep::updateHistory(Http::Message *adapted)
 
     // update the adaptation plan if needed
     if (service().cfg().routing) {
-        String services;
         if (const libecap::Area services = theMaster->option(libecap::metaNextServices)) {
             Adaptation::History::Pointer ah = request->adaptHistory(true);
             if (ah != NULL)

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -212,6 +212,13 @@ Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &)
 
     Security::ContextPointer t(createBlankContext());
     if (t) {
+        // this updateContextConfig() must precede SSL_CTX_use_certificate()
+        // below because OpenSSL checks whether the certificate matches context
+        // options (e.g., the supported ciphers and the security level).
+        if (!updateContextConfig(t)) {
+            debugs(83, DBG_CRITICAL, "ERROR: Configuring static TLS context");
+            return false;
+        }
 
 #if USE_OPENSSL
         if (certs.size() > 1) {
@@ -261,15 +268,6 @@ Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &)
             // XXX: add cert chain to the context
         }
 #endif
-
-        if (!loadClientCaFile())
-            return false;
-
-        // by this point all config related files must be loaded
-        if (!updateContextConfig(t)) {
-            debugs(83, DBG_CRITICAL, "ERROR: Configuring static TLS context");
-            return false;
-        }
     }
 
     staticContext = std::move(t);
@@ -324,26 +322,6 @@ Security::ServerOptions::syncCaFiles()
     // otherwise fall back to clientca if it is defined
     if (!clientCaFile.isEmpty())
         caFiles.emplace_back(clientCaFile);
-}
-
-/// load clientca= file (if any) into memory.
-/// \retval true   clientca is not set, or loaded successfully
-/// \retval false  unable to load the file, or not using OpenSSL
-bool
-Security::ServerOptions::loadClientCaFile()
-{
-    if (clientCaFile.isEmpty())
-        return true;
-
-#if USE_OPENSSL
-    auto *stk = SSL_load_client_CA_file(clientCaFile.c_str());
-    clientCaStack = Security::ServerOptions::X509_NAME_STACK_Pointer(stk);
-#endif
-    if (!clientCaStack) {
-        debugs(83, DBG_CRITICAL, "FATAL: Unable to read client CAs from file: " << clientCaFile);
-    }
-
-    return bool(clientCaStack);
 }
 
 void
@@ -407,7 +385,8 @@ Security::ServerOptions::updateContextConfig(Security::ContextPointer &ctx)
 
     updateContextEecdh(ctx);
     updateContextCa(ctx);
-    updateContextClientCa(ctx);
+    if (!updateContextClientCa(ctx))
+        return false;
 
 #if USE_OPENSSL
     SSL_CTX_set_mode(ctx.get(), SSL_MODE_NO_AUTO_CHAIN);
@@ -419,31 +398,45 @@ Security::ServerOptions::updateContextConfig(Security::ContextPointer &ctx)
     return true;
 }
 
-void
+bool
 Security::ServerOptions::updateContextClientCa(Security::ContextPointer &ctx)
 {
 #if USE_OPENSSL
-    if (clientCaStack) {
+    if (clientCaFile.isEmpty()) {
+        Ssl::DisablePeerVerification(ctx);
+#elif USE_GNUTLS
+        // TODO: disable client verification
+#endif
+        return true;
+    }
+
+#if USE_OPENSSL
+    clientCaStack.reset(SSL_load_client_CA_file(clientCaFile.c_str()));
+    if (!clientCaStack) {
+        const auto ssl_error = ERR_get_error();
+        debugs(83, DBG_CRITICAL, "FATAL: Failed to load client CAs from " << clientCaFile << ": " << Security::ErrorString(ssl_error));
+        // XXX: "return false" is not FATAL
+        return false;
+    } else {
         ERR_clear_error();
         if (STACK_OF(X509_NAME) *clientca = SSL_dup_CA_list(clientCaStack.get())) {
             SSL_CTX_set_client_CA_list(ctx.get(), clientca);
         } else {
             auto ssl_error = ERR_get_error();
             debugs(83, DBG_CRITICAL, "ERROR: Failed to dupe the client CA list: " << Security::ErrorString(ssl_error));
-            return;
+            return false;
         }
 
         Ssl::ConfigurePeerVerification(ctx, parsedFlags);
 
         updateContextCrl(ctx);
         updateContextTrust(ctx);
-
-    } else {
-        Ssl::DisablePeerVerification(ctx);
     }
 #else
+    // XXX: Inability to perform requested client authentication must be fatal!
     (void)ctx;
 #endif
+    return true;
 }
 
 void

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -58,7 +58,7 @@ public:
     void updateContextEecdh(Security::ContextPointer &);
 
     /// update the context with CA details used to verify client certificates
-    void updateContextClientCa(Security::ContextPointer &);
+    bool updateContextClientCa(Security::ContextPointer &);
 
     /// update the context with a configured session ID (if any)
     void updateContextSessionId(Security::ContextPointer &);
@@ -91,7 +91,6 @@ public:
     size_t dynamicCertMemCacheSize = 4*1024*1024;
 
 private:
-    bool loadClientCaFile();
     void loadDhParams();
 
     /// generate a security server-context from these configured options

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -916,15 +916,20 @@ sslGetUserCertificateChainPEM(SSL *ssl)
 Security::ContextPointer
 Ssl::createSSLContext(Security::CertPointer & x509, Security::PrivateKeyPointer & pkey, Security::ServerOptions &options)
 {
+    // TODO: Stop duplicating most of ServerOptions::createStaticServerContext()
+
     Security::ContextPointer ctx(options.createBlankContext());
+
+    // this updateContextConfig() must precede SSL_CTX_use_certificate() below
+    // because OpenSSL checks whether the certificate matches context options
+    // (e.g., the supported ciphers and the security level).
+    if (!options.updateContextConfig(ctx))
+        return Security::ContextPointer();
 
     if (!SSL_CTX_use_certificate(ctx.get(), x509.get()))
         return Security::ContextPointer();
 
     if (!SSL_CTX_use_PrivateKey(ctx.get(), pkey.get()))
-        return Security::ContextPointer();
-
-    if (!options.updateContextConfig(ctx))
         return Security::ContextPointer();
 
     return ctx;

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -129,7 +129,7 @@ bool Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &) STUB_RE
 void Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &) STUB
 bool Security::ServerOptions::updateContextConfig(Security::ContextPointer &) STUB_RETVAL(false)
 void Security::ServerOptions::updateContextEecdh(Security::ContextPointer &) STUB
-void Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB
+bool Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB
 void Security::ServerOptions::syncCaFiles() STUB
 void Security::ServerOptions::updateContextSessionId(Security::ContextPointer &) STUB
 


### PR DESCRIPTION
The selected ciphers in an https port play role in the provided
security policy and the configured certificates should accepted
or rejected depending on whether or not comply to this policy.

An example is the fake @SECLEVEL cipher used by OpenSSL toolkit.

This patch fixes the ServerOptions::createStaticServerContext
and Ssl::createSSLContext to configure TLS context ciphers
before attach certificates to this context.

This is a Measurement Factory project