### PR TITLE
Warn about bad from-helper annotations

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -764,7 +764,7 @@ UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs const &he
 {
     // Tag client connection if the helper responded with clt_conn_tag=tag.
     const char *cltTag = "clt_conn_tag";
-    if (const char *connTag = helperNotes.findFirst(cltTag)) {
+    if (const char *connTag = helperNotes.useFirst(cltTag)) {
         if (csd) {
             csd->notes()->remove(cltTag);
             csd->notes()->add(cltTag, connTag);

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -302,6 +302,29 @@ NotePairs::findFirst(const char *noteKey) const
     return nullptr;
 }
 
+const char *
+NotePairs::useFirst(const char * const noteKey) const
+{
+    const char *found = nullptr;
+    for (const auto &e: entries) {
+        if (e->name().cmp(noteKey) == 0) {
+            if (found) {
+                debugs(84, DBG_IMPORTANT, "WARNING: Ignoring repeated annotation from a helper: " <<
+                       e->name() << '=' << found << " and " <<
+                       e->name() << '=' << e->value());
+                // continue to warn about other annotations with this noteKey
+            } else {
+                // Return std::optional<SBuf> or throw instead.
+                found = const_cast<SBuf &>(e->value()).c_str();
+                if (e->used()) // already checked for repeated annotations
+                    return found;
+                e->markAsUsed();
+            }
+        }
+    }
+    return found; // may still be nil
+}
+
 void
 NotePairs::add(const char *key, const char *note)
 {

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -269,7 +269,7 @@ Notes::toString(const char *sep) const
 }
 
 bool
-NotePairs::find(SBuf &resultNote, const char *noteKey, const char *sep) const
+NotePairs::collectAllNamed(SBuf &resultNote, const char *noteKey, const char *sep) const
 {
     resultNote.clear();
     for (const auto &e: entries) {
@@ -280,6 +280,21 @@ NotePairs::find(SBuf &resultNote, const char *noteKey, const char *sep) const
         }
     }
     return resultNote.length();
+}
+
+bool
+NotePairs::useAllNamed(SBuf &result, const char *noteKey, const char *sep) const
+{
+    result.clear();
+    for (const auto &e: entries) {
+        if (e->name().cmp(noteKey) == 0) {
+            if (!result.isEmpty())
+                result.append(sep);
+            result.append(e->value());
+            e->markAsUsed();
+        }
+    }
+    return result.length();
 }
 
 const char *

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -309,15 +309,6 @@ NotePairs::toString(const char *sep) const
 }
 
 const char *
-NotePairs::findFirst(const char *noteKey) const
-{
-    for (const auto &e: entries)
-        if (!e->name().cmp(noteKey))
-            return const_cast<SBuf &>(e->value()).c_str();
-    return nullptr;
-}
-
-const char *
 NotePairs::useFirst(const char * const noteKey) const
 {
     const char *found = nullptr;

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -332,6 +332,25 @@ NotePairs::useFirst(const char * const noteKey) const
 }
 
 void
+NotePairs::checkForUnused() const
+{
+    for (const auto &e: entries) {
+        if (e->used())
+            continue;
+
+        if (!e->name().isEmpty() && *e->name().rbegin() == '_')
+            continue; // reserved for admin use which may happen later
+
+        debugs(84, DBG_IMPORTANT, "WARNING: Unsupported or unexpected helper annotation with a name reserved for Squid use: " <<
+               e->name() << '=' << e->value() <<
+               Debug::Extra << "advice: If this is a custom annotation, rename it to add a trailing underscore: " <<
+               e->name() << '_');
+
+        // continue to warn about other unused annotations
+    }
+}
+
+void
 NotePairs::add(const char *key, const char *note)
 {
     entries.push_back(new NotePairs::Entry(key, note));

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -241,6 +241,9 @@ public:
     /// Side effect: Warns about multiple same-name notes.
     const char *useFirst(const char *noteKey) const;
 
+    /// inform the admin about any unused entries
+    void checkForUnused() const;
+
     /// Adds a note key and value to the notes list.
     /// If the key name already exists in the list, add the given value to its set
     /// of values.

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -232,10 +232,11 @@ public:
     bool find(SBuf &resultNote, const char *noteKey, const char *sep = ",") const;
 
     /// \returns the first note value for this key or an empty string.
-    const char *findFirst(const char *noteKey) const;
+    [[deprecated("use useFirst() instead")]] const char *findFirst(const char *noteKey) const;
 
     /// The value of the first note with the given name (or nil).
     /// Side effect: Marks the matching note as used.
+    /// Side effect: Warns about multiple same-name notes.
     const char *useFirst(const char *noteKey) const;
 
     /// Adds a note key and value to the notes list.

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -226,10 +226,15 @@ public:
     /// Entries which already exist in the destination set are ignored.
     void appendNewOnly(const NotePairs *src);
 
-    /// \param resultNote a comma separated list of notes with key 'noteKey'.
-    /// \returns true if there are entries with the given 'noteKey'.
-    /// Use findFirst() instead when a unique kv-pair is needed.
-    bool find(SBuf &resultNote, const char *noteKey, const char *sep = ",") const;
+    /// writes all note values with a given key into the given buffer
+    /// \param result a sep-delimited list of note values with the given key
+    /// \param sep value delimiter to use between written values
+    /// \returns true if at least one value was written
+    bool collectAllNamed(SBuf &result, const char *noteKey, const char *sep = ",") const;
+
+    /// \copydoc collectAllNamed()
+    /// Side effect: Marks the matching notes as used.
+    bool useAllNamed(SBuf &result, const char *noteKey, const char *sep = ",") const;
 
     /// \returns the first note value for this key or an empty string.
     [[deprecated("use useFirst() instead")]] const char *findFirst(const char *noteKey) const;

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -191,9 +191,17 @@ public:
         const SBuf &name() const { return theName; }
         const SBuf &value() const { return theValue; }
 
+        /// whether markAsUsed() has been called
+        bool used() const { return used_; }
+
+        /// whether response processing code has requested this note by name
+        void markAsUsed() { used_ = true; }
+
     private:
         SBuf theName;
         SBuf theValue;
+
+        mutable bool used_ = false; ///< \copydoc markAsUsed()
     };
     typedef std::vector<Entry::Pointer> Entries;      ///< The key/value pair entries
     typedef std::vector<SBuf> Names;
@@ -225,6 +233,10 @@ public:
 
     /// \returns the first note value for this key or an empty string.
     const char *findFirst(const char *noteKey) const;
+
+    /// The value of the first note with the given name (or nil).
+    /// Side effect: Marks the matching note as used.
+    const char *useFirst(const char *noteKey) const;
 
     /// Adds a note key and value to the notes list.
     /// If the key name already exists in the list, add the given value to its set

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -236,9 +236,6 @@ public:
     /// Side effect: Marks the matching notes as used.
     bool useAllNamed(SBuf &result, const char *noteKey, const char *sep = ",") const;
 
-    /// \returns the first note value for this key or an empty string.
-    [[deprecated("use useFirst() instead")]] const char *findFirst(const char *noteKey) const;
-
     /// The value of the first note with the given name (or nil).
     /// Side effect: Marks the matching note as used.
     /// Side effect: Warns about multiple same-name notes.

--- a/src/auth/UserRequest.cc
+++ b/src/auth/UserRequest.cc
@@ -564,7 +564,7 @@ void
 Auth::UserRequest::denyMessageFromHelper(const char *proto, const Helper::Reply &reply)
 {
     static SBuf messageNote;
-    if (!reply.notes.find(messageNote, "message")) {
+    if (!reply.notes.useAllNamed(messageNote, "message")) {
         messageNote.append(proto);
         messageNote.append(" Authentication denied with no reason given");
     }

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -345,7 +345,7 @@ Auth::Digest::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
         Auth::Digest::User *digest_user = dynamic_cast<Auth::Digest::User *>(auth_user_request->user().getRaw());
         assert(digest_user != nullptr);
 
-        if (const char *ha1Note = reply.notes.findFirst("ha1")) {
+        if (const char *ha1Note = reply.notes.useFirst("ha1")) {
             CvtBin(ha1Note, digest_user->HA1);
             digest_user->HA1created = 1;
         } else {

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -372,7 +372,7 @@ Auth::Digest::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
         digest_request->flags.invalid_password = true;
 
         SBuf msgNote;
-        if (reply.notes.find(msgNote, "message")) {
+        if (reply.notes.useAllNamed(msgNote, "message")) {
             digest_request->setDenyMessage(msgNote.c_str());
         } else if (reply.other().hasContent()) {
             // old helpers did send ERR result but a bare message string instead of message= key name.

--- a/src/auth/negotiate/UserRequest.cc
+++ b/src/auth/negotiate/UserRequest.cc
@@ -303,7 +303,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
         safe_free(lm_request->server_blob);
         lm_request->request->flags.mustKeepalive = true;
         if (lm_request->request->flags.proxyKeepalive) {
-            const char *tokenNote = reply.notes.findFirst("token");
+            const char *tokenNote = reply.notes.useFirst("token");
             lm_request->server_blob = xstrdup(tokenNote);
             auth_user_request->user()->credentials(Auth::Handshake);
             auth_user_request->setDenyMessage("Authentication in progress");
@@ -315,8 +315,8 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
         break;
 
     case Helper::Okay: {
-        const char *userNote = reply.notes.findFirst("user");
-        const char *tokenNote = reply.notes.findFirst("token");
+        const char *userNote = reply.notes.useFirst("user");
+        const char *tokenNote = reply.notes.useFirst("token");
         if (userNote == nullptr || tokenNote == nullptr) {
             // XXX: handle a success with no username better
             /* protocol error */
@@ -360,7 +360,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
         auth_user_request->denyMessageFromHelper("Negotiate", reply);
         auth_user_request->user()->credentials(Auth::Failed);
         safe_free(lm_request->server_blob);
-        if (const char *tokenNote = reply.notes.findFirst("token"))
+        if (const char *tokenNote = reply.notes.useFirst("token"))
             lm_request->server_blob = xstrdup(tokenNote);
         lm_request->releaseAuthServer();
         debugs(29, 4, "Failed validating user via Negotiate. Result: " << reply);

--- a/src/auth/ntlm/UserRequest.cc
+++ b/src/auth/ntlm/UserRequest.cc
@@ -297,7 +297,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
         safe_free(lm_request->server_blob);
         lm_request->request->flags.mustKeepalive = true;
         if (lm_request->request->flags.proxyKeepalive) {
-            const char *serverBlob = reply.notes.findFirst("token");
+            const char *serverBlob = reply.notes.useFirst("token");
             lm_request->server_blob = xstrdup(serverBlob);
             auth_user_request->user()->credentials(Auth::Handshake);
             auth_user_request->setDenyMessage("Authentication in progress");
@@ -310,7 +310,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 
     case Helper::Okay: {
         /* we're finished, release the helper */
-        const char *userLabel = reply.notes.findFirst("user");
+        const char *userLabel = reply.notes.useFirst("user");
         if (!userLabel) {
             auth_user_request->user()->credentials(Auth::Failed);
             safe_free(lm_request->server_blob);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1181,8 +1181,8 @@ ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
         // #2: redirect with a default status code     OK url="..."
         // #3: re-write the URL                        OK rewrite-url="..."
 
-        const char *statusNote = reply.notes.findFirst("status");
-        const char *urlNote = reply.notes.findFirst("url");
+        const char *statusNote = reply.notes.useFirst("status");
+        const char *urlNote = reply.notes.useFirst("url");
 
         if (urlNote != nullptr) {
             // HTTP protocol redirect to be done.
@@ -1211,7 +1211,7 @@ ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
             }
         } else {
             // URL-rewrite wanted. Ew.
-            urlNote = reply.notes.findFirst("rewrite-url");
+            urlNote = reply.notes.useFirst("rewrite-url");
 
             // prevent broken helpers causing too much damage. If old URL == new URL skip the re-write.
             if (urlNote != nullptr && strcmp(urlNote, http->uri)) {
@@ -1290,7 +1290,7 @@ ClientRequestContext::clientStoreIdDone(const Helper::Reply &reply)
         break;
 
     case Helper::Okay: {
-        const char *urlNote = reply.notes.findFirst("store-id");
+        const char *urlNote = reply.notes.useFirst("store-id");
 
         // prevent broken helpers causing too much damage. If old URL == new URL skip the re-write.
         if (urlNote != nullptr && strcmp(urlNote, http->uri) ) {

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -968,6 +968,10 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
 
     entryData.notes.append(&reply.notes);
 
+    // Mark this annotations as recognized. If everything goes well, its _copy_
+    // (see XXX and append() above) will be used later, in UpdateRequestNotes().
+    (void)reply.notes.useFirst("clt_conn_tag");
+
     const char *label = reply.notes.useFirst("tag");
     if (label != nullptr && *label != '\0')
         entryData.tag = label;

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -968,24 +968,24 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
 
     entryData.notes.append(&reply.notes);
 
-    const char *label = reply.notes.findFirst("tag");
+    const char *label = reply.notes.useFirst("tag");
     if (label != nullptr && *label != '\0')
         entryData.tag = label;
 
-    label = reply.notes.findFirst("message");
+    label = reply.notes.useFirst("message");
     if (label != nullptr && *label != '\0')
         entryData.message = label;
 
-    label = reply.notes.findFirst("log");
+    label = reply.notes.useFirst("log");
     if (label != nullptr && *label != '\0')
         entryData.log = label;
 
 #if USE_AUTH
-    label = reply.notes.findFirst("user");
+    label = reply.notes.useFirst("user");
     if (label != nullptr && *label != '\0')
         entryData.user = label;
 
-    label = reply.notes.findFirst("password");
+    label = reply.notes.useFirst("password");
     if (label != nullptr && *label != '\0')
         entryData.password = label;
 #endif

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1370,12 +1370,12 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
 #if USE_ADAPTATION
                 Adaptation::History::Pointer ah = al->request ? al->request->adaptHistory() : Adaptation::History::Pointer();
                 if (ah && ah->metaHeaders) {
-                    if (ah->metaHeaders->find(note, fmt->data.header.header, separator))
+                    if (ah->metaHeaders->collectAllNamed(note, fmt->data.header.header, separator))
                         sb.append(note);
                 }
 #endif
                 if (al->notes) {
-                    if (al->notes->find(note, fmt->data.header.header, separator)) {
+                    if (al->notes->collectAllNamed(note, fmt->data.header.header, separator)) {
                         if (!sb.isEmpty())
                             sb.append(separator);
                         sb.append(note);

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -935,11 +935,9 @@ helperReturnBuffer(helper_server * srv, helper * hlp, char * msg, size_t msgSize
                 debugs(84, DBG_IMPORTANT, "ERROR: helper: " << r->reply << ", attempt #" << (r->request.retries + 1) << " of 2");
                 retry = true;
             } else {
-                HLPCB *callback = r->request.callback;
-                r->request.callback = nullptr;
                 void *cbdata = nullptr;
                 if (cbdataReferenceValidDone(r->request.data, &cbdata))
-                    callback(cbdata, r->reply);
+                    r->request.callback(cbdata, r->reply);
             }
         }
 

--- a/src/helper/Request.h
+++ b/src/helper/Request.h
@@ -44,12 +44,11 @@ public:
 
         assert(callback_);
 
-        // TODO: Warn about unused recognized annotations:
-        // reply.notes.checkForUnused();
-
         const auto cb = callback_;
         callback_ = nullptr;
         cb(validatedCbdata, reply);
+
+        reply.notes.checkForUnused();
     }
 
     char *buf;

--- a/src/helper/Request.h
+++ b/src/helper/Request.h
@@ -22,11 +22,11 @@ class Request
 public:
     Request(HLPCB *c, void *d, const char *b) :
         buf(b ? xstrdup(b) : nullptr),
-        callback(c),
         data(cbdataReference(d)),
         placeholder(b == nullptr),
         Id(0),
-        retries(0)
+        retries(0),
+        callback_(c)
     {
         memset(&dispatch_time, 0, sizeof(dispatch_time));
     }
@@ -36,8 +36,23 @@ public:
         xfree(buf);
     }
 
+    /// Forward helper response (or its equivalent) to the requestor. XXX: The
+    /// caller must check the cbdataReferenceValid() precondition. TODO: Move
+    /// that checking code into this method by refactoring callers.
+    void callback(void * const validatedCbdata, const Reply &reply) {
+        // TODO: Move to a src/helper/Request.cc.
+
+        assert(callback_);
+
+        // TODO: Warn about unused recognized annotations:
+        // reply.notes.checkForUnused();
+
+        const auto cb = callback_;
+        callback_ = nullptr;
+        cb(validatedCbdata, reply);
+    }
+
     char *buf;
-    HLPCB *callback;
     void *data;
 
     int placeholder;            /* if 1, this is a dummy request waiting for a stateful helper to become available */
@@ -51,6 +66,9 @@ public:
      */
     int retries;
     bool timedOut(time_t timeout) {return (squid_curtime - dispatch_time.tv_sec) > timeout;}
+
+private:
+    HLPCB *callback_; ///< where to send the final outcome of helper transaction(s)
 };
 
 } // namespace Helper


### PR DESCRIPTION
This change adds runtime warnings about bad annotations from several,
partially overlapping, categories:

1. Annotations that this Squid version does not know about at all.
   Future Squids may start using them specially. Example: "group".

2. Annotations unused by this Squid build. Example: Squid ./configured
   with --disable-auth does not use "user" and "password" annotations
   received from an external ACL helper.

3. Annotations incompatible with the current helper response type/kind.
   Example: Digest authentication code does not use "ha1" annotation in
   ERR responses received from digest authentication helpers.

4. Annotations with repeated names (only first of them will be used).
   Example: "user" in OK replies from negotiate authentication helpers.

The above list of bad annotations and the following design notes
implicitly exclude annotations with a name ending with an underscore.
Those annotations are reserved for admin exclusive use. They may cause
problems as well, but this change does not warn about them.

    WARNING: Unsupported or unexpected helper annotation with a name
    reserved for Squid use: foo=bar
    advice: If this is a custom annotation, rename it to add a trailing
    underscore: foo_

The change design is based on a simple idea: We adjust NotePairs
annotation-searching methods to mark requested annotations as "used" or
"recognized". Once the helper response is processed, we warn the admin
about unmarked annotations. This design allows correct detection of
complex use cases (e.g., categories 2-4 above).

The design relies on synchronous, immediate processing of a helper
response (up to the point where all good annotations that are looked up
at least once). Eventually, helper response callbacks will become async.
At that time, we would have to trigger the check from each callback, so
that a naturally disappearing job (e.g., due to an early client
disconnect) would not trigger warnings about unused helper response
annotations. There may be other reasons to postpone these checks (e.g.,
up to the using transaction termination time).

The "clt_conn_tag" complication in the external ACL code (caused by the
intersection of an old XXX and this change design) demonstrates the
primary weakness of this design: It is difficult to know/control the
exact use/check order in complex, asynchronous, and often messy code.
