### PR TITLE
Support sslcrtvalidator_extras and validator-set annotations

### DIFF
--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -17,6 +17,7 @@
 #include "HttpReply.h"
 #include "HttpRequest.h"
 #include "parser/Tokenizer.h"
+#include "sbuf/SBuf.h"
 #include "sbuf/Stream.h"
 #include "sbuf/StringConvert.h"
 #include "SquidConfig.h"
@@ -305,6 +306,7 @@ NotePairs::findFirst(const char *noteKey) const
 void
 NotePairs::add(const char *key, const char *note)
 {
+    debugs(93, 7, key << '=' << note << " at " << entries.size());
     entries.push_back(new NotePairs::Entry(key, note));
 }
 
@@ -359,6 +361,47 @@ void
 NotePairs::addStrList(const SBuf &key, const SBuf &values, const CharacterSet &delimiters)
 {
     AppendTokens(entries, key, values, delimiters);
+}
+
+void
+NotePairs::importFromHelper(const SBuf &rawNotes)
+{
+    // XXX: Reduce code duplication with Notes::parse()
+    Parser::Tokenizer tok(rawNotes);
+    while (!tok.atEnd()) {
+        static const auto nameChars = (
+            CharacterSet::ALPHA +
+            CharacterSet::DIGIT +
+            CharacterSet("other", "-._")
+        ).rename("helper-note-name");
+
+        static const auto valueChars = (
+            CharacterSet::WSP +
+            CharacterSet("comma", ",") // we do not support CSVs (yet?)
+        ).complement("helper-note-value");
+
+        SBuf name;
+        if (!tok.prefix(name, nameChars))
+            throw TextException(ToSBuf("malformed from-helper annotation name near: ", tok.remaining()), Here());
+
+        if (!tok.skip('='))
+            throw TextException(ToSBuf("missing '=' after from-helper annotation near: ", tok.remaining()), Here());
+
+        SBuf value;
+        if (!tok.prefix(value, valueChars))
+            throw TextException(ToSBuf("malformed from-helper annotation value: ", tok.remaining()), Here());
+
+        const auto start = value.at(0);
+        if (start == '"' || start == '`' || start == '\'' || start == '\\')
+            throw TextException(ToSBuf("unsupported complex from-helper annotation value near: ", value), Here());
+
+        if (!tok.atEnd() && !tok.skipAll(CharacterSet::WSP))
+            throw TextException(ToSBuf("from-helper annotation missing whitespace after name=value near: ", tok.remaining()), Here());
+
+        // TODO: reject blacklisted names?
+        remove(name.c_str()); // overwrite same-name values, if any
+        add(name.c_str(), value.c_str());
+    }
 }
 
 bool

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -13,6 +13,7 @@
 #include "base/RefCount.h"
 #include "format/Format.h"
 #include "mem/forward.h"
+#include "sbuf/forward.h"
 #include "SquidString.h"
 
 #include <string>
@@ -241,6 +242,10 @@ public:
     /// If the key name already exists in the list, add the new values to its set
     /// of values.
     void addStrList(const SBuf &key, const SBuf &values, const CharacterSet &delimiters);
+
+    /// import space-separated name=single-value annotations sent by a helper,
+    /// overwriting any previously stored same-name annotations
+    void importFromHelper(const SBuf &notes);
 
     /// \returns true if the key/value pair is already stored
     bool hasPair(const SBuf &key, const SBuf &value) const;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3501,6 +3501,26 @@ DOC_START
 	operation. The default value is set to 2*numberofchildren.
 
 	You must have at least one ssl_crt_validator process.
+
+	See also: sslcrtvalidator_extras
+DOC_END
+
+NAME: sslcrtvalidator_extras
+TYPE: TokenOrQuotedString
+LOC: Ssl::TheConfig.ssl_crt_validator_extras
+DEFAULT: none
+DOC_START
+	Specifies the value part of the extras=value pair sent to the validator
+	helper. "Quoted" format values may contain spaces and logformat %macros.
+	Just like with access_log, a logformat %macro expands to a dash (-) if the
+	corresponding info is unavailable when Squid sends the helper request.
+
+	If caching of certificate validation helper responses is enabled, the
+	cache key includes the sent extras=value pair (if any).
+
+	By default, no extras a sent to the helper.
+
+	See also: sslcrtvalidator_program
 DOC_END
 
 COMMENT_START

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -420,7 +420,7 @@ Security::PeerConnector::sslCrtvdCheckForErrors(Ssl::CertValidationResponse cons
                 debugs(83, 5, "confirming SSL error " << i->error_no);
                 const auto &brokenCert = i->cert;
                 Security::CertPointer peerCert(SSL_get_peer_certificate(session.get()));
-                const char *aReason = i->error_reason.empty() ? nullptr : i->error_reason.c_str();
+                const char *aReason = i->error_reason.isEmpty() ? nullptr : const_cast<SBuf &>(i->error_reason).c_str();
                 errDetails = new ErrorDetail(i->error_no, peerCert, brokenCert, aReason);
             }
             if (check) {

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -305,6 +305,7 @@ Security::PeerConnector::sslFinalized()
             // validationRequest disappears on return so no need to cbdataReference
             validationRequest.errors = errs;
         try {
+            validationRequest.ale = al;
             debugs(83, 5, "Sending SSL certificate for validation to ssl_crtvd.");
             AsyncCall::Pointer call = asyncCall(83,5, "Security::PeerConnector::sslCrtvdHandleReply", Ssl::CertValidationHelper::CbDialer(this, &Security::PeerConnector::sslCrtvdHandleReply, nullptr));
             Ssl::CertValidationHelper::Submit(validationRequest, call);
@@ -343,6 +344,9 @@ Security::PeerConnector::sslCrtvdHandleReply(Ssl::CertValidationResponse::Pointe
         SBuf *server = static_cast<SBuf *>(SSL_get_ex_data(ssl.get(), ssl_ex_index_server));
         debugs(83, 5, "cert validation result: " << validationResponse->resultCode << RawPointer(" host: ", server));
     }
+
+    if (request)
+        UpdateRequestNotes(request->clientConnectionManager.get(), *request, validationResponse->notes);
 
     if (validationResponse->resultCode == ::Helper::Error) {
         if (Security::CertErrors *errs = sslCrtvdCheckForErrors(*validationResponse, errDetails)) {

--- a/src/security/cert_validators/fake/security_fake_certverify.pl.in
+++ b/src/security/cert_validators/fake/security_fake_certverify.pl.in
@@ -127,7 +127,8 @@ while (<>) {
         my $hostname;
         my $sslVersion = "-";
         my $sslCipher = "-";
-        parseRequest($body, \$hostname, \$sslVersion, \$sslCipher, \%errors, \%certs);
+        my $extras = undef();
+        parseRequest($body, \$hostname, \$sslVersion, \$sslCipher, \%errors, \%certs, \$extras);
         print(STDERR logPrefix()."Parse result: \n") if ($debug);
         print(STDERR logPrefix()."\tFOUND host:".$hostname."\n") if ($debug);
         print(STDERR logPrefix()."\tFOUND ssl version:".$sslVersion."\n") if ($debug);
@@ -141,6 +142,8 @@ while (<>) {
             ## Use "perldoc Crypt::OpenSSL::X509" for X509 available methods.
             print(STDERR logPrefix()."\tFOUND cert ".$key.": ".$certs{$key}->subject() . "\n") if ($debug);
         }
+
+        print(STDERR logPrefix()."\tFOUND custom metadata: extras=$extras\n") if defined($extras) && $debug;
 
 #got the peer certificate ID. Assume that the peer certificate is the first one.
         my $peerCertId = (keys %certs)[0];
@@ -196,6 +199,11 @@ sub createResponse
             "error_cert_".$i."=".$err->{"error_cert"}."\n";
         $i++;
     }
+
+    # add our own annotations
+    $response .= "transaction_notes=validatorPid_=$$ validationErrorCount_=$i\n";
+    $response .= "client_notes=clt_conn_tag=" . time() . "\n";
+
     return $response;
 }
 
@@ -207,6 +215,7 @@ sub parseRequest
     my $sslCipher = shift;
     my $errors = shift;
     my $certs = shift;
+    my $extras = shift;
     while ($request !~ /^\s*$/) {
         $request = trim($request);
         if ($request =~ /^host=/) {
@@ -220,6 +229,9 @@ sub parseRequest
         }
         if ($request =~ s/^cipher=(.*?)$//m) {
             $$sslCipher = $1;
+        }
+        if ($request =~ s/^extras=(.*?)$//m) {
+            $$extras = $1;
         }
         if ($request =~ /^cert_(\d+)=/) {
             my $certId = "cert_".$1;

--- a/src/ssl/Config.cc
+++ b/src/ssl/Config.cc
@@ -15,7 +15,8 @@ Ssl::Config::Config():
 #if USE_SSL_CRTD
     ssl_crtd(nullptr),
 #endif
-    ssl_crt_validator(nullptr)
+    ssl_crt_validator(nullptr),
+    ssl_crt_validator_extras(nullptr)
 {
     ssl_crt_validator_Children.concurrency = 1;
 }
@@ -26,5 +27,6 @@ Ssl::Config::~Config()
     xfree(ssl_crtd);
 #endif
     xfree(ssl_crt_validator);
+    xfree(ssl_crt_validator_extras);
 }
 

--- a/src/ssl/Config.h
+++ b/src/ssl/Config.h
@@ -24,6 +24,7 @@ public:
 #endif
     char *ssl_crt_validator;
     ::Helper::ChildConfig ssl_crt_validator_Children;
+    char *ssl_crt_validator_extras;
     Config();
     ~Config();
 private:

--- a/src/ssl/cert_validate_message.cc
+++ b/src/ssl/cert_validate_message.cc
@@ -13,6 +13,7 @@
 #include "sbuf/Stream.h"
 #include "security/CertError.h"
 #include "ssl/cert_validate_message.h"
+#include "ssl/Config.h"
 #include "ssl/ErrorDetail.h"
 #include "ssl/support.h"
 #include "util.h"
@@ -35,7 +36,7 @@ PeerValidationCertificatesChain(const Security::SessionPointer &ssl)
 }
 
 void
-Ssl::CertValidationMsg::composeRequest(CertValidationRequest const &vcert)
+Ssl::CertValidationMsg::composeRequest(const CertValidationRequest &vcert, const std::string *extras)
 {
     body.clear();
     body += Ssl::CertValidationMsg::param_host + "=" + vcert.domainName;
@@ -45,6 +46,9 @@ Ssl::CertValidationMsg::composeRequest(CertValidationRequest const &vcert)
 
     if (const char *cipherName = SSL_CIPHER_get_name(SSL_get_current_cipher(vcert.ssl.get())))
         body += "\n" +  Ssl::CertValidationMsg::param_cipher + "=" + cipherName;
+
+    if (extras)
+        body += "\n" +  Ssl::CertValidationMsg::param_extras + "=" + *extras;
 
     STACK_OF(X509) *peerCerts = PeerValidationCertificatesChain(vcert.ssl);
     if (peerCerts) {
@@ -147,6 +151,33 @@ Ssl::CertValidationMsg::tryParsingResponse(CertValidationResponse &resp)
         debugs(83, 5, "Returned value: " << std::string(param, param_len).c_str() << ": " <<
                v.c_str());
 
+        if (param_len == param_transactionNotes.length() &&
+            strncmp(param, param_transactionNotes.c_str(), param_transactionNotes.length()) == 0) {
+            resp.notes.importFromHelper(SBuf(v.c_str(), v.length()));
+            param = value + value_len;
+            continue;
+        }
+
+        if (param_len == param_clientNotes.length() &&
+            strncmp(param, param_clientNotes.c_str(), param_clientNotes.length()) == 0) {
+
+            // TODO: Support arbitrary client annotations when up-porting.
+            static std::string supportedName = "clt_conn_tag=";
+            if (v.compare(0, supportedName.size(), supportedName) != 0) {
+                throw TextException(ToSBuf("Only annotations named ", supportedName,
+                    " can be used for client connection annotation in this Squid version. ",
+                    "Found: ", v), Here());
+            }
+            if (v.find(' ') != std::string::npos) {
+                throw TextException(ToSBuf("Only one client connection annotation can be used in this Squid version. ",
+                    "Found: ", v), Here());
+            }
+            resp.notes.importFromHelper(SBuf(v.c_str(), v.length()));
+
+            param = value + value_len;
+            continue;
+        }
+
         int errorId = get_error_id(param, param_len);
         Ssl::CertValidationResponse::RecvdError &currentItem = resp.getError(errorId);
 
@@ -248,4 +279,7 @@ const std::string Ssl::CertValidationMsg::param_error_cert("error_cert_");
 const std::string Ssl::CertValidationMsg::param_error_depth("error_depth_");
 const std::string Ssl::CertValidationMsg::param_proto_version("proto_version");
 const std::string Ssl::CertValidationMsg::param_cipher("cipher");
+const std::string Ssl::CertValidationMsg::param_extras("extras");
+const std::string Ssl::CertValidationMsg::param_transactionNotes("transaction_notes");
+const std::string Ssl::CertValidationMsg::param_clientNotes("client_notes");
 

--- a/src/ssl/cert_validate_message.h
+++ b/src/ssl/cert_validate_message.h
@@ -11,6 +11,7 @@
 
 #include "base/RefCount.h"
 #include "helper/ResultCode.h"
+#include "log/Formats.h"
 #include "ssl/crtd_message.h"
 #include "ssl/support.h"
 
@@ -29,6 +30,7 @@ public:
     Security::SessionPointer ssl;
     Security::CertErrors *errors = nullptr; ///< The list of errors detected
     std::string domainName; ///< The server name
+    AccessLogEntryPointer ale; ///< requestor's ALE
 };
 
 /**
@@ -63,6 +65,10 @@ public:
     /// Search in errors list for the error item with id=errorId.
     /// If none found a new RecvdError item added with the given id;
     RecvdError &getError(int errorId);
+
+    /// parsed transaction_annotations and client_annotations
+    NotePairs notes;
+
     RecvdErrors errors; ///< The list of parsed errors
     Helper::ResultCode resultCode = Helper::Unknown; ///< The helper result code
     Security::SessionPointer ssl;
@@ -96,8 +102,8 @@ public:
     CertValidationMsg(MessageKind kind): CrtdMessage(kind) {}
 
     /// Build a request message for the cert validation helper
-    /// using information provided by vcert object
-    void composeRequest(CertValidationRequest const &vcert);
+    /// \param extras compiled sslcrtvalidator_extras value or nil
+    void composeRequest(const CertValidationRequest &, const std::string *extras);
 
     /// Parse a response message and fill the resp object with parsed information
     bool parseResponse(CertValidationResponse &resp);
@@ -123,6 +129,12 @@ public:
     static const std::string param_proto_version;
     /// Parameter name for SSL cipher
     static const std::string param_cipher;
+    /// Parameter name for configurable transaction details sent to the helper
+    static const std::string param_extras;
+    /// Parameter name for transaction annotations sent by the helper
+    static const std::string param_transactionNotes;
+    /// Parameter name for client (connection) annotations sent by the helper
+    static const std::string param_clientNotes;
 
 private:
     void tryParsingResponse(CertValidationResponse &);

--- a/src/ssl/cert_validate_message.h
+++ b/src/ssl/cert_validate_message.h
@@ -52,7 +52,7 @@ public:
         void setCert(X509 *);  ///< Sets cert to the given certificate
         int id = 0; ///<  The id of the error
         Security::ErrorCode error_no = 0; ///< The OpenSSL error code
-        std::string error_reason; ///< A string describing the error
+        SBuf error_reason; ///< A string describing the error
         Security::CertPointer cert; ///< The broken certificate
         int error_depth = -1; ///< The error depth
     };
@@ -93,7 +93,7 @@ private:
     class CertItem
     {
     public:
-        std::string name; ///< The certificate Id to use
+        SBuf name; ///< The certificate Id to use
         Security::CertPointer cert;       ///< A pointer to certificate
         void setCert(X509 *); ///< Sets cert to the given certificate
     };
@@ -109,7 +109,7 @@ public:
     bool parseResponse(CertValidationResponse &resp);
 
     /// Search a CertItems list for the certificate with ID "name"
-    X509 *getCertByName(std::vector<CertItem> const &, std::string const & name);
+    X509 *getCertByName(std::vector<CertItem> const &, SBuf const & name);
 
     /// String code for "cert_validate" messages
     static const std::string code_cert_validate;

--- a/src/ssl/helper.cc
+++ b/src/ssl/helper.cc
@@ -167,6 +167,7 @@ Ssl::HandleGeneratorReply(void *data, const ::Helper::Reply &reply)
 #endif //USE_SSL_CRTD
 
 helper *Ssl::CertValidationHelper::ssl_crt_validator = nullptr;
+Format::Format *Ssl::CertValidationHelper::ExtrasFormat = nullptr;
 
 void Ssl::CertValidationHelper::Init()
 {
@@ -227,6 +228,12 @@ void Ssl::CertValidationHelper::Init()
     //WARNING: initializing static member in an object initialization method
     assert(HelperCache == nullptr);
     HelperCache = new CacheType(cache, ttl);
+
+    if (const auto extras = Ssl::TheConfig.ssl_crt_validator_extras) {
+        delete ExtrasFormat;
+        ExtrasFormat = new ::Format::Format("sslcrtvalidator_extras");
+        (void)ExtrasFormat->parse(extras);
+    }
 }
 
 void Ssl::CertValidationHelper::Shutdown()
@@ -237,6 +244,9 @@ void Ssl::CertValidationHelper::Shutdown()
     wordlistDestroy(&ssl_crt_validator->cmdline);
     delete ssl_crt_validator;
     ssl_crt_validator = nullptr;
+
+    delete ExtrasFormat;
+    ExtrasFormat = nullptr;
 
     // CertValidationHelper::HelperCache is a static member, it is not good policy to
     // reset it here. Will work because the current Ssl::CertValidationHelper is
@@ -302,7 +312,17 @@ void Ssl::CertValidationHelper::Submit(Ssl::CertValidationRequest const &request
 {
     Ssl::CertValidationMsg message(Ssl::CrtdMessage::REQUEST);
     message.setCode(Ssl::CertValidationMsg::code_cert_validate);
-    message.composeRequest(request);
+
+    std::unique_ptr<std::string> extras;
+    if (ExtrasFormat) {
+        static MemBuf buf;
+        buf.reset();
+        ExtrasFormat->assemble(buf, request.ale, 0);
+        extras.reset(new std::string(buf.content(), buf.contentSize()));
+    }
+
+    message.composeRequest(request, extras.get());
+
     debugs(83, 5, "SSL crtvd request: " << message.compose().c_str());
 
     submitData *crtdvdData = new submitData;

--- a/src/ssl/helper.h
+++ b/src/ssl/helper.h
@@ -53,6 +53,8 @@ public:
     static void Submit(Ssl::CertValidationRequest const & request, AsyncCall::Pointer &);
 private:
     static helper * ssl_crt_validator; ///< helper for management of ssl_crtd.
+    static Format::Format *ExtrasFormat; ///< parsed sslcrtvalidator_extras
+
 public:
     typedef ClpMap<SBuf, CertValidationResponse::Pointer, CertValidationResponse::MemoryUsedByResponse> CacheType;
     static CacheType *HelperCache; ///< cache for cert validation helper


### PR DESCRIPTION
Many Squid helpers support configurable annotations in helper requests
and custom annotations in helper responses. Certificate generation and
validation helpers support neither. This change adds bidirectional
annotation support to the certificate validation helper. The feature can
be used, for example, to access-log the root of trust (i.e. the root CA
that the certificate validator used to validate the origin
server certificate).