### PR TITLE
Custom cache_peer selection algorithm via go_to annotations

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -55,3 +55,12 @@ CachePeer::connectTimeout() const
     return Config.Timeout.peer_connect;
 }
 
+bool
+CachePeer::lessUsedThan(const CachePeer &them) const
+{
+    if (this->weight == them.weight)
+        return this->rr_count < them.rr_count;
+    else
+        return this->weightedRrCount() < them.weightedRrCount();
+}
+

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -55,12 +55,20 @@ CachePeer::connectTimeout() const
     return Config.Timeout.peer_connect;
 }
 
+// TODO: Now that we have correct comparison, fix peerClearRR() to reset
+// rr_count to 0 (and stop calling it at startup) without recreating bug 4065.
 bool
 CachePeer::lessUsedThan(const CachePeer &them) const
 {
-    if (this->weight == them.weight)
-        return this->rr_count < them.rr_count;
-    else
-        return this->weightedRrCount() < them.weightedRrCount();
+    const auto thisUsed = this->weightedRrCount();
+    const auto themUsed = them.weightedRrCount();
+
+    if (thisUsed == themUsed) {
+        if (this->weight == them.weight)
+            return this->index < them.index; // guarantee stable order
+        return this->weight > them.weight; // heavyweight bias
+    }
+
+    return thisUsed < themUsed;
 }
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -35,8 +35,10 @@ public:
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
-    /// whether a round-robin algorithm prefers us to the given cache_peer,
-    /// including the configured weight=N bias (if any)
+    /// Whether we were "used" less than the given CachePeer. An rr_count-based
+    /// implementation accounts for the configured weight=N bias (if any) and
+    /// guarantees stable sort order (i.e. for any two different CachePeer
+    /// objects a and b from the same configuration: a<b || b<a).
     bool lessUsedThan(const CachePeer &) const;
 
     u_int index = 0;
@@ -157,7 +159,7 @@ public:
 
     Ip::Address addresses[10];
     int n_addresses = 0;
-    int rr_count = 0;
+    uint64_t rr_count = 0;
     CachePeer *next = nullptr;
     int testing_now = 0;
 
@@ -204,7 +206,7 @@ public:
 
 protected:
     /// round-robin access counter adjusted for this cache_peer weight
-    double weightedRrCount() const { return static_cast<double>(rr_count)/weight; }
+    uint64_t weightedRrCount() const { return rr_count / weight; }
 };
 
 #endif /* SQUID_CACHEPEER_H_ */

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -35,6 +35,10 @@ public:
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
+    /// whether a round-robin algorithm prefers us to the given peer, including
+    /// any configured weight=N bias
+    bool lessUsedThan(const CachePeer &) const;
+
     u_int index = 0;
     char *name = nullptr;
     char *host = nullptr;
@@ -197,6 +201,13 @@ public:
 
     int front_end_https = 0; ///< 0 - off, 1 - on, 2 - auto
     int connection_auth = 2; ///< 0 - off, 1 - on, 2 - auto
+
+protected:
+    /// round-robin access counter adjusted for this cache_peer weight
+    double weightedRrCount() const
+    {
+        return static_cast<double>(rr_count) / weight;
+    }
 };
 
 #endif /* SQUID_CACHEPEER_H_ */

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -35,8 +35,8 @@ public:
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
-    /// whether a round-robin algorithm prefers us to the given peer, including
-    /// any configured weight=N bias
+    /// whether a round-robin algorithm prefers us to the given cache_peer,
+    /// including the configured weight=N bias (if any)
     bool lessUsedThan(const CachePeer &) const;
 
     u_int index = 0;
@@ -204,10 +204,7 @@ public:
 
 protected:
     /// round-robin access counter adjusted for this cache_peer weight
-    double weightedRrCount() const
-    {
-        return static_cast<double>(rr_count) / weight;
-    }
+    double weightedRrCount() const { return static_cast<double>(rr_count)/weight; }
 };
 
 #endif /* SQUID_CACHEPEER_H_ */

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -275,8 +275,13 @@ FwdState::completed()
     if (entry->store_status == STORE_PENDING) {
         if (entry->isEmpty()) {
             assert(!storedWholeReply_);
-            if (!err) // we quit (e.g., fd closed) before an error or content
+            if (!err) {
+                // We quit before an error or content. XXX: Cannot distinguish:
+                // * ERR_READ_ERROR/Http::scBadGateway (e.g., fd closed)
+                // * ERR_CANNOT_FORWARD/Http::scBadGateway (e.g., cache_peers are down)
+                // * ERR_CANNOT_FORWARD/Http::scInternalServerError (e.g., go_to=typo)
                 fail(new ErrorState(ERR_READ_ERROR, Http::scBadGateway, request, al));
+            }
             assert(err);
             updateAleWithFinalError();
             errorAppendEntry(entry, err);

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -117,6 +117,7 @@ protected:
     void checkAlwaysDirectDone(const Acl::Answer answer);
     void checkNeverDirectDone(const Acl::Answer answer);
 
+    bool selectByAnnotation();
     void selectSomeNeighbor();
     void selectSomeNeighborReplies();
     void selectSomeDirect();

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1055,34 +1055,27 @@ DOC_START
 	    If the go_to list is empty or if each named cache_peer fails the above
 	    preconditions, then request forwarding fails.
 
-	    The cache_peer use order is determined by the optional go_to_how
-	    annotation.
+	    When multiple named cache_peers are used due to reforwarding attempts,
+	    their use order is determined by the optional go_to_how annotation. By
+	    default, cache_peers are used in the go_to listing order.
 
-	  go_to_how=method A cache_peer selection method name. Two method names are
-	  currently supported:
+	  go_to_how=algorithm How to use cache_peers named in a go_to annotation.
+	    Please see the go_to annotation for the preconditions that are used to
+	    filter named peers before applying the specified algorithm:
 
-	    "default": Selects the first usable go_to cache_peer, in their naming
-	    order. If the selection fails (i.e. go_to named no cache_peers, all the
-	    named cache_peers are denied or deemed unsuitable for the current
-	    transaction), then forwarding fails. If the selected cache_peer fails,
-	    then no other cache_peer is tried. XXX: This is not what admins want!
-	    They want "all usable named cache_peers" instead of "the first one".
+	    "as-ordered": Uses named peers in their go_to naming order. Squid uses
+	    this algorithm when the go_to annotation lacks a go_to_how annotation.
 
-	    "round-robin": Selects the first usable named go_to cache_peer, in rough
-	    round-robin order (i.e. the least used cache_peer among the usable ones
-	    is selected). A cache_peer weight option (if any) is honored. The
-	    cache_peer does not have to be configured with a round-robin option.
-	    XXX: This is not what admins want! They want "all usable named
-	    cache_peers" instead of "the first one".
+	    "least-used": Uses named peers ordered by their approximate use count,
+	    with the least used cache_peer placed first. For a given isolated stable
+	    group of go_to peers, the end result should resemble a round-robin
+	    cache_peer selection. A cache_peer with weight=W increments its use
+	    count by 1/W (instead of by 1), allowing "heavyweight" peers to be
+	    reused more often than "lightweight" ones.
 
-	    If the selection fails (i.e. go_to named no cache_peers, all the named
-	    cache_peers are denied or deemed unsuitable for the current
-	    transaction), then forwarding fails. If the selected cache_peer fails,
-	    then no other cache_peer is tried.
-
-	    If this annotation is returned without a go_to annotation, then Squid
-	    currently does not treat this annotation specially, but future Squid
-	    versions may start complain (at least) about such bare go_to_how notes.
+	    If a transactions is annotated with go_to_how but without go_to, then
+	    Squid does not treat the bare go_to_how annotation specially today, but
+	    that behavior may change without notice.
 
 	Any keywords may be sent on any response whether OK, ERR or BH.
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1042,13 +1042,47 @@ DOC_START
 			Please see url_rewrite_program related documentation
 			for this kv-pair.
 
-		go_to=peerA,peerB,... A comma-separated list of cache_peer names to use,
-			in the listed order, when/if forwarding this request. Providing
-			cache_peer names via this transaction annotation disables built-in peer
-			selection algorithms that normally form such a list. However, the usual
-			preconditions for using a cache_peer still apply. See always_direct,
-			cache_peer_access, cache_peer connect-fail-limit=N, and cache_peer
-			max-conn=N for some of those still-applicable checks.
+	  go_to=peerA,peerB... A comma-separated list of cache_peer names to use
+	    when/if forwarding this request. Providing cache_peer names via this
+	    transaction annotation disables built-in peer selection algorithms that
+	    normally form such a list.
+
+	    The usual cache_peer-type-agnostic preconditions for using a cache_peer
+	    still apply: See always_direct, cache_peer_access, cache_peer
+	    connect-fail-limit=N, and cache_peer max-conn=N for the documented
+	    cache_peer checks applicable here.
+
+	    If the go_to list is empty or if each named cache_peer fails the above
+	    preconditions, then request forwarding fails.
+
+	    The cache_peer use order is determined by the optional go_to_how
+	    annotation.
+
+	  go_to_how=method A cache_peer selection method name. Two method names are
+	  currently supported:
+
+	    "default": Selects the first usable go_to cache_peer, in their naming
+	    order. If the selection fails (i.e. go_to named no cache_peers, all the
+	    named cache_peers are denied or deemed unsuitable for the current
+	    transaction), then forwarding fails. If the selected cache_peer fails,
+	    then no other cache_peer is tried. XXX: This is not what admins want!
+	    They want "all usable named cache_peers" instead of "the first one".
+
+	    "round-robin": Selects the first usable named go_to cache_peer, in rough
+	    round-robin order (i.e. the least used cache_peer among the usable ones
+	    is selected). A cache_peer weight option (if any) is honored. The
+	    cache_peer does not have to be configured with a round-robin option.
+	    XXX: This is not what admins want! They want "all usable named
+	    cache_peers" instead of "the first one".
+
+	    If the selection fails (i.e. go_to named no cache_peers, all the named
+	    cache_peers are denied or deemed unsuitable for the current
+	    transaction), then forwarding fails. If the selected cache_peer fails,
+	    then no other cache_peer is tried.
+
+	    If this annotation is returned without a go_to annotation, then Squid
+	    currently does not treat this annotation specially, but future Squid
+	    versions may start complain (at least) about such bare go_to_how notes.
 
 	Any keywords may be sent on any response whether OK, ERR or BH.
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1042,6 +1042,14 @@ DOC_START
 			Please see url_rewrite_program related documentation
 			for this kv-pair.
 
+		go_to=peerA,peerB,... A comma-separated list of cache_peer names to use,
+			in the listed order, when/if forwarding this request. Providing
+			cache_peer names via this transaction annotation disables built-in peer
+			selection algorithms that normally form such a list. However, the usual
+			preconditions for using a cache_peer still apply. See always_direct,
+			cache_peer_access, cache_peer connect-fail-limit=N, and cache_peer
+			max-conn=N for some of those still-applicable checks.
+
 	Any keywords may be sent on any response whether OK, ERR or BH.
 
 	All response keyword values need to be a single token with URL

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3666,6 +3666,7 @@ DOC_START
 			peer-selection mechanisms.
 			The weight must be an integer; default is 1,
 			larger weights are favored more.
+			Negative and zero weights are silently converted to 1.
 			This option does not affect parent selection if a peering
 			protocol is not in use.
 

--- a/src/hier_code.h
+++ b/src/hier_code.h
@@ -35,6 +35,7 @@ typedef enum {
     PINNED,
     ORIGINAL_DST,
     STANDBY_POOL,
+    HIER_GOTO,
     HIER_MAX
 } hier_code;
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -285,6 +285,28 @@ neighborsCount(PeerSelector *ps)
 }
 
 CachePeer *
+findNamedPeer(PeerSelector &ps, const char * const name)
+{
+    for (auto p = Config.peers; p; p = p->next) {
+        if (strcmp(p->name, name) != 0)
+            continue;
+
+        if (!peerHTTPOkay(p, &ps)) {
+            debugs(15, 3, "found unusable " << p->name);
+            return nullptr;
+        }
+
+        debugs(15, 3, "found usable " << p->name);
+        return p;
+    }
+
+    // Either there is a typo in the annotation-setting configuration/helper or
+    // the named cache_peer disappeared during Squid reconfiguration.
+    debugs(15, DBG_IMPORTANT, "ERROR: No go_to cache_peer named " << name);
+    return nullptr;
+}
+
+CachePeer *
 getFirstUpParent(PeerSelector *ps)
 {
     assert(ps);

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -285,10 +285,10 @@ neighborsCount(PeerSelector *ps)
 }
 
 CachePeer *
-findNamedPeer(PeerSelector &ps, const char * const name)
+findNamedPeer(PeerSelector &ps, const SBuf &name)
 {
     for (auto p = Config.peers; p; p = p->next) {
-        if (strcmp(p->name, name) != 0)
+        if (name.cmp(p->name) != 0)
             continue;
 
         if (!peerHTTPOkay(p, &ps)) {

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -350,17 +350,12 @@ getRoundRobinParent(PeerSelector *ps)
         if (!peerHTTPOkay(p, ps))
             continue;
 
+        // TODO: Here and elsewhere, stop checking for impossible weight values.
         if (p->weight == 0)
             continue;
 
-        if (q) {
-            if (p->weight == q->weight) {
-                if (q->rr_count < p->rr_count)
-                    continue;
-            } else if ( ((double) q->rr_count / q->weight) < ((double) p->rr_count / p->weight)) {
-                continue;
-            }
-        }
+        if (q && q->lessUsedThan(*p))
+            continue;
 
         q = p;
     }

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -26,7 +26,7 @@ class PeerSelector;
 CachePeer *getFirstPeer(void);
 
 /// a peerHTTPOkay() cache_peer with a given name (or nullptr)
-CachePeer *findNamedPeer(PeerSelector&, const char *name);
+CachePeer *findNamedPeer(PeerSelector&, const SBuf &name);
 
 CachePeer *getFirstUpParent(PeerSelector *);
 CachePeer *getNextPeer(CachePeer *);

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -24,6 +24,10 @@ class StoreEntry;
 class PeerSelector;
 
 CachePeer *getFirstPeer(void);
+
+/// a peerHTTPOkay() cache_peer with a given name (or nullptr)
+CachePeer *findNamedPeer(PeerSelector&, const char *name);
+
 CachePeer *getFirstUpParent(PeerSelector *);
 CachePeer *getNextPeer(CachePeer *);
 CachePeer *getSingleParent(PeerSelector *);

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -703,15 +703,15 @@ PeerSelector::selectMore()
 }
 
 /// cache_peer selection methods. The absolute values are not important.
-/// Currently, this enum only contains values supported by
-/// PeerSelector::selectByAnnotation().
+/// Currently, this enum only contains values supported by the go_to_how feature
+/// of PeerSelector::selectByAnnotation().
 using PeerSelectionMethod = enum {
     psmFirstUp,
     psmRoundRobin
 };
 
-/// Parses a cache_peer selection method name, treating a nil name as "default".
-/// The current support is limited to methods supported by selectByAnnotation().
+/// Parses a cache_peer method algorithm name, treating a nil name as "default".
+/// The current support is limited to methods supported by go_to_how=name.
 static PeerSelectionMethod
 PeerSelectionMethodFromName(const char * const methodName)
 {

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -755,8 +755,16 @@ PeerSelector::selectByAnnotation()
             sort(selected.begin(), selected.end(), [](CachePeer *a, CachePeer *b) {
                 return a->lessUsedThan(*b);
             });
-            if (!selected.empty())
-                ++selected[0]->rr_count; // TODO: The others are counted if used (during reforwarding)
+
+            if (!selected.empty()) {
+                // Do not increment rr_count of the other selected peers, if
+                // any, because those spare peers are unlikely to be actually
+                // used. TODO: Do we want or need to increment it, despite the
+                // fact that built-in peer selection algorithms do not increment
+                // it for _used_ options.roundrobin peers if those peers were
+                // selected by an algorithm other than getRoundRobinParent()?
+                ++(selected[0]->rr_count);
+            }
         }
 
         for (const auto peer: selected) {


### PR DESCRIPTION
When Squid sees a `go_to=A,B,C` transaction annotation, it selects
cache_peers named A, B, and C for forwarding the request instead of
going through the usual built-in cache_peer selection algorithms. Adding
a "go_to_how=least-used" annotation turns on emulation of the built-in
round-robin selection algorithm for named `go_to=...` peers.
