### PR TITLE
Do not use TcpAcceptor::listenPort_ unconditionally

### DIFF
--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -51,7 +51,9 @@ private:
     TcpAcceptor(const TcpAcceptor &); // not implemented.
 
 public:
+    /// will listen on a random OS-assigned port number
     TcpAcceptor(const Comm::ConnectionPointer &conn, const char *note, const Subscription::Pointer &aSub);
+    /// will listen on a Squid-configured port number
     TcpAcceptor(const AnyP::PortCfgPointer &listenPort, const char *note, const Subscription::Pointer &aSub);
 
 protected:


### PR DESCRIPTION
TcpAcceptor initializes this value only if PortCfgPointer is provided
during construction. We must not use this field in other cases.