### PR TITLE
Invalidate all cached variants using STORE_META_VARY_ID

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,9 @@ STOREMETA_SOURCE = \
 	StoreMetaURL.cc \
 	StoreMetaURL.h \
 	StoreMetaVary.cc \
-	StoreMetaVary.h
+	StoreMetaVary.h \
+	StoreMetaVaryId.cc \
+	StoreMetaVaryId.h
 
 LOADABLE_MODULES_SOURCES = \
 	LoadableModule.cc \
@@ -314,6 +316,8 @@ squid_SOURCES = \
 	PingData.h \
 	Pipeline.cc \
 	Pipeline.h \
+	RandomUuid.cc \
+	RandomUuid.h \
 	RefreshPattern.h \
 	RemovalPolicy.cc \
 	RemovalPolicy.h \

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -94,7 +94,29 @@ MemObject::setUris(char const *aStoreId, char const *aLogUri, const HttpRequestM
 #endif
 }
 
-MemObject::MemObject()
+void
+MemObject::createVaryUuid()
+{
+    delete varyUuid; // should be nil
+    varyUuid = new RandomUuid();
+}
+
+void
+MemObject::takeVaryUuid(const RandomUuid &other)
+{
+    delete varyUuid; // should be nil
+    varyUuid = new RandomUuid(other);
+}
+
+bool
+MemObject::varyUuidEqualsTo(const RandomUuid *other)
+{
+    Must(varyUuid);
+    Must(other);
+    return *varyUuid == *other;
+}
+
+MemObject::MemObject(): varyUuid(nullptr)
 {
     debugs(20, 3, "MemObject constructed, this=" << this);
     ping_reply_callback = nullptr;
@@ -117,6 +139,7 @@ MemObject::~MemObject()
     }
 
     data_hdr.freeContent();
+    delete varyUuid;
 }
 
 HttpReply &

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -12,6 +12,7 @@
 #include "CommRead.h"
 #include "dlink.h"
 #include "http/RequestMethod.h"
+#include "RandomUuid.h"
 #include "RemovalPolicy.h"
 #include "SquidString.h"
 #include "stmem.h"
@@ -134,6 +135,13 @@ public:
     /// client request URI used for logging; storeId() by default
     const char *logUri() const;
 
+    /// generate a new vary identifier
+    void createVaryUuid();
+    /// copy an existing vary identifier
+    void takeVaryUuid(const RandomUuid &);
+    /// whether our and other vary identifiers are the same
+    bool varyUuidEqualsTo(const RandomUuid *other);
+
     HttpRequestMethod method;
     mem_hdr data_hdr;
     int64_t inmem_lo = 0;
@@ -202,6 +210,9 @@ public:
 #endif
 
     SBuf vary_headers;
+    /// Identifier for for vary-based entries, which is the same
+    /// for all entries with the same marker object.
+    RandomUuid *varyUuid;
 
     void delayRead(DeferredRead const &);
     void kickReads();

--- a/src/RandomUuid.cc
+++ b/src/RandomUuid.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#include "defines.h"
+#include "RandomUuid.h"
+
+#include <chrono>
+#include <iomanip>
+#include <random>
+
+RandomUuid::RandomUuid()
+{
+    using ResultType = std::mt19937_64::result_type;
+    const auto ResultSize = sizeof(ResultType);
+    static_assert(2*sizeof(ResultType) == sizeof(RandomUuid), "RandomUuid expected size");
+    const auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    std::mt19937_64 gen(seed);
+    const auto low = gen();
+    const auto high = gen();
+    memcpy(reinterpret_cast<char *>(this), &low, ResultSize);
+    memcpy(reinterpret_cast<char *>(this) + ResultSize, &high, ResultSize);
+    // RFC4122 section 4.4
+    EBIT_CLR(clockSeqHiAndReserved, 6);
+    EBIT_SET(clockSeqHiAndReserved, 7);
+    // section 4.1.3 variant 4 
+    EBIT_CLR(timeHiAndVersion, 13);
+    EBIT_SET(timeHiAndVersion, 14);
+    EBIT_CLR(timeHiAndVersion, 15);
+    EBIT_CLR(timeHiAndVersion, 16);
+}
+
+RandomUuid::RandomUuid(void *data, const int length)
+{
+    assert(length == sizeof(RandomUuid));
+    memcpy(reinterpret_cast<char *>(this), data, sizeof(RandomUuid));
+}
+
+void
+RandomUuid::print(std::ostream &os)
+{
+    std::cout << "0x" << std::setfill('0') << std::hex << std::setw(16) <<
+        reinterpret_cast<uint64_t>(this+64) << reinterpret_cast<uint64_t>(this);
+}
+
+bool
+RandomUuid::operator ==(const RandomUuid &other)
+{
+    return memcmp(this, &other, sizeof(RandomUuid)) == 0;
+}
+

--- a/src/RandomUuid.h
+++ b/src/RandomUuid.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef RANDOM_UUID_H
+#define RANDOM_UUID_H
+
+#include <iostream>
+
+// RFC4122: Universally Unique IDentifier (UUID)
+class RandomUuid
+{
+public:
+    RandomUuid();
+    RandomUuid(void *data, int length);
+
+    void print(std::ostream &os);
+    bool operator==(const RandomUuid&);
+    bool operator!=(const RandomUuid &other) { return !(*this == other); }
+
+private:
+    uint32_t timeLow;
+    uint16_t timeMid;
+    uint16_t timeHiAndVersion;
+    uint8_t clockSeqHiAndReserved;
+    uint8_t clockSeqLow;
+    int8_t node[6];
+};
+
+#endif
+

--- a/src/StoreMeta.cc
+++ b/src/StoreMeta.cc
@@ -19,6 +19,7 @@
 #include "StoreMetaSTDLFS.h"
 #include "StoreMetaURL.h"
 #include "StoreMetaVary.h"
+#include "StoreMetaVaryId.h"
 
 bool
 StoreMeta::validType(char type)
@@ -30,9 +31,7 @@ StoreMeta::validType(char type)
     }
 
     /* Not yet implemented */
-    if (type >= STORE_META_END ||
-            type == STORE_META_STOREURL ||
-            type == STORE_META_VARY_ID) {
+    if (type >= STORE_META_END || type == STORE_META_STOREURL) {
         debugs(20, 3, "storeSwapMetaUnpack: Not yet implemented (" << type << ") in disk metadata");
         return false;
     }
@@ -98,6 +97,10 @@ StoreMeta::Factory (char type, size_t len, void const *value)
         result = new StoreMetaVary;
         break;
 
+    case STORE_META_VARY_ID:
+        result = new StoreMetaVaryId;
+        break;
+
     default:
         debugs(20, DBG_CRITICAL, "ERROR: Attempt to create unknown concrete StoreMeta");
         return NULL;
@@ -154,6 +157,9 @@ StoreMeta::checkConsistency(StoreEntry *) const
         break;
 
     case STORE_META_OBJSIZE:
+        break;
+
+    case STORE_META_VARY_ID:
         break;
 
     default:

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3465,7 +3465,7 @@ clientConnectionsClose()
 }
 
 int
-varyEvaluateMatch(StoreEntry * entry, HttpRequest * request)
+varyEvaluateMatch(StoreEntry * entry, RandomUuid *varyMarkerUuid, HttpRequest * request)
 {
     SBuf vary(request->vary_headers);
     const auto &reply = entry->mem().freshestReply();
@@ -3514,6 +3514,8 @@ varyEvaluateMatch(StoreEntry * entry, HttpRequest * request)
         if (vary.isEmpty()) {
             /* Ouch.. we cannot handle this kind of variance */
             /* XXX This cannot really happen, but just to be complete */
+            return VARY_CANCEL;
+        } else if (!entry->mem_obj->varyUuidEqualsTo(varyMarkerUuid)) {
             return VARY_CANCEL;
         } else if (vary.cmp(entry->mem_obj->vary_headers) == 0) {
             return VARY_MATCH;

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -45,6 +45,8 @@ class HttpHdrRangeSpec;
 class MasterXaction;
 typedef RefCount<MasterXaction> MasterXactionPointer;
 
+class RandomUuid;
+
 #if USE_OPENSSL
 namespace Ssl
 {
@@ -506,7 +508,7 @@ private:
 
 const char *findTrailingHTTPVersion(const char *uriAndHTTPVersion, const char *end = NULL);
 
-int varyEvaluateMatch(StoreEntry * entry, HttpRequest * req);
+int varyEvaluateMatch(StoreEntry *entry, RandomUuid *varyMarkerUuid, HttpRequest *req);
 
 /// accept requests to a given port and inform subCall about them
 void clientStartListeningOn(AnyP::PortCfgPointer &port, const RefCount< CommCbFunPtrCallT<CommAcceptCbPtrFun> > &subCall, const Ipc::FdNoteId noteId);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -154,6 +154,7 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
     calloutContext(NULL),
     maxReplyBodySize_(0),
     entry_(NULL),
+    varyMarkerUuid(nullptr),
     loggingEntry_(NULL),
     conn_(cbdataReference(aConn))
 #if USE_OPENSSL
@@ -295,6 +296,8 @@ ClientHttpRequest::~ClientHttpRequest()
 
     if (calloutContext)
         delete calloutContext;
+
+    delete varyMarkerUuid;
 
     clientConnection = NULL;
 

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -106,6 +106,10 @@ public:
 
     String store_id; /* StoreID for transactions where the request member is nil */
 
+    /// the identifier of the internal vary marker object, which
+    /// our storeEntry() relates to (may be nil).
+    RandomUuid *varyMarkerUuid;
+
     struct Out {
         Out() : offset(0), size(0), headers_sz(0) {}
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -936,7 +936,7 @@ Ipc::StoreMap::sliceAt(const SliceId sliceId) const
 
 /* Ipc::StoreMapAnchor */
 
-Ipc::StoreMapAnchor::StoreMapAnchor(): start(0), splicingPoint(-1)
+Ipc::StoreMapAnchor::StoreMapAnchor(): start(0), splicingPoint(-1), varyUuid(nullptr)
 {
     // keep in sync with rewind()
 }

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -18,6 +18,8 @@
 
 #include <functional>
 
+class RandomUuid;
+
 namespace Ipc
 {
 
@@ -113,6 +115,8 @@ public:
     /// where the updated chain prefix containing metadata/headers ends [update]
     /// if unset, this anchor points to a chain that was never updated
     std::atomic<StoreMapSliceId> splicingPoint;
+
+    RandomUuid *varyUuid;
 };
 
 /// an array of shareable Items

--- a/src/store.cc
+++ b/src/store.cc
@@ -709,6 +709,8 @@ StoreEntry::adjustVary()
     if (!mem_obj->vary_headers.isEmpty() && !storeGetPublic(mem_obj->storeId(), mem_obj->method)) {
         /* Create "vary" base object */
         StoreEntry *pe = storeCreateEntry(mem_obj->storeId(), mem_obj->logUri(), request->flags, request->method);
+        pe->mem_obj->createVaryUuid();
+        mem_obj->takeVaryUuid(*pe->mem_obj->varyUuid);
         // XXX: storeCreateEntry() already tries to make `pe` public under
         // certain conditions. If those conditions do not apply to Vary markers,
         // then refactor to call storeCreatePureEntry() above.  Otherwise,

--- a/src/store_swapmeta.cc
+++ b/src/store_swapmeta.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "md5.h"
 #include "MemObject.h"
+#include "RandomUuid.h"
 #include "Store.h"
 #include "StoreMeta.h"
 #include "StoreMetaUnpacker.h"
@@ -96,7 +97,12 @@ storeSwapMetaBuild(const StoreEntry *e)
             return NULL;
         }
 
-        StoreMeta::Add (T, t);
+        T = StoreMeta::Add(T, t);
+    }
+
+    if (e->mem_obj->varyUuid) {
+        t = StoreMeta::Factory(STORE_META_VARY_ID, sizeof(RandomUuid), e->mem_obj->varyUuid);
+        StoreMeta::Add(T, t);
     }
 
     return TLV;

--- a/src/tests/stub_client_side.cc
+++ b/src/tests/stub_client_side.cc
@@ -54,7 +54,7 @@ bool ConnStateData::serveDelayedError(Http::Stream *) STUB_RETVAL(false)
 #endif
 
 const char *findTrailingHTTPVersion(const char *, const char *) STUB_RETVAL(NULL)
-int varyEvaluateMatch(StoreEntry *, HttpRequest *) STUB_RETVAL(0)
+int varyEvaluateMatch(StoreEntry *, RandomUuid *, HttpRequest *) STUB_RETVAL(0)
 void clientOpenListenSockets(void) STUB
 void httpRequestFree(void *) STUB
 void clientPackRangeHdr(const HttpReplyPointer &, const HttpHdrRangeSpec *, String, MemBuf *) STUB


### PR DESCRIPTION
When a parent vary object is created, it acquires a UUID, which is
subsequently copied to all its child objects. When the parent object
is purged and created again, all its child objects become invalid due to
the UUID mismatch. Before this fix, the parent vary object recreation
did not invalidate its children.