### PR TITLE
Better naming for StoreMeta::checkConsistency()

### DIFF
--- a/src/StoreMeta.cc
+++ b/src/StoreMeta.cc
@@ -134,8 +134,8 @@ StoreMeta::Add(StoreMeta **tail, StoreMeta *aNode)
     return &aNode->next;        /* return new tail pointer */
 }
 
-bool
-StoreMeta::checkConsistency(StoreEntry *) const
+void
+StoreMeta::applyTo(StoreEntry *) const
 {
     switch (getType()) {
 
@@ -160,8 +160,6 @@ StoreMeta::checkConsistency(StoreEntry *) const
         debugs(20, DBG_IMPORTANT, "WARNING: got unused STORE_META type " << getType());
         break;
     }
-
-    return true;
 }
 
 StoreMeta::StoreMeta(const StoreMeta &s) :

--- a/src/StoreMeta.h
+++ b/src/StoreMeta.h
@@ -127,7 +127,9 @@ public:
 
     virtual char getType() const = 0;
     virtual bool validLength(int) const;
-    virtual bool checkConsistency(StoreEntry *) const;
+    /// Checks that this is a valid StoreMeta.
+    /// Kids may store value into StoreEntry.
+    virtual void applyTo(StoreEntry *) const;
     virtual ~StoreMeta() {}
 
     int length;

--- a/src/StoreMetaMD5.cc
+++ b/src/StoreMetaMD5.cc
@@ -9,9 +9,11 @@
 /* DEBUG: section 20    Storage Manager Swapfile Metadata */
 
 #include "squid.h"
+#include "base/TextException.h"
 #include "int.h"
 #include "md5.h"
 #include "MemObject.h"
+#include "sbuf/Stream.h"
 #include "Store.h"
 #include "StoreMetaMD5.h"
 
@@ -23,24 +25,18 @@ StoreMetaMD5::validLength(int len) const
 
 int StoreMetaMD5::md5_mismatches = 0;
 
-bool
-StoreMetaMD5::checkConsistency(StoreEntry *e) const
+void
+StoreMetaMD5::applyTo(StoreEntry *e) const
 {
     assert (getType() == STORE_META_KEY_MD5);
     assert(length == SQUID_MD5_DIGEST_LENGTH);
 
     if (!EBIT_TEST(e->flags, KEY_PRIVATE) &&
             memcmp(value, e->key, SQUID_MD5_DIGEST_LENGTH)) {
-        debugs(20, 2, "storeClientReadHeader: swapin MD5 mismatch");
-        // debugs(20, 2, "\t" << storeKeyText((const cache_key *)value));
-        debugs(20, 2, "\t" << e->getMD5Text());
-
         if (isPowTen(++md5_mismatches))
             debugs(20, DBG_IMPORTANT, "WARNING: " << md5_mismatches << " swapin MD5 mismatches");
-
-        return false;
+        const auto loadedKey = storeKeyText(static_cast<const cache_key *>(value));
+        throw TextException(ToSBuf("MD5 mismatch: {", loadedKey, "} != {", e->getMD5Text(), '}'), Here());
     }
-
-    return true;
 }
 

--- a/src/StoreMetaMD5.h
+++ b/src/StoreMetaMD5.h
@@ -21,7 +21,7 @@ public:
     char getType() const {return STORE_META_KEY_MD5;}
 
     bool validLength(int) const;
-    bool checkConsistency(StoreEntry *) const;
+    void applyTo(StoreEntry *) const;
 
 private:
     static int md5_mismatches;

--- a/src/StoreMetaSTD.h
+++ b/src/StoreMetaSTD.h
@@ -19,7 +19,6 @@ public:
     char getType() const {return STORE_META_STD;}
 
     bool validLength(int) const;
-    //    bool checkConsistency(StoreEntry *) const;
 };
 
 #endif /* SQUID_STOREMETASTD_H */

--- a/src/StoreMetaSTDLFS.h
+++ b/src/StoreMetaSTDLFS.h
@@ -19,7 +19,6 @@ public:
     char getType() const {return STORE_META_STD_LFS;}
 
     bool validLength(int) const;
-    //    bool checkConsistency(StoreEntry *) const;
 };
 
 #endif /* SQUID_STOREMETASTDLFS_H */

--- a/src/StoreMetaURL.cc
+++ b/src/StoreMetaURL.cc
@@ -10,23 +10,19 @@
 
 #include "squid.h"
 #include "MemObject.h"
+#include "sbuf/Stream.h"
 #include "Store.h"
 #include "StoreMetaURL.h"
 
-bool
-StoreMetaURL::checkConsistency(StoreEntry *e) const
+void
+StoreMetaURL::applyTo(StoreEntry *e) const
 {
     assert (getType() == STORE_META_URL);
 
     if (!e->mem_obj->hasUris())
-        return true;
+        return;
 
-    if (strcasecmp(e->mem_obj->urlXXX(), (char *)value)) {
-        debugs(20, DBG_IMPORTANT, "storeClientReadHeader: URL mismatch");
-        debugs(20, DBG_IMPORTANT, "\t{" << (char *) value << "} != {" << e->mem_obj->urlXXX() << "}");
-        return false;
-    }
-
-    return true;
+    if (strcasecmp(e->mem_obj->urlXXX(), (char *)value))
+        throw TextException(ToSBuf("URL mismatch: {", static_cast<char*>(value), "} != {", e->mem_obj->urlXXX(), '}'), Here());
 }
 

--- a/src/StoreMetaURL.h
+++ b/src/StoreMetaURL.h
@@ -18,7 +18,7 @@ class StoreMetaURL : public StoreMeta
 public:
     char getType() const {return STORE_META_URL;}
 
-    bool checkConsistency(StoreEntry *) const;
+    void applyTo(StoreEntry *) const;
 };
 
 #endif /* SQUID_STOREMETAURL_H */

--- a/src/StoreMetaVary.cc
+++ b/src/StoreMetaVary.cc
@@ -9,28 +9,28 @@
 /* DEBUG: section 20    Storage Manager Swapfile Metadata */
 
 #include "squid.h"
+#include "base/TextException.h"
 #include "MemObject.h"
+#include "sbuf/Stream.h"
 #include "Store.h"
 #include "StoreMetaVary.h"
 
-bool
-StoreMetaVary::checkConsistency(StoreEntry *e) const
+void
+StoreMetaVary::applyTo(StoreEntry *e) const
 {
     assert (getType() == STORE_META_VARY_HEADERS);
 
     if (e->mem_obj->vary_headers.isEmpty()) {
-        /* XXX separate this mutator from the query */
         /* Assume the object is OK.. remember the vary request headers */
         e->mem_obj->vary_headers.assign(static_cast<const char *>(value), length);
         /* entries created before SBuf vary handling may include string terminator */
         static const SBuf nul("\0", 1);
         e->mem_obj->vary_headers.trim(nul);
-        return true;
+        return;
     }
 
-    if (e->mem_obj->vary_headers.cmp(static_cast<const char *>(value), length) != 0)
-        return false;
-
-    return true;
+    const auto loadedVary = static_cast<const char *>(value);
+    if (e->mem_obj->vary_headers.cmp(loadedVary, length) != 0)
+        throw TextException(ToSBuf("Vary headers mismatch: {", loadedVary, "} != {", e->mem_obj->vary_headers), Here());
 }
 

--- a/src/StoreMetaVary.h
+++ b/src/StoreMetaVary.h
@@ -18,7 +18,7 @@ class StoreMetaVary : public StoreMeta
 public:
     char getType() const {return STORE_META_VARY_HEADERS;}
 
-    bool checkConsistency(StoreEntry *) const;
+    void applyTo(StoreEntry *) const;
 };
 
 #endif /* SQUID_STOREMETAVARY_H */

--- a/src/comm/Makefile.am
+++ b/src/comm/Makefile.am
@@ -8,7 +8,9 @@
 include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/src/TestHeaders.am
 
-noinst_LTLIBRARIES = libcomm.la
+noinst_LTLIBRARIES = \
+	libcomm.la \
+	libminimal.la
 
 ## Library holding comm socket handlers
 libcomm_la_SOURCES = \
@@ -39,3 +41,7 @@ libcomm_la_SOURCES = \
 	Write.h \
 	comm_internal.h \
 	forward.h
+
+# a bare-bones implementation of few Comm APIs sufficient for helpers use
+libminimal_la_SOURCES = \
+	minimal.cc

--- a/src/comm/minimal.cc
+++ b/src/comm/minimal.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "debug/Stream.h"
+#include "fd.h"
+
+void
+fd_open(const int fd, unsigned int, const char *description)
+{
+    debugs(51, 3, "FD " << fd << ' ' << description);
+}
+
+void
+fd_close(const int fd)
+{
+    debugs(51, 3, "FD " << fd);
+}
+

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -38,7 +38,6 @@ libicmp_la_LIBADD= libicmpcore.la
 COPIED_SOURCE= \
 	globals.cc \
 	SquidConfig.cc \
-	tests/stub_fd.cc \
 	tests/stub_HelperChildConfig.cc \
 	tests/STUB.h \
 	time.cc
@@ -60,6 +59,7 @@ pinger_LDADD=\
 	$(top_builddir)/src/ip/libip.la \
 	$(top_builddir)/src/sbuf/libsbuf.la \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 	$(top_builddir)/src/base/libbase.la \
 	$(top_builddir)/src/mem/libminimal.la \
 	$(COMPAT_LIB) \
@@ -94,9 +94,6 @@ SquidConfig.cc: $(top_srcdir)/src/SquidConfig.cc
 
 tests/stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc | tests
 	cp $(top_srcdir)/src/tests/stub_HelperChildConfig.cc $@
-
-tests/stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc | tests
-	cp $(top_srcdir)/src/tests/stub_fd.cc $@
 
 tests/STUB.h: $(top_srcdir)/src/tests/STUB.h | tests
 	cp $(top_srcdir)/src/tests/STUB.h $@

--- a/src/tests/stub_StoreMeta.cc
+++ b/src/tests/stub_StoreMeta.cc
@@ -18,5 +18,5 @@ bool StoreMeta::validLength(int) const STUB_RETVAL(false)
 StoreMeta * StoreMeta::Factory (char, size_t, void const *) STUB_RETVAL(NULL)
 void StoreMeta::FreeList(StoreMeta **) STUB
 StoreMeta ** StoreMeta::Add(StoreMeta **, StoreMeta *) STUB_RETVAL(NULL)
-bool StoreMeta::checkConsistency(StoreEntry *) const STUB_RETVAL(false)
+void StoreMeta::applyTo(StoreEntry *) const STUB
 

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -63,7 +63,6 @@ STUBS = \
 	stub_SBuf.cc \
 	stub_tools.cc \
 	stub_fatal.cc \
-	stub_fd.cc \
 	STUB.h
 DEBUG_SOURCE = test_tools.cc $(STUBS)
 CLEANFILES += $(STUBS) stub_libmem.cc
@@ -83,9 +82,6 @@ stub_tools.cc: $(top_srcdir)/src/tests/stub_tools.cc
 stub_fatal.cc: $(top_srcdir)/src/tests/stub_fatal.cc
 	cp $(top_srcdir)/src/tests/stub_fatal.cc $@
 
-stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc
-	cp $(top_srcdir)/src/tests/stub_fd.cc $@
-
 stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc STUB.h
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 	
@@ -98,6 +94,7 @@ ESIExpressions_SOURCES = \
 	stub_libmem.cc
 ESIExpressions_LDADD = $(top_builddir)/src/esi/Expression.o \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 		$(LDADD)
 
 mem_node_test_SOURCES = \
@@ -107,6 +104,7 @@ mem_node_test_LDADD = \
 	$(top_builddir)/src/mem_node.o \
 	$(top_builddir)/src/mem/libmem.la \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 	$(LDADD)
 
 mem_hdr_test_SOURCES = \
@@ -117,6 +115,7 @@ mem_hdr_test_LDADD = \
 	$(top_builddir)/src/mem_node.o \
 	$(top_builddir)/src/mem/libmem.la \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 	$(LDADD)
 
 splay_SOURCES = \


### PR DESCRIPTION
... and StoreMeta kids. Generally, these methods implement 3 steps:

* check whether the TLV enum type is valid
* validate against the (passed) StoreEntry argument
* store some fields into the StoreEntry argument

Though (2) and (3) are optional - we should emphasize (via naming)
that the intention is to apply the loaded meta TLV to the existing
StoreEntry.

Also avoid memory leak in store_client::unpackHeader() in
a case of an exception.