### PR TITLE
Fix access logging of truncated responses

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -410,7 +410,10 @@ ClientHttpRequest::logRequest()
 
     al->cache.highOffset = out.offset;
 
-    al->cache.code = logType;
+    // TODO: move into a new LogTags method
+    al->cache.code.update(logType.oldType);
+    al->cache.code.err.update(logType.err);
+    al->cache.code.collapsingHistory = logType.collapsingHistory;
 
     tvSub(al->cache.trTime, al->cache.start_time, current_time);
 


### PR DESCRIPTION
When logging transactions involving truncated server responses,
the following format code details were missing:

1. _ABORTED or _TIMEOUT suffixes in %Ss format code

2. %err_code and %err_detail were not logged at all

(1) occurred because LogTagsErrors in ALE (filled
after detecting a truncated response) were overwritten
(rather than updated) with empty values.

(2) occurred because ALE::error_ was not filled when
receiving premature EOF. 