### PR TITLE
Do not leak caller context to other transactions in helperHandleRead()

### DIFF
--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -905,7 +905,8 @@ public:
         callback_data(NULL),
         key(xstrdup(aKey)),
         def(cbdataReference(aDef)),
-        queue(NULL)
+        queue(nullptr),
+        codeContext(CodeContext::Current())
     {}
     ~externalAclState();
 
@@ -915,6 +916,7 @@ public:
     external_acl *def;
     dlink_node list;
     externalAclState *queue;
+    CodeContextPointer codeContext;
 };
 
 CBDATA_CLASS_INIT(externalAclState);
@@ -999,9 +1001,11 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
         entry = external_acl_cache_add(state->def, state->key, entryData);
 
     do {
-        void *cbdata;
-        if (state->callback && cbdataReferenceValidDone(state->callback_data, &cbdata))
-            state->callback(cbdata, entry);
+        CallBack(state->codeContext, [&] {
+            void *cbdata = nullptr;
+            if (state->callback && cbdataReferenceValidDone(state->callback_data, &cbdata))
+                state->callback(cbdata, entry);
+        });
 
         next = state->queue;
         state->queue = NULL;

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1207,8 +1207,10 @@ Enqueue(helper * hlp, Helper::Xaction * r)
 
     /* do this first so idle=N has a chance to grow the child pool before it hits critical. */
     if (hlp->childs.needNew() > 0) {
-        debugs(84, DBG_CRITICAL, "Starting new " << hlp->id_name << " helpers...");
-        helperOpenServers(hlp);
+        CallService(nullptr, [&hlp] {
+            debugs(84, DBG_CRITICAL, "Starting new " << hlp->id_name << " helpers...");
+            helperOpenServers(hlp);
+        });
         return;
     }
 


### PR DESCRIPTION
When the transaction A starts a new helper instance, it schedules
helperHandleRead() read callback and waits for the helper reply.  After
receiving reply from the helper, it re-schedules the call again with A
context, thus propagating it to the next and all future transactions,
reading from this helper.

So we need to:

* Run the general helper initialization code, such as starting
  servers and I/O scheduling without any specific context.

* Store the context before requesting and restore it after receiving
  response from the helper.