### PR TITLE
Print TrafficMode flags uniformly

### DIFF
--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -111,3 +111,9 @@ AnyP::PortCfg::detailCodeContext(std::ostream &os) const
     return os;
 }
 
+std::ostream &
+AnyP::PortCfg::print(std::ostream &os) const
+{
+    return os << s << " " << flags;
+}
+

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -36,6 +36,8 @@ public:
     virtual ScopedId codeContextGist() const override;
     virtual std::ostream &detailCodeContext(std::ostream &os) const override;
 
+    std::ostream &print(std::ostream &) const;
+
     PortCfgPointer next;
 
     Ip::Address s;
@@ -75,6 +77,12 @@ private:
 };
 
 } // namespace AnyP
+
+inline std::ostream &
+operator <<(std::ostream &os, const AnyP::PortCfg &p)
+{
+    return p.print(os);
+}
 
 /// list of Squid http(s)_port configured
 extern AnyP::PortCfgPointer HttpPortList;

--- a/src/anyp/TrafficMode.h
+++ b/src/anyp/TrafficMode.h
@@ -9,6 +9,10 @@
 #ifndef SQUID_ANYP_TRAFFIC_MODE_H
 #define SQUID_ANYP_TRAFFIC_MODE_H
 
+#include "sbuf/Stream.h"
+
+#include <ostream>
+
 namespace AnyP
 {
 
@@ -138,21 +142,22 @@ private:
 inline std::ostream &
 TrafficMode::print(std::ostream &os) const
 {
+    SBufStream str;
     if (flags_.natIntercept)
-        os << " NAT intercepted";
+        str << "intercept";
     else if (flags_.tproxyIntercept)
-        os << " TPROXY intercepted";
+        str << "tproxy";
     else if (flags_.accelSurrogate)
-        os << " reverse-proxy";
-    else
-        os << " forward-proxy";
+        str << "accel";
+
+    const auto sep = str.buf().isEmpty() ? "" : " ";
 
     if (flags_.tunnelSslBumping)
-        os << " SSL bumped";
+        str << sep << "ssl-bump";
     if (proxySurrogate())
-        os << " (with PROXY protocol header)";
+        str << sep << "require-proxy-header";
 
-    return os;
+    return os << str.buf();
 }
 
 inline std::ostream &

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3385,9 +3385,7 @@ clientListenerConnectionOpened(AnyP::PortCfgPointer &s, const Ipc::FdNoteId port
     // TCP: setup a job to handle accept() with subscribed handler
     AsyncJob::Start(new Comm::TcpAcceptor(s, FdNote(portTypeNote), sub));
 
-    debugs(1, Important(13), "Accepting" << s->flags << " " <<
-           FdNote(portTypeNote) << " connections " <<
-           "at " << s->listenConn);
+    debugs(1, Important(13), "Accepting " << FdNote(portTypeNote) << " connections at " << *s);
 
     Must(AddOpenedHttpSocket(s->listenConn)); // otherwise, we have received a fd we did not ask for
 


### PR DESCRIPTION
The cache manager flags reporting syntax (dump_config()) is
now used in other cases, including startup debugs() showing
listening ports info.