### PR TITLE
Hard-code the manager ACL

### DIFF
--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -54,6 +54,7 @@
 #include "acl/Ip.h"
 #include "acl/LocalIp.h"
 #include "acl/LocalPort.h"
+#include "acl/Manager.h"
 #include "acl/MaxConnection.h"
 #include "acl/Method.h"
 #include "acl/MethodData.h"
@@ -160,6 +161,7 @@ Acl::Init()
     RegisterMaker("annotate_transaction", [](TypeName name)->ACL* { return new ACLStrategised<NotePairs::Entry*>(new ACLAnnotationData, new ACLAnnotateTransactionStrategy, name); });
     RegisterMaker("has", [](TypeName name)->ACL* {return new ACLStrategised<ACLChecklist *>(new ACLHasComponentData, new ACLHasComponentStrategy, name); });
     RegisterMaker("transaction_initiator", [](TypeName name)->ACL* {return new TransactionInitiator(name);});
+    RegisterMaker("manager_type", [](TypeName name)->ACL* {return new ACLManager(name);});
 
 #if USE_LIBNETFILTERCONNTRACK
     RegisterMaker("clientside_mark", [](TypeName)->ACL* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -252,10 +252,6 @@ ACL::ParseAclLine(ConfigParser &parser, ACL **)
         }
         theType = "localport";
         debugs(28, DBG_IMPORTANT, "WARNING: UPGRADE: ACL 'myport' type has been renamed to 'localport' and matches the port the client connected to.");
-    } else if (strcmp(theType, "proto") == 0 && strcmp(aclname, "manager") == 0) {
-        // ACL manager is now a built-in and has a different type.
-        debugs(28, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: UPGRADE: ACL 'manager' is now a built-in ACL. Remove it from your config file.");
-        return; // ignore the line
     } else if (strcmp(theType, "clientside_mark") == 0) {
         debugs(28, DBG_IMPORTANT, "WARNING: UPGRADE: ACL 'clientside_mark' type has been renamed to 'client_connection_mark'.");
         theType = "client_connection_mark";
@@ -267,7 +263,10 @@ ACL::ParseAclLine(ConfigParser &parser, ACL **)
         A->context(aclname, config_input_line);
         new_acl = 1;
     } else {
-        if (strcmp (A->typeString(),theType) ) {
+        if (Acl::IsPredefined(A->typeString())) {
+            debugs(28, DBG_IMPORTANT, "WARNING: ACL " << A->name << " is now a pre-defined ACL. Remove it from your config file.");
+            return; // ignore the line
+        } else if (strcmp (A->typeString(),theType) ) {
             debugs(28, DBG_CRITICAL, "aclParseAclLine: ACL '" << A->name << "' already exists with different type.");
             parser.destruct();
             return;

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -46,6 +46,8 @@ public:
     static void ParseAclLine(ConfigParser &parser, ACL ** head);
     static void Initialize();
     static ACL *FindByName(const char *name);
+    /// creates hard-coded ACLs such as manager ACL
+    static void CreatePredefined();
 
     ACL();
     ACL(ACL &&) = delete; // no copying of any kind

--- a/src/acl/Makefile.am
+++ b/src/acl/Makefile.am
@@ -102,6 +102,8 @@ libacls_la_SOURCES = \
 	LocalIp.h \
 	LocalPort.cc \
 	LocalPort.h \
+	Manager.cc \
+	Manager.h \
 	MaxConnection.cc \
 	MaxConnection.h \
 	Method.cc \

--- a/src/acl/Manager.cc
+++ b/src/acl/Manager.cc
@@ -33,6 +33,6 @@ ACLManager::match(ACLChecklist *checklist)
 void
 ACLManager::parse()
 {
-    TextException(ToSBuf("cannot parse predefined ", class_), Here());
+    TextException(ToSBuf("cannot parse pre-sdefined ", class_), Here());
 }
 

--- a/src/acl/Manager.cc
+++ b/src/acl/Manager.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "acl/FilledChecklist.h"
+#include "acl/Manager.h"
+#include "anyp/ProtocolType.h"
+#include "base/TextException.h"
+#include "HttpRequest.h"
+#include "sbuf/Stream.h"
+
+SBufList
+ACLManager::dump() const
+{
+    SBufList sl;
+    sl.push_back(SBuf(name));
+    return sl;
+}
+
+int
+ACLManager::match(ACLChecklist *checklist)
+{
+    static const SBuf mgrPfx("/squid-internal-mgr/");
+    const auto request = Filled(checklist)->request;
+    return request->url.path().startsWith(mgrPfx) || request->url.getScheme() == AnyP::PROTO_CACHE_OBJECT;
+}
+
+void
+ACLManager::parse()
+{
+    TextException(ToSBuf("cannot parse predefined ", class_), Here());
+}
+

--- a/src/acl/Manager.h
+++ b/src/acl/Manager.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_ACLMANAGER_H
+#define SQUID_ACLMANAGER_H
+
+#include "acl/Acl.h"
+
+class ACLManager : public ACL
+{
+    MEMPROXY_CLASS(ACLManager);
+
+public:
+    ACLManager(char const *aClass) : class_(aClass) { context("manager", nullptr); }
+
+    /* ACL API */
+    char const *typeString() const override { return class_; }
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    bool requiresRequest() const override { return true; }
+    SBufList dump() const override;
+    bool empty () const override { return false; }
+
+private:
+    char const *class_;
+};
+
+#endif
+

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -604,6 +604,11 @@ parseConfigFileOrThrow(const char *file_name)
     configFreeMemory();
 
     ACLMethodData::ThePurgeCount = 0;
+
+    // hard-coded ACLs must be created before parsing
+    // ACL-related configuration lines
+    ACL::CreatePredefined();
+
     default_all();
 
     err_count = parseOneConfigFile(file_name, 0);

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1068,7 +1068,6 @@ DEFAULT: ssl::certUntrusted ssl_error X509_V_ERR_INVALID_CA X509_V_ERR_SELF_SIGN
 DEFAULT: ssl::certSelfSigned ssl_error X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
 ENDIF
 DEFAULT: all src all
-DEFAULT: manager url_regex -i ^cache_object:// +i ^[^:]+://[^/]+/squid-internal-mgr/
 DEFAULT: localhost src 127.0.0.1/32 ::1
 DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1/128 ::/128
 DEFAULT: to_linklocal dst 169.254.0.0/16 fe80::/10


### PR DESCRIPTION
The manager ACL used to be a version-dependent default ACL.  Admins
could extend it by adding custom acl manager ... rules, thinking that
this would affect which requests Squid will treat as cache manager
requests (not forwarded upstream). However, in reality, Squid has a
hard-coded logic that determines which requests are treated as cache
manager requests. This logic is unaffected by the manager ACL. Such
disconnect between the manager ACL and Squid code could lead to
misconfigurations and bugs.

To avoid these problems, manager ACL was made hard-coded,
old manager ACL rules in squid.conf are warned about and ignored.