### PR TITLE
Close idle persistent connections to a CachePeer after reconfigure

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -10,6 +10,7 @@
 #include "acl/Gadgets.h"
 #include "CachePeer.h"
 #include "defines.h"
+#include "FwdState.h"
 #include "neighbors.h"
 #include "NeighborTypeDomainList.h"
 #include "pconn.h"
@@ -28,6 +29,8 @@ CachePeer::CachePeer(const char * const hostname):
 
 CachePeer::~CachePeer()
 {
+    fwdPconnPool->notePeerRemoved(this);
+
     xfree(name);
     xfree(host);
 

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -61,6 +61,9 @@ public:
     int count() const { return size_; }
     void closeN(size_t count);
 
+    // closes idle connections to a CachePeer before its deletion
+    void notePeerRemoved(const CachePeer *);
+
     // IndependentRunner API
     virtual void endingShutdown();
 private:
@@ -68,6 +71,7 @@ private:
     bool removeAt(int index);
     int findIndexOf(const Comm::ConnectionPointer &conn) const;
     void findAndClose(const Comm::ConnectionPointer &conn);
+    void closeByIndex(int);
     static IOCB Read;
     static CTCB Timeout;
 
@@ -145,6 +149,8 @@ public:
 
     // sends an async message to the pool manager, if any
     void notifyManager(const char *reason);
+    // adjusts idle connections to a CachePeer before its deletion
+    void notePeerRemoved(const CachePeer *);
 
 private:
 


### PR DESCRIPTION
The Connection object representing connection to a cache_peer has a
cbdata-protected CachePeer, becoming invalid after reconfiguration (when
old CachePeer objects are removed). Unaware of this,
HttpStateData sets its toOrigin flag and communicates to the peer
(via the old persistent connection) as with origin. This, in fact,
leads to the request URI built in the origin-form (instead of
absolute-form) and subsequently 400 Bad Request response
from the peer.

Now we close all persistent connections associated with removed
CachePeers.