### PR TITLE
Break long store_client call chains with async calls

### DIFF
--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -168,8 +168,7 @@ struct LowestMemReader : public unary_function<store_client, void> {
     LowestMemReader(int64_t seed):current(seed) {}
 
     void operator() (store_client const &x) {
-        if (x.memReaderHasLowerOffset(current))
-            current = x.copyInto.offset;
+        current = x.memHeaderOffsetLowerThan(current);
     }
 
     int64_t current;
@@ -468,7 +467,7 @@ MemObject::mostBytesAllowed() const
     for (dlink_node *node = clients.head; node; node = node->next) {
         store_client *sc = (store_client *) node->data;
 
-        j = sc->delayId.bytesWanted(0, sc->copyInto.length);
+        j = sc->bytesWanted();
 
         if (j > jmax) {
             jmax = j;

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -168,7 +168,8 @@ struct LowestMemReader : public unary_function<store_client, void> {
     LowestMemReader(int64_t seed):current(seed) {}
 
     void operator() (store_client const &x) {
-        current = x.memHeaderOffsetLowerThan(current);
+        if (x.reliesOnReadingFromMemory())
+            current = std::min(current, x.readOffset());
     }
 
     int64_t current;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -61,14 +61,14 @@ public:
     store_client(StoreEntry *);
     ~store_client();
 
-    /// Whether this Store client requires memory-stored response content. A
-    /// false result does not mean the client never reads from memory, only that
-    /// it has other means of getting the response content (e.g. from disk) and,
+    /// Whether this Store client requires memory-stored response content.
+    /// \retval false does not mean the client never reads from memory, only
+    /// that it has other means of getting that content (e.g., from disk) and,
     /// hence, will keep working even if unread content is purged from memory.
     bool reliesOnReadingFromMemory() const;
 
     /// The offset of the stored response that the client wants to read next.
-    /// A zero offset means the client wants to read HTTP response headers.
+    /// \retval 0 means the client wants to read HTTP response headers.
     int64_t readOffset() const { return copyInto.offset; }
 
     int getType() const;
@@ -99,7 +99,7 @@ public:
 
     struct {
         /// whether we are expecting a response to be swapped in from disk
-        /// (i.e. whether storeRead() is currently in progress)
+        /// (i.e. whether async storeRead() is currently in progress)
         bool disk_io_pending;
 
         /// whether store_client::doCopy() is currently in progress
@@ -109,7 +109,10 @@ public:
 #if USE_DELAY_POOLS
     DelayId delayId;
 
-    /// the number of bytes we can read without violating delay pool limits
+    /// The maximum number of bytes the Store client can read/copy next without
+    /// overflowing its buffer and without violating delay pool limits. Store
+    /// I/O is not rate-limited, but we assume that the same number of bytes may
+    /// be read from the Squid-to-server connection that may be rate-limited.
     int bytesWanted() const;
 
     void setDelayId(DelayId delay_id);

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -60,8 +60,17 @@ class store_client
 public:
     store_client(StoreEntry *);
     ~store_client();
-    /// \returns the smallest of the passed value and the memory offset of the client
-    int memHeaderOffsetLowerThan(const int64_t offset) const;
+
+    /// Whether this Store client requires memory-stored response content. A
+    /// false result does not mean the client never reads from memory, only that
+    /// it has other means of getting the response content (e.g. from disk) and,
+    /// hence, will keep working even if unread content is purged from memory.
+    bool reliesOnReadingFromMemory() const;
+
+    // TODO: Document whether zero means the first HTTP response header byte.
+    /// the stored response offset the client is going to read next
+    int64_t readOffset() const { return copyInto.offset; }
+
     int getType() const;
     void fail();
     void callback(ssize_t len, bool error = false);

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -101,6 +101,9 @@ public:
         /// whether we are expecting a response to be swapped in from disk
         /// (i.e. whether storeRead() is currently in progress)
         bool disk_io_pending;
+
+        /// whether store_client::doCopy() is currently in progress
+        bool store_copying;
     } flags;
 
 #if USE_DELAY_POOLS

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -10,7 +10,7 @@
 #define SQUID_STORECLIENT_H
 
 #include "acl/ChecklistFiller.h"
-#include "base/AsyncCbdataCalls.h"
+#include "base/AsyncCall.h"
 #include "base/forward.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
@@ -60,7 +60,7 @@ class store_client
 public:
     store_client(StoreEntry *);
     ~store_client();
-    /// returns the smallest of the passed value and the memory offset of the client
+    /// \returns the smallest of the passed value and the memory offset of the client
     int memHeaderOffsetLowerThan(const int64_t offset) const;
     int getType() const;
     void fail();

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -60,7 +60,8 @@ class store_client
 public:
     store_client(StoreEntry *);
     ~store_client();
-    bool memReaderHasLowerOffset(int64_t) const;
+    /// returns the smallest of the passed value and the memory offset of the client
+    int memHeaderOffsetLowerThan(const int64_t offset) const;
     int getType() const;
     void fail();
     void callback(ssize_t len, bool error = false);
@@ -84,18 +85,14 @@ public:
         bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
-    AsyncCall::Pointer clientSideCaller;
-
 #if USE_DELAY_POOLS
+    int bytesWanted() const { return delayId.bytesWanted(0, copyInto.length); }
     DelayId delayId;
     void setDelayId(DelayId delay_id);
 #endif
 
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
-    StoreIOBuffer copyInto;
-    /// the number of bytes effectively copied from Store into the I/O buffer
-    size_t copiedSize;
 
 private:
     bool moreToSend() const;
@@ -109,6 +106,11 @@ private:
 
     int type;
     bool object_ok;
+
+    StoreIOBuffer copyInto;
+    /// the number of bytes effectively copied from Store into the I/O buffer
+    size_t copiedSize;
+    AsyncCall::Pointer clientSideCaller;
 
     /* Until we finish stuffing code into store_client */
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -71,7 +71,11 @@ public:
     void readBody(const char *buf, ssize_t len);
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
-    bool canCopy() const { return _callback.pending() && !clientSideCaller && !flags.disk_io_pending; }
+    /// whether doCopy() can be called
+    bool canCopy() const { return canScheduleCallback() && !flags.disk_io_pending; }
+    /// TODO: revise/verify all usages
+    /// whether callback() can be called
+    bool canScheduleCallback() const { return _callback.pending() && !clientSideCaller; }
 
 #if STORE_CLIENT_LIST_DEBUG
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -120,8 +120,8 @@ private:
     bool unpackHeader(char const *buf, ssize_t len);
 
     void fail();
-    void callback(ssize_t len);
-    void noteMoreCopiedBytes(size_t sz);
+    void callback(ssize_t);
+    void noteCopiedBytes(size_t);
     void noteEof();
     void noteNews();
     void finishCallback();

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -88,6 +88,7 @@ public:
 
     void dumpStats(MemBuf * output, int clientNumber) const;
 
+    int64_t cmp_offset;
 #if STORE_CLIENT_LIST_DEBUG
 
     void *owner;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -71,7 +71,6 @@ public:
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
 
-    int64_t cmp_offset;
 #if STORE_CLIENT_LIST_DEBUG
 
     void *owner;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -71,6 +71,7 @@ public:
     void readBody(const char *buf, ssize_t len);
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
     void dumpStats(MemBuf * output, int clientNumber) const;
+    bool canCopy() const { return _callback.pending() && !clientSideCaller && !flags.disk_io_pending; }
 
 #if STORE_CLIENT_LIST_DEBUG
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -80,8 +80,7 @@ public:
 
     struct {
         bool disk_io_pending;
-        bool store_copying;
-        bool copy_event_pending;
+        bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
 #if USE_DELAY_POOLS

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -58,8 +58,10 @@ class store_client
     CBDATA_CLASS(store_client);
 
 public:
+    /// destroys the given object; use storeUnregister() instead
+    static void storeUnregisterFinish(store_client *);
+
     store_client(StoreEntry *);
-    ~store_client();
 
     /// Whether this Store client requires memory-stored response content. A
     /// false result does not mean the client never reads from memory, only that
@@ -115,6 +117,8 @@ public:
     dlink_node node;
 
 private:
+    ~store_client();
+
     bool moreToSend() const;
 
     void fileRead();

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -58,10 +58,8 @@ class store_client
     CBDATA_CLASS(store_client);
 
 public:
-    /// destroys the given object; use storeUnregister() instead
-    static void storeUnregisterFinish(store_client *);
-
     store_client(StoreEntry *);
+    ~store_client();
 
     /// Whether this Store client requires memory-stored response content. A
     /// false result does not mean the client never reads from memory, only that
@@ -117,8 +115,6 @@ public:
     dlink_node node;
 
 private:
-    ~store_client();
-
     bool moreToSend() const;
 
     void fileRead();

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -10,6 +10,7 @@
 #define SQUID_STORECLIENT_H
 
 #include "acl/ChecklistFiller.h"
+#include "base/AsyncCbdataCalls.h"
 #include "base/forward.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
@@ -63,6 +64,7 @@ public:
     int getType() const;
     void fail();
     void callback(ssize_t len, bool error = false);
+    void callbackClientSide();
     void doCopy (StoreEntry *e);
     void readHeader(const char *buf, ssize_t len);
     void readBody(const char *buf, ssize_t len);
@@ -83,6 +85,8 @@ public:
         bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
+    AsyncCall::Pointer clientSideCaller;
+
 #if USE_DELAY_POOLS
     DelayId delayId;
     void setDelayId(DelayId delay_id);
@@ -91,6 +95,8 @@ public:
     dlink_node node;
     /* Below here is private - do no alter outside storeClient calls */
     StoreIOBuffer copyInto;
+    /// the number of bytes effectively copied from Store into the I/O buffer
+    size_t copiedSize;
 
 private:
     bool moreToSend() const;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -72,14 +72,9 @@ public:
     int64_t readOffset() const { return copyInto.offset; }
 
     int getType() const;
-    void fail();
 
-    /// schedules (or updates parameters of a pending) asynchronous STCB call
-    /// \param len XXX: Document
-    void callback(ssize_t len, bool error = false);
-
-    /// finishes a copy()-callback()-STCB sequence by synchronously calling STCB
-    void finishCallback();
+    /// react to the end of reading the response from disk
+    void noteSwapInDone(bool error);
 
     void doCopy (StoreEntry *e);
     void readHeader(const char *buf, ssize_t len);
@@ -92,9 +87,6 @@ public:
     void dumpStats(MemBuf * output, int clientNumber) const;
     /// whether doCopy() can be called
     bool canCopy() const { return canScheduleCallback() && !flags.disk_io_pending; }
-    /// TODO: revise/verify all usages
-    /// whether callback() can be called
-    bool canScheduleCallback() const { return _callback.pending() && !notifier; }
 
 #if STORE_CLIENT_LIST_DEBUG
 
@@ -126,6 +118,18 @@ private:
     void scheduleRead();
     bool startSwapin();
     bool unpackHeader(char const *buf, ssize_t len);
+
+    /// TODO: revise/verify all usages
+    /// whether callback() can be called
+    bool canScheduleCallback() const { return _callback.pending() && !notifier; }
+
+    void fail();
+    void callback(ssize_t len);
+    void noteMoreCopiedBytes(size_t sz);
+    void noteEof();
+    void noteNews();
+    void finishCallback();
+    static void FinishCallback(store_client *);
 
     int type;
     bool object_ok;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -82,7 +82,6 @@ public:
 
     struct {
         bool disk_io_pending;
-        bool copy_pending; ///< whether a copy operation was scheduled
     } flags;
 
 #if USE_DELAY_POOLS

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -433,6 +433,7 @@ store_client::startSwapin()
 void
 store_client::noteSwapInDone(const bool error)
 {
+    Assure(_callback.pending());
     if (error)
         fail();
     else

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -176,17 +176,13 @@ store_client::callbackClientSide()
 void
 store_client::callback(ssize_t sz, bool error)
 {
-    if (sz >= 0 && !error)
-        copiedSize = sz;
+    copiedSize = (sz > 0 && !error) ? sz : 0;
+
     if (sz < 0 || error)
         copyInto.flags.error = 1;
 
-    if (clientSideCaller) {
-        if (!copyInto.flags.error)
-            return;
-        // reschedule with error
-        clientSideCaller->cancel("failed"); // TODO: provide a meaningful reason
-    }
+    if (clientSideCaller)
+        return;
 
     /// XXX: do not schedule if the object is going to be deleted,
     /// see storeUnregister().

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -791,10 +791,7 @@ StoreEntry::invokeHandlers()
         // does not happen in the current code, but no observed invariant
         // prevents this from (accidentally) happening in the future.
 
-        // TODO: Make this call asynchronous after making sure that no indirect
-        // invokeHandlers() caller assumes that newly added data is consumed
-        // immediately if it is needed by current store_clients. We do not want
-        // our callers to swap new data out following no-claim==no-need logic.
+        // TODO: Convert store_client into AsyncJob; make this call asynchronous
         CodeContext::Reset(sc->_callback.codeContext);
         debugs(90, 3, "checking client #" << i);
         storeClientCopy2(this, sc);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -164,6 +164,7 @@ store_client::finishCallback()
     result.flags.error = object_ok ? 0 : 1;
     copiedSize = 0;
 
+    cmp_offset = copyInto.offset + copyInto.length;
     STCB *temphandler = _callback.callback_handler;
     void *cbdata = _callback.callback_data;
     _callback = Callback(NULL, NULL);
@@ -230,6 +231,7 @@ store_client::noteNews()
 }
 
 store_client::store_client(StoreEntry *e) :
+    cmp_offset(0),
 #if STORE_CLIENT_LIST_DEBUG
     owner(cbdataReference(data)),
 #endif
@@ -284,7 +286,12 @@ store_client::copy(StoreEntry * anEntry,
 #endif
 
     assert(!_callback.pending());
+#if ONLYCONTIGUOUSREQUESTS
+
+    assert(cmp_offset == copyRequest.offset);
+#endif
     /* range requests will skip into the body */
+    cmp_offset = copyRequest.offset;
     _callback = Callback (callback_fn, cbdataReference(data));
     copyInto.data = copyRequest.data;
     copyInto.length = copyRequest.length;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -85,10 +85,12 @@ StoreClient::startCollapsingOn(const StoreEntry &e, const bool doingRevalidation
 
 /* store_client */
 
-bool
-store_client::memReaderHasLowerOffset(int64_t anOffset) const
+int
+store_client::memHeaderOffsetLowerThan(const int64_t anOffset) const
 {
-    return getType() == STORE_MEM_CLIENT && copyInto.offset < anOffset;
+    if (getType() == STORE_MEM_CLIENT && copyInto.offset < anOffset)
+        return copyInto.offset;
+    return anOffset;
 }
 
 int
@@ -193,9 +195,9 @@ store_client::store_client(StoreEntry *e) :
     owner(cbdataReference(data)),
 #endif
     entry(e),
-    copiedSize(0),
     type(e->storeClientType()),
-    object_ok(true)
+    object_ok(true),
+    copiedSize(0)
 {
     flags.disk_io_pending = false;
     ++ entry->refcount;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -248,6 +248,7 @@ store_client::copy(StoreEntry * anEntry,
     copyInto.data = copyRequest.data;
     copyInto.length = copyRequest.length;
     copyInto.offset = copyRequest.offset;
+    // copyInto.flags.error should persist between the calls, do not modify it.
 
     static bool copying (false);
     assert (!copying);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -486,7 +486,7 @@ store_client::scheduleMemRead()
     /* What the client wants is in memory */
     /* Old style */
     debugs(90, 3, "store_client::doCopy: Copying normal from memory");
-    const auto sz = entry->mem_obj->data_hdr.copy(copyInto); // may be <= 0
+    const auto sz = entry->mem_obj->data_hdr.copy(copyInto); // may be <= 0 per copy() API
     callback(sz);
     flags.store_copying = false;
 }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -157,8 +157,8 @@ store_client::FinishCallback(store_client * const sc)
 void
 store_client::finishCallback()
 {
-    assert(_callback.callback_handler);
-    assert(_callback.notifier);
+    Assure(_callback.callback_handler);
+    Assure(_callback.notifier);
 
     StoreIOBuffer result(copiedSize, copyInto.offset, copyInto.data);
     result.flags.error = object_ok ? 0 : 1;
@@ -358,9 +358,9 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
 void
 store_client::doCopy(StoreEntry *anEntry)
 {
-    assert(_callback.pending());
-    assert(!flags.disk_io_pending);
-    assert(!flags.store_copying);
+    Assure(_callback.pending());
+    Assure(!flags.disk_io_pending);
+    Assure(!flags.store_copying);
 
     assert (anEntry == entry);
     flags.store_copying = true;
@@ -586,7 +586,7 @@ store_client::noteNews()
     _callback.notifier = asyncCall(17, 4, "store_client::FinishCallback", cbdataDialer(store_client::FinishCallback, this));
     ScheduleCallHere(_callback.notifier);
 
-    assert(!_callback.pending());
+    Assure(!_callback.pending());
 }
 
 static void

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -184,8 +184,6 @@ store_client::callback(ssize_t sz, bool error)
     if (clientSideCaller)
         return;
 
-    /// XXX: do not schedule if the object is going to be deleted,
-    /// see storeUnregister().
     clientSideCaller = asyncCall(17, 4, "Callback", cbdataDialer(CallbackClientSide, this));
     ScheduleCallHere(clientSideCaller);
 }
@@ -667,12 +665,6 @@ storeUnregister(store_client * sc, StoreEntry * e, void *data)
         storeClose(sc->swapin_sio, StoreIOState::readerDone);
         sc->swapin_sio = NULL;
         ++statCounter.swap.ins;
-    }
-
-    if (sc->_callback.pending()) {
-        /* callback with ssize = -1 to indicate unexpected termination */
-        debugs(90, 3, "store_client for " << *e << " has a callback");
-        sc->fail();
     }
 
 #if STORE_CLIENT_LIST_DEBUG

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -176,14 +176,14 @@ store_client::finishCallback()
 }
 
 /// schedules asynchronous STCB call to relay disk or memory read results
-/// \param sz an error signal (if negative), EOF signal (if zero), or bytes read
+/// \param outcome an error signal (if negative), an EOF signal (if zero), or the number of bytes read
 void
-store_client::callback(const ssize_t sz)
+store_client::callback(const ssize_t outcome)
 {
-    if (sz > 0)
-        return noteCopiedBytes(sz);
+    if (outcome > 0)
+        return noteCopiedBytes(outcome);
 
-    if (sz < 0)
+    if (outcome < 0)
         return fail();
 
     noteEof();
@@ -214,12 +214,12 @@ void
 store_client::noteNews()
 {
     if (!_callback.callback_handler) {
-        debugs(90, 5, "nobody is interested in these news");
+        debugs(90, 5, "nobody is interested in this news anymore");
         return;
     }
 
     if (_callback.notifier) {
-        debugs(90, 5, "these news should be delivered by scheduled " << _callback.notifier);
+        debugs(90, 5, "earlier news is being delivered by " << _callback.notifier);
         return;
     }
 
@@ -927,6 +927,13 @@ store_client::Callback::Callback(STCB *function, void *data):
 }
 
 #if USE_DELAY_POOLS
+int
+store_client::bytesWanted() const
+{
+    // TODO: Just return zero unless _callback.pending()?
+    return delayId.bytesWanted(0, copyInto.length);
+}
+
 void
 store_client::setDelayId(DelayId delay_id)
 {

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -542,7 +542,7 @@ store_client::readBody(const char *, ssize_t len)
 void
 store_client::fail()
 {
-    debugs(90, 3, "new failure: " << object_ok);
+    debugs(90, 3, (object_ok ? "once" : "again"));
     if (!object_ok)
         return; // we failed earlier; nothing to do now
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -85,12 +85,10 @@ StoreClient::startCollapsingOn(const StoreEntry &e, const bool doingRevalidation
 
 /* store_client */
 
-int
-store_client::memHeaderOffsetLowerThan(const int64_t anOffset) const
+bool
+store_client::reliesOnReadingFromMemory() const
 {
-    if (getType() == STORE_MEM_CLIENT && copyInto.offset < anOffset)
-        return copyInto.offset;
-    return anOffset;
+    return getType() == STORE_MEM_CLIENT;
 }
 
 int

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -160,6 +160,9 @@ store_client::finishCallback()
     Assure(_callback.callback_handler);
     Assure(_callback.notifier);
 
+    // callers are not ready to handle a content+error combination
+    Assure(object_ok || !copiedSize);
+
     StoreIOBuffer result(copiedSize, copyInto.offset, copyInto.data);
     result.flags.error = object_ok ? 0 : 1;
     copiedSize = 0;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -162,7 +162,7 @@ store_client::finishCallback()
     assert(_callback.notifier);
 
     StoreIOBuffer result(copiedSize, copyInto.offset, copyInto.data);
-    result.flags.error = copyInto.flags.error;
+    result.flags.error = object_ok ? 0 : 1;
     copiedSize = 0;
 
     STCB *temphandler = _callback.callback_handler;
@@ -287,7 +287,6 @@ store_client::copy(StoreEntry * anEntry,
     copyInto.data = copyRequest.data;
     copyInto.length = copyRequest.length;
     copyInto.offset = copyRequest.offset;
-    // copyInto.flags.error should persist between the calls, do not modify it.
 
     static bool copying (false);
     assert (!copying);
@@ -548,7 +547,6 @@ store_client::fail()
         return; // we failed earlier; nothing to do now
 
     object_ok = false;
-    copyInto.flags.error = 1;
 
     noteNews();
 }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -586,7 +586,7 @@ store_client::noteNews()
         return;
     }
 
-    _callback.notifier = asyncCall(17, 4, "store_client::FinishCallback", cbdataDialer(store_client::FinishCallback, this));
+    _callback.notifier = asyncCall(90, 4, "store_client::FinishCallback", cbdataDialer(store_client::FinishCallback, this));
     ScheduleCallHere(_callback.notifier);
 
     Assure(!_callback.pending());

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -181,7 +181,7 @@ store_client::finishCallback()
     result.flags.error = object_ok ? 0 : 1;
     copiedSize = 0;
 
-    cmp_offset = copyInto.offset + copyInto.length;
+    cmp_offset = result.offset + result.length;
     STCB *temphandler = _callback.callback_handler;
     void *cbdata = _callback.callback_data;
     _callback = Callback(NULL, NULL);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -317,8 +317,6 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
      * everything we got before the abort condition occurred.
      */
 
-    // TODO: optimize, immediately returning if is no data yet
-
     sc->doCopy(sc->entry);
 }
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -722,15 +722,11 @@ StoreEntry::invokeHandlers()
         nx = node->next;
         ++i;
 
-        if (!sc->_callback.pending())
-            continue;
-
-        if (sc->flags.disk_io_pending)
-            continue;
-
-        CodeContext::Reset(sc->_callback.codeContext);
-        debugs(90, 3, "checking client #" << i);
-        storeClientCopy2(this, sc);
+        if (sc->canCopy()) {
+            CodeContext::Reset(sc->_callback.codeContext);
+            debugs(90, 3, "checking client #" << i);
+            storeClientCopy2(this, sc);
+        }
     }
     CodeContext::Reset(savedContext);
 }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -776,6 +776,16 @@ StoreEntry::invokeHandlers()
         if (sc->flags.disk_io_pending)
             continue;
 
+        // XXX: If invokeHandlers() is (indirectly) called from a store_client
+        // method, then the above two conditions may not be sufficient to
+        // prevent us reentering the same store_client object! This probably
+        // does not happen in the current code, but no observed invariant
+        // prevents this from (accidentally) happening in the future.
+
+        // TODO: Make this call asynchronous after making sure that no indirect
+        // invokeHandlers() caller assumes that newly added data is consumed
+        // immediately if it is needed by current store_clients. We do not want
+        // our callers to swap new data out following no-claim==no-need logic.
         CodeContext::Reset(sc->_callback.codeContext);
         debugs(90, 3, "checking client #" << i);
         storeClientCopy2(this, sc);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -147,17 +147,17 @@ storeClientListAdd(StoreEntry * e, void *data)
 }
 
 static void
-CallbackClientSide(store_client *sc)
+FinishCallback(store_client *sc)
 {
-    sc->callbackClientSide();
+    sc->finishCallback();
 }
 
 void
-store_client::callbackClientSide()
+store_client::finishCallback()
 {
     assert(_callback.pending());
 
-    clientSideCaller = nullptr;
+    notifier = nullptr;
     StoreIOBuffer result(copiedSize, copyInto.offset, copyInto.data);
     result.flags.error = copyInto.flags.error;
 
@@ -185,11 +185,11 @@ store_client::callback(ssize_t sz, bool error)
     if (sz < 0 || error)
         copyInto.flags.error = 1;
 
-    if (clientSideCaller)
+    if (notifier)
         return;
 
-    clientSideCaller = asyncCall(17, 4, "Callback", cbdataDialer(CallbackClientSide, this));
-    ScheduleCallHere(clientSideCaller);
+    notifier = asyncCall(17, 4, "store_client::finishCallback", cbdataDialer(FinishCallback, this));
+    ScheduleCallHere(notifier);
 }
 
 store_client::store_client(StoreEntry *e) :

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -188,6 +188,8 @@ store_client::callback(ssize_t sz, bool error)
         clientSideCaller->cancel("failed"); // TODO: provide a meaningful reason
     }
 
+    /// XXX: do not schedule if the object is going to be deleted,
+    /// see storeUnregister().
     clientSideCaller = asyncCall(17, 4, "Callback", cbdataDialer(CallbackClientSide, this));
     ScheduleCallHere(clientSideCaller);
 }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -347,6 +347,7 @@ static void
 storeClientCopy2(StoreEntry * e, store_client * sc)
 {
     debugs(90, 3, "storeClientCopy2: " << e->getMD5Text());
+    assert(sc->_callback.pending());
     /*
      * We used to check for ENTRY_ABORTED here.  But there were some
      * problems.  For example, we might have a slow client (or two) and
@@ -354,8 +355,7 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
      * if the peer aborts, we want to give the client(s)
      * everything we got before the abort condition occurred.
      */
-
-    sc->doCopy(sc->entry);
+    sc->doCopy(e);
 }
 
 void

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -253,12 +253,6 @@ store_client::store_client(StoreEntry *e) :
 store_client::~store_client()
 {}
 
-void
-store_client::storeUnregisterFinish(store_client * const sc)
-{
-    delete sc;
-}
-
 /* copy bytes requested by the client */
 void
 storeClientCopy(store_client * sc,
@@ -734,10 +728,9 @@ storeUnregister(store_client * sc, StoreEntry * e, void *data)
 
 #endif
 
-    // delete sc asynchronously so that if this code is synchronously reached
-    // while inside a store_client method, that call sequence can finish safely
-    AsyncCall::Pointer asyncDestructor = asyncCall(17, 3, "store_client::storeUnregisterFinish", cbdataDialer(store_client::storeUnregisterFinish, sc));
-    ScheduleCallHere(asyncDestructor);
+    // XXX: We might be inside this store_client method somewhere up the calls
+    // stack. TODO: Convert store_client to AsyncJob to make destruction async.
+    delete sc;
 
     assert(e->locked());
     // An entry locked by others may be unlocked (and destructed) by others, so

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -146,31 +146,51 @@ storeClientListAdd(StoreEntry * e, void *data)
     return sc;
 }
 
-void
-store_client::callback(ssize_t sz, bool error)
+static void
+CallbackClientSide(store_client *sc)
 {
-    size_t bSz = 0;
+    sc->callbackClientSide();
+}
 
-    if (sz >= 0 && !error)
-        bSz = sz;
-
-    StoreIOBuffer result(bSz, 0,copyInto.data);
-
-    if (sz < 0 || error)
-        result.flags.error = 1;
-
-    result.offset = cmp_offset;
+void
+store_client::callbackClientSide()
+{
     assert(_callback.pending());
-    cmp_offset = copyInto.offset + bSz;
-    STCB *temphandler = _callback.callback_handler;
+
+    clientSideCaller = nullptr;
+    StoreIOBuffer result(copiedSize, copyInto.offset, copyInto.data);
+    result.flags.error = copyInto.flags.error;
+    cmp_offset = copyInto.offset + copiedSize;
+
+    auto temphandler = _callback.callback_handler;
     void *cbdata = _callback.callback_data;
-    _callback = Callback(NULL, NULL);
-    copyInto.data = NULL;
+    _callback = store_client::Callback(nullptr, nullptr);
+    copyInto.data = nullptr;
+    copiedSize = 0;
 
     if (cbdataReferenceValid(cbdata))
         temphandler(cbdata, result);
 
     cbdataReferenceDone(cbdata);
+}
+
+void
+store_client::callback(ssize_t sz, bool error)
+{
+    if (sz >= 0 && !error)
+        copiedSize = sz;
+    if (sz < 0 || error)
+        copyInto.flags.error = 1;
+
+    if (clientSideCaller) {
+        if (!copyInto.flags.error)
+            return;
+        // reschedule with error
+        clientSideCaller->cancel("failed"); // TODO: provide a meaningful reason
+    }
+
+    clientSideCaller = asyncCall(17, 4, "Callback", cbdataDialer(CallbackClientSide, this));
+    ScheduleCallHere(clientSideCaller);
 }
 
 store_client::store_client(StoreEntry *e) :
@@ -179,11 +199,11 @@ store_client::store_client(StoreEntry *e) :
     owner(cbdataReference(data)),
 #endif
     entry(e),
+    copiedSize(0),
     type(e->storeClientType()),
     object_ok(true)
 {
     flags.disk_io_pending = false;
-    flags.copy_pending = false;
     ++ entry->refcount;
 
     if (getType() == STORE_DISK_CLIENT) {
@@ -294,35 +314,8 @@ store_client::moreToSend() const
 }
 
 static void
-DoCopy(store_client *sc)
-{
-    if (!cbdataReferenceValid(sc)) {
-        debugs(33, 2, "invalid store_client " << sc);
-        return;
-    }
-
-    assert(sc->_callback.pending());
-
-    sc->flags.copy_pending = false;
-
-    /* Warning: doCopy may indirectly free itself in callbacks,
-     * hence the lock to keep it active for the duration of
-     * this function
-     * XXX: Locking does not prevent calling sc destructor (it only prevents
-     * freeing sc memory) so sc may become invalid from C++ p.o.v.
-     */
-
-    CbcPointer<store_client> tmpLock = sc;
-
-    sc->doCopy(sc->entry);
-}
-
-static void
 storeClientCopy2(StoreEntry * e, store_client * sc)
 {
-    if (sc->flags.copy_pending)
-        return;
-
     debugs(90, 3, "storeClientCopy2: " << e->getMD5Text());
     /*
      * We used to check for ENTRY_ABORTED here.  But there were some
@@ -334,9 +327,7 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
 
     // TODO: optimize, immediately returning if is no data yet
 
-    AsyncCall::Pointer call = asyncCall(17, 4, "DoCopy", cbdataDialer(DoCopy, sc));
-    ScheduleCallHere(call);
-    sc->flags.copy_pending = true;
+    sc->doCopy(sc->entry);
 }
 
 void
@@ -883,9 +874,6 @@ store_client::dumpStats(MemBuf * output, int clientNumber) const
 
     if (flags.disk_io_pending)
         output->append(" disk_io_pending", 16);
-
-    if (flags.copy_pending)
-        output->append(" copy_pending", 19);
 
     output->append("\n",1);
 }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -160,7 +160,6 @@ store_client::callbackClientSide()
     clientSideCaller = nullptr;
     StoreIOBuffer result(copiedSize, copyInto.offset, copyInto.data);
     result.flags.error = copyInto.flags.error;
-    cmp_offset = copyInto.offset + copiedSize;
 
     auto temphandler = _callback.callback_handler;
     void *cbdata = _callback.callback_data;
@@ -194,7 +193,6 @@ store_client::callback(ssize_t sz, bool error)
 }
 
 store_client::store_client(StoreEntry *e) :
-    cmp_offset(0),
 #if STORE_CLIENT_LIST_DEBUG
     owner(cbdataReference(data)),
 #endif
@@ -249,12 +247,7 @@ store_client::copy(StoreEntry * anEntry,
 #endif
 
     assert(!_callback.pending());
-#if ONLYCONTIGUOUSREQUESTS
-
-    assert(cmp_offset == copyRequest.offset);
-#endif
     /* range requests will skip into the body */
-    cmp_offset = copyRequest.offset;
     _callback = Callback (callback_fn, cbdataReference(data));
     copyInto.data = copyRequest.data;
     copyInto.length = copyRequest.length;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -332,6 +332,8 @@ storeClientCopy2(StoreEntry * e, store_client * sc)
      * everything we got before the abort condition occurred.
      */
 
+    // TODO: optimize, immediately returning if is no data yet
+
     AsyncCall::Pointer call = asyncCall(17, 4, "DoCopy", cbdataDialer(DoCopy, sc));
     ScheduleCallHere(call);
     sc->flags.copy_pending = true;

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -56,6 +56,7 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
 
     if (sc->canScheduleCallback()) {
         assert (errflag <= 0);
+        // TODO: should we sc->fail() on error instead?
         sc->callback(0, errflag ? true : false);
     }
 

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -54,7 +54,7 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
     debugs(20, 3, "storeSwapInFileClosed: sio=" << sc->swapin_sio.getRaw() << ", errflag=" << errflag);
     sc->swapin_sio = NULL;
 
-    if (sc->_callback.pending()) {
+    if (sc->canScheduleCallback()) {
         assert (errflag <= 0);
         sc->callback(0, errflag ? true : false);
     }

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -53,7 +53,12 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
     store_client *sc = (store_client *)data;
     debugs(20, 3, "storeSwapInFileClosed: sio=" << sc->swapin_sio.getRaw() << ", errflag=" << errflag);
     sc->swapin_sio = NULL;
-    sc->noteSwapInDone(errflag);
+
+    if (sc->_callback.pending()) {
+        assert (errflag <= 0);
+        sc->noteSwapInDone(errflag ? true : false);
+    }
+
     ++statCounter.swap.ins;
 }
 

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -53,13 +53,7 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
     store_client *sc = (store_client *)data;
     debugs(20, 3, "storeSwapInFileClosed: sio=" << sc->swapin_sio.getRaw() << ", errflag=" << errflag);
     sc->swapin_sio = NULL;
-
-    if (sc->canScheduleCallback()) {
-        assert (errflag <= 0);
-        // TODO: should we sc->fail() on error instead?
-        sc->callback(0, errflag ? true : false);
-    }
-
+    sc->noteSwapInDone(errflag);
     ++statCounter.swap.ins;
 }
 

--- a/src/tests/stub_store_client.cc
+++ b/src/tests/stub_store_client.cc
@@ -24,7 +24,7 @@ void storeLogOpen(void) STUB
 void storeDigestInit(void) STUB
 void storeRebuildStart(void) STUB
 void storeReplSetup(void) STUB
-bool store_client::memReaderHasLowerOffset(int64_t) const STUB_RETVAL(false)
+bool store_client::reliesOnReadingFromMemory() const STUB_RETVAL(false)
 void store_client::dumpStats(MemBuf *, int) const STUB
 int store_client::getType() const STUB_RETVAL(0)
 

--- a/src/tests/stub_store_client.cc
+++ b/src/tests/stub_store_client.cc
@@ -26,7 +26,9 @@ void storeRebuildStart(void) STUB
 void storeReplSetup(void) STUB
 bool store_client::reliesOnReadingFromMemory() const STUB_RETVAL(false)
 void store_client::noteSwapInDone(bool) STUB
+#if USE_DELAY_POOLS
 int store_client::bytesWanted() const STUB_RETVAL(0)
+#endif
 void store_client::dumpStats(MemBuf *, int) const STUB
 int store_client::getType() const STUB_RETVAL(0)
 

--- a/src/tests/stub_store_client.cc
+++ b/src/tests/stub_store_client.cc
@@ -25,6 +25,8 @@ void storeDigestInit(void) STUB
 void storeRebuildStart(void) STUB
 void storeReplSetup(void) STUB
 bool store_client::reliesOnReadingFromMemory() const STUB_RETVAL(false)
+void store_client::noteSwapInDone(bool) STUB
+int store_client::bytesWanted() const STUB_RETVAL(0)
 void store_client::dumpStats(MemBuf *, int) const STUB
 int store_client::getType() const STUB_RETVAL(0)
 


### PR DESCRIPTION
The store_client class design created very long call chains spanning
Squid-client and Squid-server processing and multiple transactions.
These call chains also create ideal conditions for dangerous recursive
relationships between communicating classes (a.k.a. "reentrancy" among
Squid developers). For example, storeClientCopy() enters store_client
and triggers disk I/O that triggers invokeHandlers() that re-enters the
same store_client object and starts competing with the original
storeClientCopy() processing state.

The official code prevented the worst recursion cases with three(!)
boolean flags and time-based events abused to break some of the call
chains, but that approach did not solve all of the problems while also
losing transaction context information across time-based events.

This change effectively makes STCB storeClientCopy() callbacks
asynchronous, eliminating the need for time-based events and one of the
flags. It shortens many call chains and preserves transaction context.
The remaining problems can and should be eliminated by converting
store_client into AsyncJob, but those changes deserve a dedicated PR.

store_client orchestrates cooperation of multiple asynchronous players:

* Sink: A Store client requests a STCB callback via a
  storeClientCopy()/copy() call. A set _callback.callback_handler
  implies that the client is waiting for this callback.

* Source1: A Store disk reading subsystem activated by the storeRead()
  call "spontaneously" delivers response bytes via storeClientRead*()
  callbacks. The disk_io_pending flag implies waiting for them.

* Source2: Store memory subsystem activated by storeClientListAdd()
  "spontaneously" delivers response bytes via invokeHandlers().

* Source3: Store disk subsystem activated by storeSwapInStart()
  "spontaneously" notifies of EOF/error by calling noteSwapInDone().

* Source4: A store_client object owner may delete the object by
  "spontaneously" calling storeUnregister(). The official code was
  converting this event into an error-notifying callback.

We continue to answer each storeClientCopy() request with the first
available information even though several SourceN calls are possible
while we are waiting to complete the STCB callback. The StoreIOBuffer
API and STCB recipients do not support data+error/eof combinations, and
future code will move this wait to the main event loop anyway. This
first-available approach means that the creation of the notifier call
effectively ends answer processing -- store_client just waits for that
call to fire so that it can relay the answer to still-synchronous STCB.
When STCB itself becomes asynchronous, this logic will continue to work.

Also stopped calling STCB from storeUnregister(). Conceptually, the
storeUnregister() and storeClientCopy() callers ought to represent the
same get-content-from-Store task; there should be no need to notify that
task about what it is doing. Technically, analysis of STCB callbacks
showed that many such notifications would be dangerous (if they are or
become reachable). At the time of the storeUnregister() call, the STCB
callbacks are usually unset (e.g., when storeUnregister() is called from
the destructor, after that object has finished copying -- a very common
case) or do not do anything (useful).

Also removed callback_data from the Callback::pending() condition. It is
conceptually wrong to require non-nil callback parameter, and it is
never cleared separately from the callback_handler data member anyway.

Also hid copyInto into the private store_client section to make sure it
is not modified while we are waiting to complete the STCB callback. This
move required adding a couple of read-only wrapper methods like
bytesWanted() and noteSwapInDone().

Also simplified error/EOF/bytes handling on copy()-STCB path using
dedicated methods (e.g., store_client::callback() API is no longer
mixing EOF and error signals).
