### PR TITLE
Support multiple client connection annotations from helpers

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -762,14 +762,9 @@ HttpRequest::notes()
 void
 UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs const &helperNotes)
 {
-    // Tag client connection if the helper responded with clt_conn_tag=tag.
-    const char *cltTag = "clt_conn_tag";
-    if (const char *connTag = helperNotes.findFirst(cltTag)) {
-        if (csd) {
-            csd->notes()->remove(cltTag);
-            csd->notes()->add(cltTag, connTag);
-        }
-    }
+    // Tag client connection with all clt_conn_*=tag pairs.
+    static const SBuf cltConnPrefix("clt_conn_");
+    csd->notes()->replaceOrAddIf(&helperNotes, [&](const NotePairs::Entry::Pointer e) { return e->name().startsWith(cltConnPrefix); });
     request.notes()->replaceOrAdd(&helperNotes);
 }
 

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -214,6 +214,11 @@ public:
     /// Entries which do not exist in the destination set are added.
     void replaceOrAdd(const NotePairs *src);
 
+    /// same as replaceOrAdd() but ignore source elements for which
+    /// cond returns false
+    template <class Cond>
+    void replaceOrAddIf(const NotePairs *src, Cond cond);
+
     /// Append any new entries of the src NotePairs list to our list.
     /// Entries which already exist in the destination set are ignored.
     void appendNewOnly(const NotePairs *src);
@@ -261,6 +266,19 @@ public:
 private:
     Entries entries; ///< The key/value pair entries
 };
+
+
+template <class Cond>
+void
+NotePairs::replaceOrAddIf(const NotePairs *src, const Cond cond)
+{
+    for (const auto &e: src->entries) {
+        if (cond(e)) {
+            remove(e->name());
+            add(e->name(), e->value());
+        }
+    }
+}
 
 #endif
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1038,7 +1038,7 @@ DOC_START
 	  log=		String to be logged in access.log. Available as
 			%ea in logformat specifications.
 
-	  clt_conn_tag= Associates a TAG with the client TCP connection.
+	  clt_conn_*=	Associates a TAG with the client TCP connection.
 			Please see url_rewrite_program related documentation
 			for this kv-pair.
 
@@ -5955,10 +5955,10 @@ DOC_START
 	In addition to the kv-pairs mentioned above, Squid also understands
 	the following optional kv-pairs in URL rewriter responses:
 
-	  clt_conn_tag=TAG
+	  clt_conn_*=TAG
 		Associates a TAG with the client TCP connection.
 
-		The clt_conn_tag=TAG pair is treated as a regular transaction
+		Each clt_conn_*=TAG pair is treated as a regular transaction
 		annotation for the current request and also annotates future
 		requests on the same client connection. A helper may update
 		the TAG during subsequent requests by returning a new kv-pair.
@@ -6167,7 +6167,7 @@ DOC_START
 
 	In addition to the above kv-pairs Squid also understands the following
 	optional kv-pairs received from URL rewriters:
-	  clt_conn_tag=TAG
+	  clt_conn_*=TAG
 		Associates a TAG with the client TCP connection.
 		Please see url_rewrite_program related documentation for this
 		kv-pair

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -498,7 +498,7 @@ private:
     const char *stoppedSending_ = nullptr;
     /// the reason why we no longer read the request or nil
     const char *stoppedReceiving_ = nullptr;
-    /// Connection annotations, clt_conn_tag and other tags are stored here.
+    /// Connection annotations, such as clt_conn_* tags are stored here.
     /// If set, are propagated to the current and all future master transactions
     /// on the connection.
     NotePairs::Pointer theNotes;


### PR DESCRIPTION
Before this improvement, client connection annotation could contain a
single clt_conn_tag=TAG kv-pair. Now we add all kv-pairs matching
clt_conn_* pattern.

We also considered using the existing namespace mechanism (e.g.,
client_connection::) for this purpose, but rejected due to its
complexity compared with the simpler pattern-matching approach.