### PR TITLE
cache_peer_fault directive

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -48,12 +48,15 @@ CachePeer::~CachePeer()
     xfree(domain);
 }
 
-time_t
-CachePeer::connectTimeout() const
+void
+CachePeer::noteSuccess()
 {
-    if (connect_timeout_raw > 0)
-        return connect_timeout_raw;
-    return Config.Timeout.peer_connect;
+    if (!tcp_up) {
+        debugs(15, 2, "TCP connection to " << host << "/" << http_port << " succeeded");
+        tcp_up = connect_fail_limit; // NP: so peerAlive() works properly.
+        peerAlive(this);
+    } else
+        tcp_up = connect_fail_limit;
 }
 
 // TODO: Require callers to detail failures instead of using one (and often
@@ -85,14 +88,11 @@ CachePeer::countFailure()
     }
 }
 
-void
-CachePeer::noteSuccess()
+time_t
+CachePeer::connectTimeout() const
 {
-    if (!tcp_up) {
-        debugs(15, 2, "TCP connection to " << host << "/" << http_port << " succeeded");
-        tcp_up = connect_fail_limit; // NP: so peerAlive() works properly.
-        peerAlive(this);
-    } else
-        tcp_up = connect_fail_limit;
+    if (connect_timeout_raw > 0)
+        return connect_timeout_raw;
+    return Config.Timeout.peer_connect;
 }
 

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -95,10 +95,3 @@ CachePeer::noteSuccess()
         tcp_up = connect_fail_limit;
 }
 
-void
-NoteOutgoingConnectionSuccess(CachePeer * const peer)
-{
-    if (peer)
-        peer->noteSuccess();
-}
-

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -55,8 +55,9 @@ CachePeer::noteSuccess()
         debugs(15, 2, "TCP connection to " << host << "/" << http_port << " succeeded");
         tcp_up = connect_fail_limit; // NP: so peerAlive() works properly.
         peerAlive(this);
-    } else
+    } else {
         tcp_up = connect_fail_limit;
+    }
 }
 
 // TODO: Require callers to detail failures instead of using one (and often

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -86,29 +86,12 @@ CachePeer::countFailure()
 }
 
 void
-CachePeer::setAlive()
-{
-    if (stats.logged_state == PEER_DEAD && tcp_up) {
-        debugs(15, DBG_IMPORTANT, "Detected REVIVED " << neighborTypeStr(this) << ": " << name);
-        stats.logged_state = PEER_ALIVE;
-        peerClearRR();
-        if (standby.mgr.valid())
-            PeerPoolMgr::Checkpoint(standby.mgr, "revived peer");
-    }
-
-    stats.last_reply = squid_curtime;
-    stats.probe_start = 0;
-}
-
-void
 CachePeer::noteSuccess()
 {
     if (!tcp_up) {
         debugs(15, 2, "TCP connection to " << host << "/" << http_port << " succeeded");
-        tcp_up = connect_fail_limit; // NP: so setAlive() works properly.
-        setAlive();
-        if (!n_addresses)
-            lookupPeer(this);
+        tcp_up = connect_fail_limit; // NP: so peerAlive() works properly.
+        peerAlive(this);
     } else
         tcp_up = connect_fail_limit;
 }

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -7,7 +7,6 @@
  */
 
 #include "squid.h"
-#include "acl/FilledChecklist.h"
 #include "acl/Gadgets.h"
 #include "CachePeer.h"
 #include "defines.h"

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -57,19 +57,9 @@ CachePeer::connectTimeout() const
     return Config.Timeout.peer_connect;
 }
 
+/// updates failure statistics
 void
-CachePeer::peerConnectFailed(ACLFilledChecklist *checklist)
-{
-    debugs(15, DBG_IMPORTANT, "ERROR: TCP connection to " << host << "/" << http_port << " failed");
-
-    if (checklist && !checklist->fastCheck().allowed())
-        return;
-
-    peerConnectFailedSilent();
-}
-
-void
-CachePeer::peerConnectFailedSilent()
+CachePeer::countFailure()
 {
     stats.last_connect_failure = squid_curtime;
 

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -58,6 +58,7 @@ CachePeer::connectTimeout() const
 
 // TODO: Require callers to detail failures instead of using one (and often
 // misleading!) "TCP" label for all of them.
+/// noteFailure() helper for handling failures attributed to this peer
 void
 CachePeer::countFailure()
 {

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -97,7 +97,7 @@ CachePeer::noteSuccess()
 }
 
 void
-NoteOutgoingConnectionSuccess(CachePeer *peer)
+NoteOutgoingConnectionSuccess(CachePeer * const peer)
 {
     if (peer)
         peer->noteSuccess();

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -58,14 +58,11 @@ CachePeer::connectTimeout() const
 }
 
 void
-CachePeer::peerConnectFailed(ACLFilledChecklist &checklist)
+CachePeer::peerConnectFailed(ACLFilledChecklist *checklist)
 {
     debugs(15, DBG_IMPORTANT, "ERROR: TCP connection to " << host << "/" << http_port << " failed");
 
-    if (!Config.accessList.cachePeerFault)
-        return;
-
-    if (!checklist.fastCheck().allowed())
+    if (checklist && !checklist->fastCheck().allowed())
         return;
 
     peerConnectFailedSilent();

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -84,3 +84,39 @@ CachePeer::countFailure()
         debugs(15, 2, "cache_peer " << host << "/" << http_port << " is still DEAD");
     }
 }
+
+void
+CachePeer::setAlive()
+{
+    if (stats.logged_state == PEER_DEAD && tcp_up) {
+        debugs(15, DBG_IMPORTANT, "Detected REVIVED " << neighborTypeStr(this) << ": " << name);
+        stats.logged_state = PEER_ALIVE;
+        peerClearRR();
+        if (standby.mgr.valid())
+            PeerPoolMgr::Checkpoint(standby.mgr, "revived peer");
+    }
+
+    stats.last_reply = squid_curtime;
+    stats.probe_start = 0;
+}
+
+void
+CachePeer::noteSuccess()
+{
+    if (!tcp_up) {
+        debugs(15, 2, "TCP connection to " << host << "/" << http_port << " succeeded");
+        tcp_up = connect_fail_limit; // NP: so setAlive() works properly.
+        setAlive();
+        if (!n_addresses)
+            lookupPeer(this);
+    } else
+        tcp_up = connect_fail_limit;
+}
+
+void
+NoteOutgoingConnectionSuccess(CachePeer *peer)
+{
+    if (peer)
+        peer->noteSuccess();
+}
+

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -9,8 +9,8 @@
 #ifndef SQUID_CACHEPEER_H_
 #define SQUID_CACHEPEER_H_
 
-#include "acl/forward.h"
 #include "acl/FilledChecklist.h"
+#include "acl/forward.h"
 #include "base/CbcPointer.h"
 #include "enums.h"
 #include "icp_opcode.h"

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -236,7 +236,13 @@ NoteOutgoingConnectionFailure(CachePeer * const peer, const Filler filler)
         peer->noteFailure(filler);
 }
 
-void NoteOutgoingConnectionSuccess(CachePeer *);
+/// reacts to a Squid-to-origin or a Squid-to-cache_peer connection establishment success
+inline void
+NoteOutgoingConnectionSuccess(CachePeer * const peer)
+{
+    if (peer)
+        peer->noteSuccess();
+}
 
 #endif /* SQUID_CACHEPEER_H_ */
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -211,7 +211,7 @@ public:
 
 template <typename Filler>
 void
-CachePeer::noteFailure(Filler filler)
+CachePeer::noteFailure(const Filler filler)
 {
     if (const auto acls = Config.accessList.cachePeerFault) {
         ACLFilledChecklist checklist(acls, nullptr, nullptr);
@@ -226,7 +226,7 @@ CachePeer::noteFailure(Filler filler)
 /// reacts to a Squid-to-origin or a Squid-to-cache_peer connection error
 /// \param filler a function to configure an ACLFilledChecklist if that becomes necessary
 template <typename Filler>
-void NoteOutgoingConnectionFailure(CachePeer *peer, Filler filler)
+void NoteOutgoingConnectionFailure(CachePeer *peer, const Filler filler)
 {
     if (peer)
         peer->noteFailure(filler);

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -35,7 +35,7 @@ public:
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
-    void peerConnectFailed(ACLFilledChecklist &);
+    void peerConnectFailed(ACLFilledChecklist *);
 
     void peerConnectFailedSilent();
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -220,10 +220,6 @@ CachePeer::noteFailure(Filler filler)
             return; // this failure is not our fault
     }
 
-    // else take the blame for all failures
-
-    debugs(15, DBG_IMPORTANT, "ERROR: TCP connection to " << host << "/" << http_port << " failed");
-
     countFailure();
 }
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -34,19 +34,19 @@ public:
     CachePeer() = default;
     ~CachePeer();
 
-    /// \returns the effective connect timeout for the given peer
-    time_t connectTimeout() const;
+    /// reacts to a successful peer connection attempt
+    void noteSuccess();
 
     /// reacts to a cache_peer-related failure
     /// \param filler a function to configure an ACLFilledChecklist if that becomes necessary
     template <typename Filler>
     void noteFailure(Filler filler);
 
-    /// reacts to a successful peer connection attempt
-    void noteSuccess();
-
     /// updates failure statistics
     void countFailure();
+
+    /// \returns the effective connect timeout for the given peer
+    time_t connectTimeout() const;
 
     u_int index = 0;
     char *name = nullptr;
@@ -226,6 +226,14 @@ CachePeer::noteFailure(const Filler filler)
     countFailure();
 }
 
+/// reacts to a Squid-to-origin or a Squid-to-cache_peer connection establishment success
+inline void
+NoteOutgoingConnectionSuccess(CachePeer * const peer)
+{
+    if (peer)
+        peer->noteSuccess();
+}
+
 /// reacts to a Squid-to-origin or a Squid-to-cache_peer connection error
 /// \param filler a function to configure an ACLFilledChecklist if that becomes necessary
 template <typename Filler>
@@ -234,14 +242,6 @@ NoteOutgoingConnectionFailure(CachePeer * const peer, const Filler filler)
 {
     if (peer)
         peer->noteFailure(filler);
-}
-
-/// reacts to a Squid-to-origin or a Squid-to-cache_peer connection establishment success
-inline void
-NoteOutgoingConnectionSuccess(CachePeer * const peer)
-{
-    if (peer)
-        peer->noteSuccess();
 }
 
 #endif /* SQUID_CACHEPEER_H_ */

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -42,8 +42,14 @@ public:
     template <typename Filler>
     void noteFailure(Filler filler);
 
+    /// reacts to a successful peer connection attempt
+    void noteSuccess();
+
     /// updates failure statistics
     void countFailure();
+
+    /// performs all actions when a CachePeer is detected revived
+    void setAlive();
 
     u_int index = 0;
     char *name = nullptr;
@@ -226,11 +232,14 @@ CachePeer::noteFailure(const Filler filler)
 /// reacts to a Squid-to-origin or a Squid-to-cache_peer connection error
 /// \param filler a function to configure an ACLFilledChecklist if that becomes necessary
 template <typename Filler>
-void NoteOutgoingConnectionFailure(CachePeer *peer, const Filler filler)
+void
+NoteOutgoingConnectionFailure(CachePeer *peer, const Filler filler)
 {
     if (peer)
         peer->noteFailure(filler);
 }
+
+void NoteOutgoingConnectionSuccess(CachePeer *);
 
 #endif /* SQUID_CACHEPEER_H_ */
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -230,7 +230,7 @@ CachePeer::noteFailure(const Filler filler)
 /// \param filler a function to configure an ACLFilledChecklist if that becomes necessary
 template <typename Filler>
 void
-NoteOutgoingConnectionFailure(CachePeer *peer, const Filler filler)
+NoteOutgoingConnectionFailure(CachePeer * const peer, const Filler filler)
 {
     if (peer)
         peer->noteFailure(filler);

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -42,9 +42,6 @@ public:
     template <typename Filler>
     void noteFailure(Filler filler);
 
-    /// updates failure statistics
-    void countFailure();
-
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
@@ -210,6 +207,9 @@ public:
 
     int front_end_https = 0; ///< 0 - off, 1 - on, 2 - auto
     int connection_auth = 2; ///< 0 - off, 1 - on, 2 - auto
+
+private:
+    void countFailure();
 };
 
 template <typename Filler>

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -34,10 +34,10 @@ public:
     CachePeer() = default;
     ~CachePeer();
 
-    /// reacts to a successful peer connection attempt
+    /// reacts to a successful establishment of a TCP connection to this cache_peer
     void noteSuccess();
 
-    /// reacts to a cache_peer-related failure
+    /// reacts to a failure on a TCP connection to this cache_peer
     /// \param filler a function to configure an ACLFilledChecklist if that becomes necessary
     template <typename Filler>
     void noteFailure(Filler filler);
@@ -226,7 +226,8 @@ CachePeer::noteFailure(const Filler filler)
     countFailure();
 }
 
-/// reacts to a Squid-to-origin or a Squid-to-cache_peer connection establishment success
+/// reacts to a successful establishment of a TCP connection to an origin server or cache_peer
+/// \param peer nil if Squid established a connection to an origin server
 inline void
 NoteOutgoingConnectionSuccess(CachePeer * const peer)
 {
@@ -234,7 +235,8 @@ NoteOutgoingConnectionSuccess(CachePeer * const peer)
         peer->noteSuccess();
 }
 
-/// reacts to a Squid-to-origin or a Squid-to-cache_peer connection error
+/// reacts to a failure on a TCP connection to an origin server or cache_peer
+/// \param peer nil if the connection is to an origin server
 /// \param filler a function to configure an ACLFilledChecklist if that becomes necessary
 template <typename Filler>
 void

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -218,6 +218,7 @@ CachePeer::noteFailure(const Filler filler)
 {
     if (const auto acls = Config.accessList.cachePeerFault) {
         ACLFilledChecklist checklist(acls, nullptr, nullptr);
+        checklist.setPeer(this);
         filler(checklist);
         if (!checklist.fastCheck().allowed())
             return; // this failure is not our fault

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -35,6 +35,10 @@ public:
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
+    void peerConnectFailed(ACLFilledChecklist &);
+
+    void peerConnectFailedSilent();
+
     u_int index = 0;
     char *name = nullptr;
     char *host = nullptr;

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -48,9 +48,6 @@ public:
     /// updates failure statistics
     void countFailure();
 
-    /// performs all actions when a CachePeer is detected revived
-    void setAlive();
-
     u_int index = 0;
     char *name = nullptr;
     char *host = nullptr;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1060,8 +1060,7 @@ FwdState::successfullyConnectedToPeer(const Comm::ConnectionPointer &conn)
     CallJobHere1(17, 4, request->clientConnectionManager, ConnStateData,
                  ConnStateData::notePeerConnection, serverConnection());
 
-    if (serverConnection()->getPeer())
-        peerConnectSucceded(serverConnection()->getPeer());
+    NoteOutgoingConnectionSuccess(serverConnection()->getPeer());
 
     dispatch();
 }

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -31,7 +31,6 @@
 
 class AccessLogEntry;
 typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
-class ErrorState;
 class HttpRequest;
 class PconnPool;
 class ResolvedPeers;

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -8,7 +8,6 @@
 
 #include "squid.h"
 #include "AccessLogEntry.h"
-#include "acl/FilledChecklist.h"
 #include "base/AsyncCallbacks.h"
 #include "base/CodeContext.h"
 #include "CachePeer.h"

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -632,14 +632,13 @@ HappyConnOpener::handleConnOpenerAnswer(Attempt &attempt, const CommConnectCbPar
 
     debugs(17, 8, what << " failed: " << params.conn);
     if (const auto peer = params.conn->getPeer()) {
-        ACLFilledChecklist *ch = nullptr;
+        std::unique_ptr<ACLFilledChecklist> ch;
         if (Config.accessList.cachePeerFault) {
-            ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, cause.getRaw(), nullptr);
+            ch.reset(new ACLFilledChecklist(Config.accessList.cachePeerFault, cause.getRaw(), nullptr));
             ch->al = ale;
             ch->syncAle(cause.getRaw(), nullptr);
         }
-        peer->peerConnectFailed(ch);
-        delete ch;
+        peer->peerConnectFailed(ch.get());
     }
 
     // remember the last failure (we forward it if we cannot connect anywhere)

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -630,7 +630,7 @@ HappyConnOpener::handleConnOpenerAnswer(Attempt &attempt, const CommConnectCbPar
     }
 
     debugs(17, 8, what << " failed: " << params.conn);
-    // TODO: Use auto as the lambda parameter type after upgrading to C++14
+    // TODO: Use auto as the lambda parameter type (in all callers) after upgrading to C++14
     NoteOutgoingConnectionFailure(params.conn->getPeer(), [&](ACLFilledChecklist &checklist) {
         checklist.setRequest(cause.getRaw());
         checklist.setOutgoingConnection(params.conn);

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -632,10 +632,14 @@ HappyConnOpener::handleConnOpenerAnswer(Attempt &attempt, const CommConnectCbPar
 
     debugs(17, 8, what << " failed: " << params.conn);
     if (const auto peer = params.conn->getPeer()) {
-        ACLFilledChecklist ch(Config.accessList.cachePeerFault, cause.getRaw(), nullptr);
-        ch.al = ale;
-        ch.syncAle(cause.getRaw(), nullptr);
+        ACLFilledChecklist *ch = nullptr;
+        if (Config.accessList.cachePeerFault) {
+            ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, cause.getRaw(), nullptr);
+            ch->al = ale;
+            ch->syncAle(cause.getRaw(), nullptr);
+        }
         peer->peerConnectFailed(ch);
+        delete ch;
     }
 
     // remember the last failure (we forward it if we cannot connect anywhere)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1709,6 +1709,7 @@ nodist_tests_testACLMaxUserIP_SOURCES = \
 	tests/stub_fatal.cc \
 	globals.cc \
 	tests/stub_libauth.cc \
+	tests/stub_libcomm.cc \
 	tests/stub_libhttp.cc \
 	tests/stub_libmem.cc \
 	tests/stub_libsecurity.cc

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -87,14 +87,13 @@ PeerPoolMgr::handleOpenedConnection(const CommConnectCbParams &params)
     }
 
     if (params.flag != Comm::OK) {
-        ACLFilledChecklist *ch = nullptr;
+        std::unique_ptr<ACLFilledChecklist> ch;
         if (Config.accessList.cachePeerFault) {
-            ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
+            ch.reset(new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr));
             ch->dst_addr = params.conn->remote;
             ch->my_addr = params.conn->local;
         }
-        peer->peerConnectFailed(ch);
-        delete ch;
+        peer->peerConnectFailed(ch.get());
         checkpoint("conn opening failure"); // may retry
         return;
     }

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -8,6 +8,7 @@
 
 #include "squid.h"
 #include "AccessLogEntry.h"
+#include "acl/FilledChecklist.h"
 #include "base/AsyncCallbacks.h"
 #include "base/RunnersRegistry.h"
 #include "CachePeer.h"
@@ -86,7 +87,10 @@ PeerPoolMgr::handleOpenedConnection(const CommConnectCbParams &params)
     }
 
     if (params.flag != Comm::OK) {
-        peerConnectFailed(peer);
+        ACLFilledChecklist ch;
+        ch.src_addr = params.conn->remote;
+        ch.my_addr = params.conn->local;
+        peer->peerConnectFailed(ch);
         checkpoint("conn opening failure"); // may retry
         return;
     }

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -87,13 +87,10 @@ PeerPoolMgr::handleOpenedConnection(const CommConnectCbParams &params)
     }
 
     if (params.flag != Comm::OK) {
-        std::unique_ptr<ACLFilledChecklist> ch;
-        if (Config.accessList.cachePeerFault) {
-            ch.reset(new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr));
-            ch->dst_addr = params.conn->remote;
-            ch->my_addr = params.conn->local;
-        }
-        peer->peerConnectFailed(ch.get());
+        NoteOutgoingConnectionFailure(peer, [&](ACLFilledChecklist &checklist) {
+            checklist.setRequest(request.getRaw());
+            checklist.setOutgoingConnection(params.conn);
+        });
         checkpoint("conn opening failure"); // may retry
         return;
     }

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -8,7 +8,6 @@
 
 #include "squid.h"
 #include "AccessLogEntry.h"
-#include "acl/FilledChecklist.h"
 #include "base/AsyncCallbacks.h"
 #include "base/RunnersRegistry.h"
 #include "CachePeer.h"

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -138,7 +138,7 @@ PeerPoolMgr::handleSecuredPeer(Security::EncryptorAnswer &answer)
     assert(!answer.tunneled);
     if (answer.error.get()) {
         assert(!answer.conn);
-        // PeerConnector calls peerConnectFailed() for us;
+        // PeerConnector calls NoteOutgoingConnectionFailure() for us;
         checkpoint("conn securing failure"); // may retry
         return;
     }

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -87,10 +87,14 @@ PeerPoolMgr::handleOpenedConnection(const CommConnectCbParams &params)
     }
 
     if (params.flag != Comm::OK) {
-        ACLFilledChecklist ch;
-        ch.src_addr = params.conn->remote;
-        ch.my_addr = params.conn->local;
+        ACLFilledChecklist *ch = nullptr;
+        if (Config.accessList.cachePeerFault) {
+            ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
+            ch->dst_addr = params.conn->remote;
+            ch->my_addr = params.conn->local;
+        }
         peer->peerConnectFailed(ch);
+        delete ch;
         checkpoint("conn opening failure"); // may retry
         return;
     }

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -138,7 +138,7 @@ PeerPoolMgr::handleSecuredPeer(Security::EncryptorAnswer &answer)
     assert(!answer.tunneled);
     if (answer.error.get()) {
         assert(!answer.conn);
-        // PeerConnector calls NoteOutgoingConnectionFailure() for us;
+        // PeerConnector calls NoteOutgoingConnectionFailure() for us
         checkpoint("conn securing failure"); // may retry
         return;
     }

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -402,6 +402,7 @@ public:
         acl_access *forceRequestBodyContinuation;
         acl_access *serverPconnForNonretriable;
         acl_access *collapsedForwardingAccess;
+        acl_access *cachePeerFault;
     } accessList;
     AclDenyInfoList *denyInfoList;
 

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "acl/FilledChecklist.h"
 #include "client_side.h"
+#include "CachePeer.h"
 #include "comm/Connection.h"
 #include "comm/forward.h"
 #include "debug/Messages.h"
@@ -245,6 +246,16 @@ ACLFilledChecklist::ACLFilledChecklist(const acl_access *A, HttpRequest *http_re
     changeAcl(A);
     setRequest(http_request);
     setIdent(ident);
+}
+
+void
+ACLFilledChecklist::setOutgoingConnection(const Comm::ConnectionPointer &conn)
+{
+    if (conn && conn->isOpen()) {
+        dst_addr = conn->remote;
+        my_addr = conn->local;
+        dst_peer_name = conn->getPeer() ? conn->getPeer()->name : nullptr;
+    }
 }
 
 void ACLFilledChecklist::setRequest(HttpRequest *httpRequest)

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -260,11 +260,19 @@ ACLFilledChecklist::setPeer(const CachePeer * const peer)
 void
 ACLFilledChecklist::setOutgoingConnection(const Comm::ConnectionPointer &outgoingConn)
 {
-    if (outgoingConn && outgoingConn->isOpen()) {
+    // TODO: Replace code that still does this manually with setOutgoingConnection().
+    if (!outgoingConn)
+        return;
+
+    setPeer(outgoingConn->getPeer());
+
+    // TODO: ACLIP::match(ip) does not check whether ip has been set. Should it?
+    static const Ip::Address Empty; // constructed with setEmpty()
+
+    if (dst_addr == Empty)
         dst_addr = outgoingConn->remote;
-        my_addr = outgoingConn->local;
-        setPeer(outgoingConn->getPeer());
-    }
+
+    // no ACLs check outgoingConn->local
 }
 
 void ACLFilledChecklist::setRequest(HttpRequest *httpRequest)

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -8,8 +8,8 @@
 
 #include "squid.h"
 #include "acl/FilledChecklist.h"
-#include "client_side.h"
 #include "CachePeer.h"
+#include "client_side.h"
 #include "comm/Connection.h"
 #include "comm/forward.h"
 #include "debug/Messages.h"

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -276,7 +276,9 @@ ACLFilledChecklist::setOutgoingConnection(const Comm::ConnectionPointer &outgoin
 
 void ACLFilledChecklist::setRequest(HttpRequest *httpRequest)
 {
-    assert(!request);
+    if (request)
+        return;
+
     if (httpRequest) {
         request = httpRequest;
         HTTPMSGLOCK(request);

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -249,12 +249,12 @@ ACLFilledChecklist::ACLFilledChecklist(const acl_access *A, HttpRequest *http_re
 }
 
 void
-ACLFilledChecklist::setOutgoingConnection(const Comm::ConnectionPointer &conn)
+ACLFilledChecklist::setOutgoingConnection(const Comm::ConnectionPointer &outgoingConn)
 {
-    if (conn && conn->isOpen()) {
-        dst_addr = conn->remote;
-        my_addr = conn->local;
-        dst_peer_name = conn->getPeer() ? conn->getPeer()->name : nullptr;
+    if (outgoingConn && outgoingConn->isOpen()) {
+        dst_addr = outgoingConn->remote;
+        my_addr = outgoingConn->local;
+        dst_peer_name = outgoingConn->getPeer() ? outgoingConn->getPeer()->name : nullptr;
     }
 }
 

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -268,9 +268,8 @@ ACLFilledChecklist::setOutgoingConnection(const Comm::ConnectionPointer &outgoin
 
     // TODO: ACLIP::match(ip) does not check whether ip has been set. Should it?
     static const Ip::Address Empty; // constructed with setEmpty()
-
     if (dst_addr == Empty)
-        dst_addr = outgoingConn->remote;
+        dst_addr = outgoingConn->remote; // may be empty
 
     // no ACLs check outgoingConn->local
 }

--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -42,6 +42,7 @@ public:
     void setRequest(HttpRequest *);
     /// configure rfc931 user identity for the first time
     void setIdent(const char *userIdentity);
+    void setOutgoingConnection(const Comm::ConnectionPointer &);
 
 public:
     /// The client connection manager

--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -14,6 +14,7 @@
 #include "acl/forward.h"
 #include "base/CbcPointer.h"
 #include "error/forward.h"
+#include "http/forward.h"
 #include "ip/Address.h"
 #if USE_AUTH
 #include "auth/UserRequest.h"
@@ -22,8 +23,6 @@
 
 class CachePeer;
 class ConnStateData;
-class HttpRequest;
-class HttpReply;
 
 /** \ingroup ACLAPI
     ACLChecklist filled with specific data, representing Squid and transaction
@@ -38,11 +37,28 @@ public:
     ACLFilledChecklist(const acl_access *, HttpRequest *, const char *ident = nullptr);
     ~ACLFilledChecklist();
 
-    /// configure client request-related fields for the first time
+    // The following checklist configuration functions may be called in any
+    // order, repeatedly, and/or with nil arguments. They all extract new (as in
+    // "previously not set") information but do not update changed (as in
+    // "previously set to a different value") info.
+
+    /// configure client request-related fields
     void setRequest(HttpRequest *);
-    /// configure rfc931 user identity for the first time
+
+    /// configure rfc931 user identity
     void setIdent(const char *userIdentity);
+
+    /// configure cache_peer-related fields
+    void setPeer(const CachePeer *);
+
+    /// configure Squid-to-origin/cache_peer connection-related fields
     void setOutgoingConnection(const Comm::ConnectionPointer &);
+
+    /// configure server response-related fields
+    void setReply(const HttpReplyPointer &);
+
+    /// configure Squid-generated error-related fields
+    void setError(const ErrorState *);
 
 public:
     /// The client connection manager

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4005,6 +4005,22 @@ DOC_START
 
 DOC_END
 
+NAME: cache_peer_fault
+TYPE: acl_access
+DEFAULT: none
+DEFAULT_DOC: Blame cache peer for certain errors
+LOC: Config.accessList.cachePeerFault
+DEFAULT: none
+DOC_START
+
+		cache_peer_fault allow|deny [!]aclname ...
+
+	Use this directive to control whether an error response from a cache_peer
+	should be counted as a peer failure or a problem unrelated to the peer
+	health.
+
+DOC_END
+
 NAME: neighbor_type_domain
 TYPE: hostdomaintype
 DEFAULT: none

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4008,19 +4008,36 @@ DOC_END
 NAME: cache_peer_fault
 TYPE: acl_access
 DEFAULT: none
-DEFAULT_DOC: Blame cache peer for cache_peer-related errors
+DEFAULT_DOC: Blame the selected cache_peer for all forwarding errors
 LOC: Config.accessList.cachePeerFault
 DEFAULT: none
 DOC_START
+	When Squid encounters a problem associated with a cache_peer connection,
+	this directive decides whether the corresponding cache_peer should be
+	blamed for that problem. A cache_peer blamed for connect-fail-limit
+	sequential problems is marked as "dead". Squid does not forward requests
+	to dead cache_peers.
 
 		cache_peer_fault allow|deny [!]aclname ...
 
-	Use this directive to control whether an error response from a cache_peer
-	should be counted as a peer failure or a problem unrelated to the peer
-	health.
+	Connection-cache_peer association starts when Squid attempts to open a TCP
+	connection to the cache_peer and ends when that connection establishment
+	attempt fails or the open connection is closed. Currently, a failure to
+	resolve a cache_peer domain name is not associated with that cache_peer,
+	but that should change.
 
-	Only fast ACLs are supported.
+	If certain forwarding problems should not count towards the cache_peer
+	connect-fail-limit, add the corresponding deny rule. For example:
 
+		# Do not blame any cache_peer for blocking our CONNECT requests. No
+		# change for other failures, including GET failures and those
+		# failures that happen before Squid gets a response.
+		acl hasResponse has response
+		acl forbiddenResponse http_status 403
+		cache_peer_fault deny CONNECT hasResponse forbiddenResponse
+
+	This clause only supports fast acl types.
+	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 DOC_END
 
 NAME: neighbor_type_domain

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4026,15 +4026,21 @@ DOC_START
 	resolve a cache_peer domain name is not associated with that cache_peer,
 	but that should change.
 
+	Squid probes configured cache_peers using TCP connections that are not
+	associated with any HTTP request. Some connections fail before Squid
+	receives an HTTP response. Thus, cache_peer_fault rules should not assume
+	request and response availability.
+
 	If certain forwarding problems should not count towards the cache_peer
 	connect-fail-limit, add the corresponding deny rule. For example:
 
 		# Do not blame any cache_peer for blocking our CONNECT requests. No
-		# change for other failures, including GET failures and those
-		# failures that happen before Squid gets a response.
+		# change for all other failures, including probing connections, GET
+		# failures, and failures that happen before Squid gets a response.
+		acl hasRequest has request
 		acl hasResponse has response
 		acl forbiddenResponse http_status 403
-		cache_peer_fault deny CONNECT hasResponse forbiddenResponse
+		cache_peer_fault deny hasRequest CONNECT hasResponse forbiddenResponse
 
 	This clause only supports fast acl types.
 	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4008,7 +4008,7 @@ DOC_END
 NAME: cache_peer_fault
 TYPE: acl_access
 DEFAULT: none
-DEFAULT_DOC: Blame cache peer for certain errors
+DEFAULT_DOC: Blame cache peer for cache_peer-related errors
 LOC: Config.accessList.cachePeerFault
 DEFAULT: none
 DOC_START
@@ -4018,6 +4018,8 @@ DOC_START
 	Use this directive to control whether an error response from a cache_peer
 	should be counted as a peer failure or a problem unrelated to the peer
 	health.
+
+	Only fast ACLs are supported.
 
 DOC_END
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3537,8 +3537,7 @@ clientAclChecklistFill(ACLFilledChecklist &checklist, ClientHttpRequest *http)
 {
     assert(http);
 
-    if (!checklist.request && http->request)
-        checklist.setRequest(http->request);
+    checklist.setRequest(http->request);
 
     if (!checklist.al && http->al) {
         checklist.al = http->al;

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -383,10 +383,7 @@ Http::Tunneler::countFailingConnection(const ErrorState * const error)
         checklist.setOutgoingConnection(connection);
         checklist.al = al;
         checklist.syncAle(request.getRaw(), nullptr);
-        if (error) {
-            checklist.reply = error->response_.getRaw();
-            HTTPMSGLOCK(checklist.reply);
-        }
+        checklist.setError(error);
     });
     if (noteFwdPconnUse && connection->isOpen())
         fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -7,7 +7,6 @@
  */
 
 #include "squid.h"
-#include "acl/FilledChecklist.h"
 #include "base/Raw.h"
 #include "CachePeer.h"
 #include "clients/HttpTunneler.h"

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -379,9 +379,9 @@ Http::Tunneler::countFailingConnection(ErrorState *error)
 {
     assert(connection);
     if (const auto p = connection->getPeer()) {
-        ACLFilledChecklist *ch = nullptr;
+        std::unique_ptr<ACLFilledChecklist> ch;
         if (Config.accessList.cachePeerFault) {
-            ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
+            ch.reset(new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr));
             ch->al = al;
             ch->syncAle(request.getRaw(), nullptr);
             if (error) {
@@ -389,8 +389,7 @@ Http::Tunneler::countFailingConnection(ErrorState *error)
                 HTTPMSGLOCK(ch->reply);
             }
         }
-        p->peerConnectFailed(ch);
-        delete ch;
+        p->peerConnectFailed(ch.get());
     }
     if (noteFwdPconnUse && connection->isOpen())
         fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -80,7 +80,7 @@ private:
     void disconnect();
 
     /// updates connection usage history before the connection is closed
-    void countFailingConnection(ErrorState *);
+    void countFailingConnection(const ErrorState * const);
 
     AsyncCall::Pointer writer; ///< called when the request has been written
     AsyncCall::Pointer reader; ///< called when the response should be read

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -80,7 +80,7 @@ private:
     void disconnect();
 
     /// updates connection usage history before the connection is closed
-    void countFailingConnection();
+    void countFailingConnection(ErrorState *);
 
     AsyncCall::Pointer writer; ///< called when the request has been written
     AsyncCall::Pointer reader; ///< called when the response should be read

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -80,7 +80,7 @@ private:
     void disconnect();
 
     /// updates connection usage history before the connection is closed
-    void countFailingConnection(const ErrorState * const);
+    void countFailingConnection(const ErrorState *);
 
     AsyncCall::Pointer writer; ///< called when the request has been written
     AsyncCall::Pointer reader; ///< called when the response should be read

--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -90,6 +90,7 @@ typedef enum {
 
 class Error;
 class ErrorDetail;
+class ErrorState;
 
 typedef RefCount<ErrorDetail> ErrorDetailPointer;
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1275,32 +1275,6 @@ peerRefreshDNS(void *data)
     eventAddIsh("peerRefreshDNS", peerRefreshDNS, nullptr, 3600.0, 1);
 }
 
-static void
-peerConnectFailedSilent(CachePeer * p)
-{
-    p->stats.last_connect_failure = squid_curtime;
-
-    if (!p->tcp_up) {
-        debugs(15, 2, "TCP connection to " << p->host << "/" << p->http_port <<
-               " dead");
-        return;
-    }
-
-    -- p->tcp_up;
-
-    if (!p->tcp_up) {
-        debugs(15, DBG_IMPORTANT, "Detected DEAD " << neighborTypeStr(p) << ": " << p->name);
-        p->stats.logged_state = PEER_DEAD;
-    }
-}
-
-void
-peerConnectFailed(CachePeer *p)
-{
-    debugs(15, DBG_IMPORTANT, "ERROR: TCP connection to " << p->host << "/" << p->http_port << " failed");
-    peerConnectFailedSilent(p);
-}
-
 void
 peerConnectSucceded(CachePeer * p)
 {
@@ -1368,7 +1342,7 @@ peerProbeConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int
     if (status == Comm::OK) {
         peerConnectSucceded(p);
     } else {
-        peerConnectFailedSilent(p);
+        p->peerConnectFailedSilent();
     }
 
     -- p->testing_now;

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -452,9 +452,6 @@ peerClearRR()
     }
 }
 
-/**
- * Perform all actions when a CachePeer is detected revived.
- */
 void
 peerAlive(CachePeer *p)
 {

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1333,7 +1333,9 @@ peerProbeConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int
     if (status == Comm::OK) {
         p->noteSuccess();
     } else {
-        p->countFailure();
+        p->noteFailure([&](ACLFilledChecklist &checklist) {
+            checklist.setOutgoingConnection(conn);
+        });
     }
 
     -- p->testing_now;

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1342,7 +1342,7 @@ peerProbeConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int
     if (status == Comm::OK) {
         peerConnectSucceded(p);
     } else {
-        p->peerConnectFailedSilent();
+        p->countFailure();
     }
 
     -- p->testing_now;

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -466,12 +466,12 @@ peerAlive(CachePeer *p)
             PeerPoolMgr::Checkpoint(p->standby.mgr, "revived peer");
     }
 
+    p->stats.last_reply = squid_curtime;
+    p->stats.probe_start = 0;
+
     // TODO: Remove or explain how we could detect an alive peer without IP addresses
     if (!p->n_addresses)
         ipcache_nbgethostbyname(p->host, peerDNSConfigure, p);
-
-    p->stats.last_reply = squid_curtime;
-    p->stats.probe_start = 0;
 }
 
 CachePeer *

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -49,7 +49,12 @@ CachePeer *getRoundRobinParent(PeerSelector*);
 CachePeer *getWeightedRoundRobinParent(PeerSelector*);
 void peerClearRRStart(void);
 void peerClearRR(void);
+
+// TODO: Move, together with its many dependencies and callers, into CachePeer.
+/// Updates protocol-agnostic CachePeer state after an indication of a
+/// successful contact with the given cache_peer.
 void peerAlive(CachePeer *);
+
 lookup_t peerDigestLookup(CachePeer * p, PeerSelector *);
 CachePeer *neighborsDigestSelect(PeerSelector *);
 void peerNoteDigestLookup(HttpRequest * request, CachePeer * p, lookup_t lookup);

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -56,7 +56,6 @@ void peerNoteDigestGone(CachePeer * p);
 int neighborUp(const CachePeer * e);
 const char *neighborTypeStr(const CachePeer * e);
 peer_t neighborType(const CachePeer *, const AnyP::Uri &);
-void peerConnectFailed(CachePeer *);
 void peerConnectSucceded(CachePeer *);
 void dump_peer_options(StoreEntry *, CachePeer *);
 int peerHTTPOkay(const CachePeer *, PeerSelector *);

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -49,6 +49,7 @@ CachePeer *getRoundRobinParent(PeerSelector*);
 CachePeer *getWeightedRoundRobinParent(PeerSelector*);
 void peerClearRRStart(void);
 void peerClearRR(void);
+void peerAlive(CachePeer *);
 lookup_t peerDigestLookup(CachePeer * p, PeerSelector *);
 CachePeer *neighborsDigestSelect(PeerSelector *);
 void peerNoteDigestLookup(HttpRequest * request, CachePeer * p, lookup_t lookup);
@@ -58,7 +59,6 @@ const char *neighborTypeStr(const CachePeer * e);
 peer_t neighborType(const CachePeer *, const AnyP::Uri &);
 void dump_peer_options(StoreEntry *, CachePeer *);
 int peerHTTPOkay(const CachePeer *, PeerSelector *);
-void lookupPeer(CachePeer *);
 
 /// \returns max(1, timeout)
 time_t positiveTimeout(const time_t timeout);

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -56,9 +56,9 @@ void peerNoteDigestGone(CachePeer * p);
 int neighborUp(const CachePeer * e);
 const char *neighborTypeStr(const CachePeer * e);
 peer_t neighborType(const CachePeer *, const AnyP::Uri &);
-void peerConnectSucceded(CachePeer *);
 void dump_peer_options(StoreEntry *, CachePeer *);
 int peerHTTPOkay(const CachePeer *, PeerSelector *);
+void lookupPeer(CachePeer *);
 
 /// \returns max(1, timeout)
 time_t positiveTimeout(const time_t timeout);

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -8,7 +8,6 @@
 
 #include "squid.h"
 #include "AccessLogEntry.h"
-#include "acl/FilledChecklist.h"
 #include "CachePeer.h"
 #include "comm/Connection.h"
 #include "errorpage.h"

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -72,15 +72,14 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
     if (error) {
         debugs(83, 5, "error=" << (void*)error);
         // XXX: FwdState calls NoteOutgoingConnectionSuccess() after an OK TCP connect, but
-        // we call NoteOutgoingConnectionFailure() if SSL failed afterwards. Is that OK?
-        // It is not clear whether we should call NoteOutgoingConnectionSuccess()/NoteOutgoingConnectionFailure()
+        // we call noteFailure() if SSL failed afterwards. Is that OK?
+        // It is not clear whether we should call noteSuccess()/noteFailure()/etc.
         // based on TCP results, SSL results, or both. And the code is probably not
         // consistent in this aspect across tunnelling and forwarding modules.
         if (peer && peer->secure.encryptTransport) {
-            NoteOutgoingConnectionFailure(peer, [&](ACLFilledChecklist &checklist) {
-                checklist.setRequest(request.getRaw());
-                checklist.setOutgoingConnection(serverConn);
+            peer->noteFailure([&](ACLFilledChecklist &checklist) {
                 fillChecklist(checklist);
+                checklist.setError(error);
             });
         }
         return;

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -77,12 +77,11 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
         // based on TCP results, SSL results, or both. And the code is probably not
         // consistent in this aspect across tunnelling and forwarding modules.
         if (peer && peer->secure.encryptTransport) {
-            std::unique_ptr<ACLFilledChecklist> ch;
-            if (Config.accessList.cachePeerFault) {
-                ch.reset(new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr));
-                fillChecklist(*ch);
-            }
-            peer->peerConnectFailed(ch.get());
+            NoteOutgoingConnectionFailure(peer, [&](ACLFilledChecklist &checklist) {
+                checklist.setRequest(request.getRaw());
+                checklist.setOutgoingConnection(serverConn);
+                fillChecklist(checklist);
+            });
         }
         return;
     }

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -71,9 +71,9 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
 
     if (error) {
         debugs(83, 5, "error=" << (void*)error);
-        // XXX: FwdState.cc calls NoteOutgoingConnectionSuccess() after an OK TCP connect but
+        // XXX: FwdState calls NoteOutgoingConnectionSuccess() after an OK TCP connect, but
         // we call NoteOutgoingConnectionFailure() if SSL failed afterwards. Is that OK?
-        // It is not clear whether we should call NoteOutgoingConnectionSuccess/NoteOutgoingConnectionFailure()
+        // It is not clear whether we should call NoteOutgoingConnectionSuccess()/NoteOutgoingConnectionFailure()
         // based on TCP results, SSL results, or both. And the code is probably not
         // consistent in this aspect across tunnelling and forwarding modules.
         if (peer && peer->secure.encryptTransport) {

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -71,9 +71,9 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
 
     if (error) {
         debugs(83, 5, "error=" << (void*)error);
-        // XXX: forward.cc calls peerConnectSucceeded() after an OK TCP connect but
+        // XXX: FwdState.cc calls NoteOutgoingConnectionSuccess() after an OK TCP connect but
         // we call NoteOutgoingConnectionFailure() if SSL failed afterwards. Is that OK?
-        // It is not clear whether we should call peerConnectSucceeded/NoteOutgoingConnectionFailure()
+        // It is not clear whether we should call NoteOutgoingConnectionSuccess/NoteOutgoingConnectionFailure()
         // based on TCP results, SSL results, or both. And the code is probably not
         // consistent in this aspect across tunnelling and forwarding modules.
         if (peer && peer->secure.encryptTransport) {

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -77,10 +77,13 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
         // based on TCP results, SSL results, or both. And the code is probably not
         // consistent in this aspect across tunnelling and forwarding modules.
         if (peer && peer->secure.encryptTransport) {
-            ACLFilledChecklist ch(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
-            ch.al = al;
-            ch.syncAle(request.getRaw(), nullptr);
+            ACLFilledChecklist *ch = nullptr;
+            if (Config.accessList.cachePeerFault) {
+                ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
+                fillChecklist(*ch);
+            }
             peer->peerConnectFailed(ch);
+            delete ch;
         }
         return;
     }

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -77,13 +77,12 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
         // based on TCP results, SSL results, or both. And the code is probably not
         // consistent in this aspect across tunnelling and forwarding modules.
         if (peer && peer->secure.encryptTransport) {
-            ACLFilledChecklist *ch = nullptr;
+            std::unique_ptr<ACLFilledChecklist> ch;
             if (Config.accessList.cachePeerFault) {
-                ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
+                ch.reset(new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr));
                 fillChecklist(*ch);
             }
-            peer->peerConnectFailed(ch);
-            delete ch;
+            peer->peerConnectFailed(ch.get());
         }
         return;
     }

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -72,8 +72,8 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
     if (error) {
         debugs(83, 5, "error=" << (void*)error);
         // XXX: forward.cc calls peerConnectSucceeded() after an OK TCP connect but
-        // we call peerConnectFailed() if SSL failed afterwards. Is that OK?
-        // It is not clear whether we should call peerConnectSucceeded/Failed()
+        // we call NoteOutgoingConnectionFailure() if SSL failed afterwards. Is that OK?
+        // It is not clear whether we should call peerConnectSucceeded/NoteOutgoingConnectionFailure()
         // based on TCP results, SSL results, or both. And the code is probably not
         // consistent in this aspect across tunnelling and forwarding modules.
         if (peer && peer->secure.encryptTransport) {

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -42,8 +42,8 @@ public:
     /// Return the configured TLS context object
     virtual Security::ContextPointer getTlsContext();
 
-    /// On error calls NoteOutgoingConnectionFailure().
-    /// On success store the used TLS session for later use.
+    /// On success, stores the used TLS session for later use.
+    /// On error, informs the peer.
     virtual void noteNegotiationDone(ErrorState *);
 };
 

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -42,7 +42,7 @@ public:
     /// Return the configured TLS context object
     virtual Security::ContextPointer getTlsContext();
 
-    /// On error calls peerConnectFailed().
+    /// On error calls NoteOutgoingConnectionFailure().
     /// On success store the used TLS session for later use.
     virtual void noteNegotiationDone(ErrorState *);
 };

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -531,13 +531,12 @@ Security::PeerConnector::countFailingConnection()
 {
     assert(serverConn);
     if (const auto p = serverConn->getPeer()) {
-        ACLFilledChecklist *ch = nullptr;
+        std::unique_ptr<ACLFilledChecklist> ch;
         if (Config.accessList.cachePeerFault) {
-            ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
+            ch.reset(new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr));
             fillChecklist(*ch);
         }
-        p->peerConnectFailed(ch);
-        delete ch;
+        p->peerConnectFailed(ch.get());
     }
     // TODO: Calling PconnPool::noteUses() should not be our responsibility.
     if (noteFwdPconnUse && serverConn->isOpen())

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -531,9 +531,13 @@ Security::PeerConnector::countFailingConnection()
 {
     assert(serverConn);
     if (const auto p = serverConn->getPeer()) {
-        ACLFilledChecklist ch(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
-        fillChecklist(ch);
+        ACLFilledChecklist *ch = nullptr;
+        if (Config.accessList.cachePeerFault) {
+            ch = new ACLFilledChecklist(Config.accessList.cachePeerFault, request.getRaw(), nullptr);
+            fillChecklist(*ch);
+        }
         p->peerConnectFailed(ch);
+        delete ch;
     }
     // TODO: Calling PconnPool::noteUses() should not be our responsibility.
     if (noteFwdPconnUse && serverConn->isOpen())

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -26,7 +26,6 @@
 #include <iosfwd>
 #include <queue>
 
-class ErrorState;
 class Downloader;
 class DownloaderAnswer;
 class AccessLogEntry;
@@ -151,7 +150,7 @@ protected:
     void disconnect();
 
     /// updates connection usage history before the connection is closed
-    void countFailingConnection();
+    void countFailingConnection(const ErrorState *);
 
     /// If called the certificates validator will not used
     void bypassCertValidator() {useCertValidator_ = false;}

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -98,7 +98,7 @@ void PeerConnector::bail(ErrorState *) STUB
 void PeerConnector::sendSuccess() STUB
 void PeerConnector::callBack() STUB
 void PeerConnector::disconnect() STUB
-void PeerConnector::countFailingConnection() STUB
+void PeerConnector::countFailingConnection(const ErrorState *) STUB
 void PeerConnector::recordNegotiationDetails() STUB
 EncryptorAnswer &PeerConnector::answer() STUB_RETREF(EncryptorAnswer)
 }


### PR DESCRIPTION
This directive controls whether a cache peer error response is treated
as a peer failure (decreasing its health) or a problem unrelated to the
peer health.