### PR TITLE
CI: Fix support for running a subset of GitHub Actions tests

### DIFF
--- a/test-suite/test-functionality.sh
+++ b/test-suite/test-functionality.sh
@@ -260,5 +260,5 @@ main() {
     run_tests $tests
 }
 
-main
+main "$@"
 exit $?

--- a/test-suite/test-sources.sh
+++ b/test-suite/test-sources.sh
@@ -229,7 +229,8 @@ main() {
     fi
     echo "Starting point: $STARTING_POINT (`git rev-parse $STARTING_POINT`)"
 
-    checks="$@"
+    local checks="$@"
+
     if test -z "$checks"
     then
         local default_checks="
@@ -243,5 +244,5 @@ main() {
     run_checks $checks
 }
 
-main
+main "$@"
 exit $?


### PR DESCRIPTION
The scripts were always running all/default tests instead of those named
on the command line. Broken since inception in recent commit 2ed8cc4.
