### PR TITLE
Do not kill Squid if parameters() file is empty or missing

### DIFF
--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -378,9 +378,7 @@ ConfigParser::NextToken()
 
             ConfigParser::CfgFile *wordfile = new ConfigParser::CfgFile();
             if (!path || !wordfile->startParse(path)) {
-                debugs(3, DBG_CRITICAL, "FATAL: Error opening config file: " << token);
                 delete wordfile;
-                self_destruct();
                 return nullptr;
             }
             CfgFiles.push(wordfile);
@@ -623,7 +621,11 @@ ConfigParser::CfgFile::startParse(char *path)
 #endif
 
     filePath = path;
-    return getFileLine();
+    if (!getFileLine()) {
+        debugs(3, DBG_CRITICAL, "WARNING: file: " << path << " is empty");
+        return false;
+    }
+    return true;
 }
 
 bool


### PR DESCRIPTION
We can provide ACL-specific arguments from external files in two ways:

* with the 'parameters' option, e.g.:
  acl allowlist dstdomain parameters("/path/to/filename")

* with the file name in double quotes, e,g.:
  acl allowlist dstdomain "/path/to/filename"

If the filename is empty or missing, ConfigParser aborts Squid
with a configuration error in the first case but just shows a
level 0 error message in the second. We need to handle both
cases similarly and let the ConfigParser caller decide whether
an empty or missing configuration is fatal or not.