### PR TITLE
CI: Install all known dependencies for test-builds.sh on GitHub

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -102,13 +102,10 @@ jobs:
       - name: Install prerequisite Linux packages
         if: runner.os == 'Linux'
         run: |
+          # required for "apt-get build-dep" to work
+          sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
           sudo apt-get --quiet=2 update
-          sudo apt-get --quiet=2 install libtool-bin
-          sudo apt-get --quiet=2 install libcppunit-dev
-          sudo apt-get --quiet=2 install libldap2-dev
-          # TODO: Add some deb-src URI to sources.list and do build-dep
-          # instead of the above installs?
-          # sudo apt-get --quiet=2 build-dep squid
+          sudo apt-get --quiet=2 build-dep squid
 
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -48,6 +48,7 @@ MAKETEST="distcheck"
 #   --with-gnugss \
 #   --with-heimdal-krb5 \
 #   --with-mit-krb5 \
+#   --with-ldap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
 #
@@ -111,7 +112,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-gnu-ld \
 	--with-ipv6-split-stack \
 	--with-large-files \
-	--with-ldap \
 	--with-pic \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -47,6 +47,7 @@ MAKETEST="distcheck"
 #   --enable-kqueue \
 #   --enable-win32-service \
 #   --with-valgrind-debug \
+#   --with-ldap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
 #
@@ -113,7 +114,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-gnu-ld \
 	--with-ipv6-split-stack \
 	--with-large-files \
-	--with-ldap \
 	--with-pic \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \


### PR DESCRIPTION
The apt-get build-dep trick makes us dependent on Ubuntu decisions, but it saves us work, and we can always add more dependencies manually if we discover holes in the Ubuntu-maintained list.