### PR TITLE
Bug 5162: mgr:index URL do not produce MGR_INDEX template

### DIFF
--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -212,7 +212,8 @@ static const char *
 FindDefaultTemplate(const err_type type)
 {
     const auto foundDefault = std::find_if(begin(TemplateDefaults), end(TemplateDefaults), [&](const DefaultMessages &m) {
-            return m.type == type; });
+        return m.type == type;
+    });
     return foundDefault == end(TemplateDefaults) ? nullptr : foundDefault->text;
 }
 
@@ -354,7 +355,8 @@ static const char *
 errorFindHardText(err_type type)
 {
     const auto foundError = std::find_if(begin(HardCodedErrors), end(HardCodedErrors), [&](const DefaultMessages &m) {
-            return m.type == type; });
+        return m.type == type;
+    });
     return foundError == end(HardCodedErrors) ? nullptr : foundError->text;
 }
 

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -219,10 +219,11 @@ template <class Messages>
 static const char *
 FindHardCodedTemplate(const err_type type, const Messages &messages)
 {
-    const auto foundDefault = std::find_if(messages.cbegin(), messages.cend(), [&](const HardCodedMessage &m) {
-        return m.type == type;
-    });
-    return foundDefault == messages.cend() ? nullptr : foundDefault->text;
+    for (const auto &m : messages) {
+        if (m.type == type)
+            return m.text;
+    }
+    return nullptr;
 }
 
 /// \ingroup ErrorPageInternal

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -192,7 +192,7 @@ static std::array<HardCodedMessage, 7> HardCodedErrors = {{
 
 /// error messages that may be configured/customized by the admin,
 /// like the regular ones, but that also have a hard-coded last-resort default
-static std::array<HardCodedMessage, 1> TemplateDefaults = {{
+static std::array<HardCodedMessage, 1> ErrorsWithDefaultTemplates = {{
     {
         MGR_INDEX,
         "mgr_index"
@@ -387,7 +387,7 @@ TemplateFile::loadDefault()
     }
 
     if (!loaded()) {
-        if (const auto defaultTemplate = FindHardCodedTemplate(templateCode, TemplateDefaults)) {
+        if (const auto defaultTemplate = FindHardCodedTemplate(templateCode, ErrorsWithDefaultTemplates)) {
             template_ = defaultTemplate;
             wasLoaded = true;
         }
@@ -441,7 +441,7 @@ TemplateFile::loadFromFile(const char *path)
 
     if (fd < 0) {
         /* with dynamic locale negotiation we may see some failures before a success. */
-        if (!silent && templateCode < TCP_RESET && !FindHardCodedTemplate(templateCode, TemplateDefaults)) {
+        if (!silent && templateCode < TCP_RESET) {
             int xerrno = errno;
             debugs(4, DBG_CRITICAL, "ERROR: loading file '" << path << "': " << xstrerr(xerrno));
         }

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -219,7 +219,7 @@ template <class Messages>
 static const char *
 FindHardCodedTemplate(const err_type type, const Messages &messages)
 {
-    for (const auto &m : messages) {
+    for (const auto &m: messages) {
         if (m.type == type)
             return m.text;
     }

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -322,6 +322,9 @@ protected:
     /// recover from loadDefault() failure to load or parse() a template
     virtual void setDefault() {}
 
+    /// sets default text for optional and missing error pages
+    void applyTemplateDefaults();
+
     /**
      * Try to load the "page_name" template for a given language "lang"
      * from squid errors directory

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -322,9 +322,6 @@ protected:
     /// recover from loadDefault() failure to load or parse() a template
     virtual void setDefault() {}
 
-    /// sets default text for optional and missing error pages
-    void applyTemplateDefaults();
-
     /**
      * Try to load the "page_name" template for a given language "lang"
      * from squid errors directory


### PR DESCRIPTION
There are currently two categories of special err_type values that have
no corresponding official ERR_FOO template files. Squid now explicitly
recognizes them and handles errors in each category specially:

1. Errors that cannot be customized. Most errors in this category are
   not customizable because their customization would have to be ignored
   since Squid cannot or should not send an error response. For example,
   ERR_CLIENT_GONE means the connection to the client is already closed,
   and TCP_RESET means it must be closed when the error is encountered.

2. Errors that may be customized. There is only one err_type in this
   category -- MGR_INDEX. Since 7e6eabb, these errors always used the
   hard-coded message, even when the custom template file existed.

Also discovered and listed two error codes that cannot be customized:
ERR_REQUEST_PARSE_TIMEOUT and ERR_RELAY_REMOTE. Listing them removes the
following level-3 (re)configuration warnings:

    loadDefault: WARNING: failed to find or read error text file ERR_...
