### PR TITLE
New API for PRNG seed generation

### DIFF
--- a/src/acl/Random.cc
+++ b/src/acl/Random.cc
@@ -93,7 +93,11 @@ ACLRandom::parse()
 int
 ACLRandom::match(ACLChecklist *)
 {
-    static std::mt19937 mt(Seed32());
+    // make up the random value.
+    // The fixed-value default seed is fine because we are
+    // actually matching whether the random value is above
+    // or below the configured threshold ratio.
+    static std::mt19937 mt;
     static xuniform_real_distribution<> dist(0, 1);
 
     const double random = dist(mt);

--- a/src/acl/Random.cc
+++ b/src/acl/Random.cc
@@ -93,10 +93,6 @@ ACLRandom::parse()
 int
 ACLRandom::match(ACLChecklist *)
 {
-    // make up the random value.
-    // The fixed-value default seed is fine because we are
-    // actually matching whether the random value is above
-    // or below the configured threshold ratio.
     static std::mt19937 mt(Seed32());
     static xuniform_real_distribution<> dist(0, 1);
 

--- a/src/acl/Random.cc
+++ b/src/acl/Random.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "acl/FilledChecklist.h"
 #include "acl/Random.h"
+#include "base/Random.h"
 #include "debug/Stream.h"
 #include "Parsing.h"
 #include "wordlist.h"
@@ -96,7 +97,7 @@ ACLRandom::match(ACLChecklist *)
     // The fixed-value default seed is fine because we are
     // actually matching whether the random value is above
     // or below the configured threshold ratio.
-    static std::mt19937 mt;
+    static std::mt19937 mt(Seed32());
     static xuniform_real_distribution<> dist(0, 1);
 
     const double random = dist(mt);

--- a/src/acl/Random.cc
+++ b/src/acl/Random.cc
@@ -11,7 +11,6 @@
 #include "squid.h"
 #include "acl/FilledChecklist.h"
 #include "acl/Random.h"
-#include "base/Random.h"
 #include "debug/Stream.h"
 #include "Parsing.h"
 #include "wordlist.h"

--- a/src/auth/basic/RADIUS/Makefile.am
+++ b/src/auth/basic/RADIUS/Makefile.am
@@ -19,6 +19,7 @@ basic_radius_auth_SOURCES = \
 
 basic_radius_auth_LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
+	$(top_builddir)/src/base/libbase.la \
 	$(COMPAT_LIB) \
 	$(NETTLELIB) \
 	$(SSLLIB) \

--- a/src/auth/basic/RADIUS/basic_radius_auth.cc
+++ b/src/auth/basic/RADIUS/basic_radius_auth.cc
@@ -56,6 +56,7 @@
 #include "squid.h"
 #include "auth/basic/RADIUS/radius-util.h"
 #include "auth/basic/RADIUS/radius.h"
+#include "base/Random.h"
 #include "helper/protocol_defines.h"
 #include "md5.h"
 
@@ -206,7 +207,7 @@ result_recv(char *buffer, int length)
 static void
 random_vector(char *aVector)
 {
-    static std::mt19937 mt(time(nullptr));
+    static std::mt19937 mt(Seed32());
     static xuniform_int_distribution<uint8_t> dist;
 
     for (int i = 0; i < AUTH_VECTOR_LEN; ++i)

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -22,6 +22,7 @@
 #include "auth/State.h"
 #include "auth/toUtf.h"
 #include "base/LookupTable.h"
+#include "base/Random.h"
 #include "cache_cf.h"
 #include "event.h"
 #include "helper.h"
@@ -160,7 +161,7 @@ authenticateDigestNonceNew(void)
      */
     // NP: this will likely produce the same randomness sequences for each worker
     // since they should all start within the 1-second resolution of seed value.
-    static std::mt19937 mt(static_cast<uint32_t>(getCurrentTime() & 0xFFFFFFFF));
+    static std::mt19937 mt(Seed32());
     static xuniform_int_distribution<uint32_t> newRandomData;
 
     /* create a new nonce */

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -159,8 +159,6 @@ authenticateDigestNonceNew(void)
      * - the timestamp also guarantees local uniqueness in the input to
      * the hash function.
      */
-    // NP: this will likely produce the same randomness sequences for each worker
-    // since they should all start within the 1-second resolution of seed value.
     static std::mt19937 mt(Seed32());
     static xuniform_int_distribution<uint32_t> newRandomData;
 

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -51,6 +51,8 @@ libbase_la_SOURCES = \
 	Optional.h \
 	Packable.h \
 	PackableStream.h \
+	Random.cc \
+	Random.h \
 	RandomUuid.cc \
 	RandomUuid.h \
 	Range.h \

--- a/src/base/Random.cc
+++ b/src/base/Random.cc
@@ -33,7 +33,7 @@ Seed32()
 std::mt19937_64::result_type
 Seed64()
 {
-    std::mt19937_64::result_type value = Seed32();
-    return (value << 32) | Seed32();
+    std::mt19937_64::result_type left = Seed32();
+    return (left << 32) | Seed32();
 }
 

--- a/src/base/Random.cc
+++ b/src/base/Random.cc
@@ -11,8 +11,12 @@
 std::mt19937::result_type
 Seed32()
 {
-    static_assert(sizeof(std::random_device::result_type) == 4, "std::random_device generates a 4-byte number");
-    static std::random_device dev;
+    // By default, std::random_device may be blocking or non-blocking, which is
+    // implementation-defined, so we need "/dev/urandom" to guarantee the non-blocking
+    // behavior. Theoretically, this file may be missing in some exotic
+    // configurations, causing std::runtime_error. For simplicity, we assume that
+    // such configurations do not exist until the opposite is confirmed.
+    static std::random_device dev("/dev/urandom");
     return dev();
 }
 

--- a/src/base/Random.cc
+++ b/src/base/Random.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "base/Random.h"
+
+std::mt19937::result_type
+Seed32()
+{
+    static_assert(sizeof(std::random_device::result_type) == 4, "std::random_device generates a 4-byte number");
+    static std::random_device dev;
+    return dev();
+}
+
+std::mt19937_64::result_type
+Seed64()
+{
+    std::mt19937_64::result_type value = Seed32();
+    return (value << 32) | Seed32();
+}
+

--- a/src/base/Random.h
+++ b/src/base/Random.h
@@ -12,8 +12,8 @@
 #include <random>
 
 /// A 32-bit random value suitable for seeding a 32-bit random number generator.
-/// Computing this value may require device I/O but does not block to accumulate
-/// entropy. Thus, this function:
+/// Computing this value may require blocking device I/O but does not require
+/// waiting to accumulate entropy. Thus, this function:
 /// * may be called at runtime (e.g., the first time a given r.n.g. is needed)
 /// * should not be called frequently (e.g., once per transaction is too often)
 /// * should not be used as a source of randomness (use a r.n.g. instead)

--- a/src/base/Random.h
+++ b/src/base/Random.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_BASE_RANDOM_H
+#define SQUID_SRC_BASE_RANDOM_H
+
+#include <random>
+
+/// A 32-bit random value suitable for seeding a 32-bit random number generator.
+/// Computing this value may require device I/O but does not block to accumulate
+/// entropy. Thus, this function:
+/// * may be called at runtime (e.g., the first time a given r.n.g. is needed)
+/// * should not be called frequently (e.g., once per transaction is too often)
+/// * should not be used as a source of randomness (use a r.n.g. instead)
+std::mt19937::result_type Seed32();
+
+/// a 64-bit version of Seed32()
+std::mt19937_64::result_type Seed64();
+
+#endif /* SQUID_SRC_BASE_RANDOM_H */
+

--- a/src/base/RandomUuid.cc
+++ b/src/base/RandomUuid.cc
@@ -8,6 +8,7 @@
 
 #include "squid.h"
 #include "base/IoManip.h"
+#include "base/Random.h"
 #include "base/RandomUuid.h"
 #include "base/TextException.h"
 #include "defines.h"
@@ -20,9 +21,7 @@ static_assert(sizeof(RandomUuid) == 128/8, "RandomUuid has RFC 4122-prescribed 1
 RandomUuid::RandomUuid()
 {
     // Generate random bits for populating our UUID.
-    // STL implementation bugs notwithstanding (e.g., MinGW bug #338), this is
-    // our best chance of getting a non-deterministic seed value for the r.n.g.
-    static std::mt19937_64 rng(std::random_device {}()); // produces 64-bit sized values
+    static std::mt19937_64 rng(Seed64()); // produces 64-bit sized values
     const auto rnd1 = rng();
     const auto rnd2 = rng();
 

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "base/CodeContext.h"
 #include "base/InstanceId.h"
+#include "base/Random.h"
 #include "base/RunnersRegistry.h"
 #include "comm.h"
 #include "comm/Connection.h"
@@ -1047,7 +1048,7 @@ static unsigned short
 idnsQueryID()
 {
     // NP: apparently ranlux are faster, but not quite as "proven"
-    static std::mt19937 mt(static_cast<uint32_t>(getCurrentTime() & 0xFFFFFFFF));
+    static std::mt19937 mt(Seed32());
     unsigned short id = mt() & 0xFFFF;
     unsigned short first_id = id;
 

--- a/src/event.cc
+++ b/src/event.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 41    Event Processing */
 
 #include "squid.h"
+#include "base/Random.h"
 #include "event.h"
 #include "mgr/Registration.h"
 #include "Store.h"
@@ -114,9 +115,7 @@ void
 eventAddIsh(const char *name, EVH * func, void *arg, double delta_ish, int weight)
 {
     if (delta_ish >= 3.0) {
-        // Default seed is fine. We just need values random enough
-        // relative to each other to prevent waves of synchronised activity.
-        static std::mt19937 rng;
+        static std::mt19937 rng(Seed32());
         auto third = (delta_ish/3.0);
         xuniform_real_distribution<> thirdIsh(delta_ish - third, delta_ish + third);
         delta_ish = thirdIsh(rng);

--- a/src/event.cc
+++ b/src/event.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 41    Event Processing */
 
 #include "squid.h"
+#include "base/Random.h"
 #include "event.h"
 #include "mgr/Registration.h"
 #include "Store.h"
@@ -116,7 +117,7 @@ eventAddIsh(const char *name, EVH * func, void *arg, double delta_ish, int weigh
     if (delta_ish >= 3.0) {
         // Default seed is fine. We just need values random enough
         // relative to each other to prevent waves of synchronised activity.
-        static std::mt19937 rng;
+        static std::mt19937 rng(Seed32());
         auto third = (delta_ish/3.0);
         xuniform_real_distribution<> thirdIsh(delta_ish - third, delta_ish + third);
         delta_ish = thirdIsh(rng);

--- a/src/event.cc
+++ b/src/event.cc
@@ -9,7 +9,6 @@
 /* DEBUG: section 41    Event Processing */
 
 #include "squid.h"
-#include "base/Random.h"
 #include "event.h"
 #include "mgr/Registration.h"
 #include "Store.h"
@@ -117,7 +116,7 @@ eventAddIsh(const char *name, EVH * func, void *arg, double delta_ish, int weigh
     if (delta_ish >= 3.0) {
         // Default seed is fine. We just need values random enough
         // relative to each other to prevent waves of synchronised activity.
-        static std::mt19937 rng(Seed32());
+        static std::mt19937 rng;
         auto third = (delta_ish/3.0);
         xuniform_real_distribution<> thirdIsh(delta_ish - third, delta_ish + third);
         delta_ish = thirdIsh(rng);

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -1079,7 +1079,7 @@ Fs::Ufs::UFSSwapDir::HandleCleanEvent()
          * value.  j equals the total number of UFS level 2
          * swap directories
          */
-        std::mt19937 mt(Seed32());
+        static std::mt19937 mt(Seed32());
         xuniform_int_distribution<> dist(0, j);
         swap_index = dist(mt);
     }

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -11,6 +11,7 @@
 #define CLEAN_BUF_SZ 16384
 
 #include "squid.h"
+#include "base/Random.h"
 #include "cache_cf.h"
 #include "ConfigOption.h"
 #include "DiskIO/DiskIOModule.h"
@@ -1078,7 +1079,7 @@ Fs::Ufs::UFSSwapDir::HandleCleanEvent()
          * value.  j equals the total number of UFS level 2
          * swap directories
          */
-        std::mt19937 mt(static_cast<uint32_t>(getCurrentTime() & 0xFFFFFFFF));
+        std::mt19937 mt(Seed32());
         xuniform_int_distribution<> dist(0, j);
         swap_index = dist(mt);
     }

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -1226,8 +1226,7 @@ snmp_netIpFn(variable_list * Var, snint * ErrP)
 
     default:
         *ErrP = SNMP_ERR_NOSUCHNAME;
-        snmp_var_free(Answer);
-        return (nullptr);
+        assert(!Answer);
     }
 
     return Answer;

--- a/src/tests/SBufFindTest.cc
+++ b/src/tests/SBufFindTest.cc
@@ -7,8 +7,8 @@
  */
 
 #include "squid.h"
-#include "base/Random.h"
 #include "base/CharacterSet.h"
+#include "base/Random.h"
 #include "tests/SBufFindTest.h"
 
 #include <cppunit/extensions/HelperMacros.h>

--- a/src/tests/SBufFindTest.cc
+++ b/src/tests/SBufFindTest.cc
@@ -7,6 +7,7 @@
  */
 
 #include "squid.h"
+#include "base/Random.h"
 #include "base/CharacterSet.h"
 #include "tests/SBufFindTest.h"
 
@@ -370,7 +371,7 @@ SBufFindTest::RandomSBuf(const int length)
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklomnpqrstuvwxyz";
 
-    static std::mt19937 mt(time(nullptr));
+    static std::mt19937 mt(Seed32());
 
     // sizeof() counts the terminating zero at the end of characters
     // and the distribution is an 'inclusive' value range, so -2


### PR DESCRIPTION
The new API should substitute the flawed current-time-based
approach for seed calculation in mt19937 PRNG generators.