### PR TITLE
Drop cache_object protocol support

### DIFF
--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -37,11 +37,13 @@ The Squid-6 change history can be <url url="http://www.squid-cache.org/Versions/
 
 <p>The most important of these new features are:
 <itemize>
-	<item>No new features documented yet.
+	<item>cache_object scheme removal
 </itemize>
 
 Most user-facing changes are reflected in squid.conf (see below).
 
+<sect1>cache_object scheme removal
+<p>The Squid cache manager is not accessible by cache_object:// URL scheme anymore. Removed its support from squidclient tool and CGI cache manager tool.
 
 <sect>Changes to squid.conf since Squid-5
 <p>

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -343,8 +343,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
      * be allowed.  yuck, I know.
      */
 
-    if ( Config.accessList.miss && !request->client_addr.isNoAddr() &&
-            !request->flags.internal && request->url.getScheme() != AnyP::PROTO_CACHE_OBJECT) {
+    if ( Config.accessList.miss && !request->client_addr.isNoAddr() && !request->flags.internal) {
         /**
          * Check if this host is allowed to fetch MISSES from us (miss_access).
          * Intentionally replace the src_addr automatically selected by the checklist code
@@ -392,11 +391,6 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
     }
 
     switch (request->url.getScheme()) {
-
-    case AnyP::PROTO_CACHE_OBJECT:
-        debugs(17, 2, "calling CacheManager due to request scheme " << request->url.getScheme());
-        CacheManager::GetInstance()->start(clientConn, request, entry, al);
-        return;
 
     case AnyP::PROTO_URN:
         urnStart(request, entry, al);
@@ -1277,8 +1271,6 @@ FwdState::dispatch()
             else
                 Ftp::StartGateway(this);
             break;
-
-        case AnyP::PROTO_CACHE_OBJECT:
 
         case AnyP::PROTO_URN:
             fatal_dump("Should never get here");

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -544,6 +544,8 @@ HttpRequest::maybeCacheable()
     if (!flags.hostVerified && (flags.intercepted || flags.interceptTproxy))
         return false;
 
+    /// XXX: handle squid-internal-mgr requests
+
     switch (url.getScheme()) {
     case AnyP::PROTO_HTTP:
     case AnyP::PROTO_HTTPS:
@@ -559,9 +561,6 @@ HttpRequest::maybeCacheable()
         if (!flags.ignoreCc && cache_control && cache_control->hasNoStore())
             return false;
         break;
-
-    case AnyP::PROTO_CACHE_OBJECT:
-        return false;
 
     //case AnyP::PROTO_FTP:
     default:

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -544,8 +544,6 @@ HttpRequest::maybeCacheable()
     if (!flags.hostVerified && (flags.intercepted || flags.interceptTproxy))
         return false;
 
-    /// XXX: handle squid-internal-mgr requests
-
     switch (url.getScheme()) {
     case AnyP::PROTO_HTTP:
     case AnyP::PROTO_HTTPS:

--- a/src/adaptation/ecap/Host.cc
+++ b/src/adaptation/ecap/Host.cc
@@ -21,7 +21,6 @@
 #include "MasterXaction.h"
 
 const libecap::Name Adaptation::Ecap::protocolInternal("internal", libecap::Name::NextId());
-const libecap::Name Adaptation::Ecap::protocolCacheObj("cache_object", libecap::Name::NextId());
 const libecap::Name Adaptation::Ecap::protocolIcp("ICP", libecap::Name::NextId());
 #if USE_HTCP
 const libecap::Name Adaptation::Ecap::protocolHtcp("Htcp", libecap::Name::NextId());
@@ -52,7 +51,6 @@ Adaptation::Ecap::Host::Host()
     libecap::protocolWais.assignHostId(AnyP::PROTO_WAIS);
     libecap::protocolUrn.assignHostId(AnyP::PROTO_URN);
     libecap::protocolWhois.assignHostId(AnyP::PROTO_WHOIS);
-    protocolCacheObj.assignHostId(AnyP::PROTO_CACHE_OBJECT);
     protocolIcp.assignHostId(AnyP::PROTO_ICP);
 #if USE_HTCP
     protocolHtcp.assignHostId(AnyP::PROTO_HTCP);

--- a/src/adaptation/ecap/MessageRep.cc
+++ b/src/adaptation/ecap/MessageRep.cc
@@ -152,8 +152,6 @@ Adaptation::Ecap::FirstLineRep::protocol() const
     case AnyP::PROTO_HTCP:
         return protocolHtcp;
 #endif
-    case AnyP::PROTO_CACHE_OBJECT:
-        return protocolCacheObj;
     case AnyP::PROTO_ICY:
         return protocolIcy;
     case AnyP::PROTO_COAP:

--- a/src/anyp/ProtocolType.h
+++ b/src/anyp/ProtocolType.h
@@ -28,7 +28,6 @@ typedef enum {
     PROTO_COAP,
     PROTO_COAPS,
     PROTO_WAIS,
-    PROTO_CACHE_OBJECT,
     PROTO_ICP,
 #if USE_HTCP
     PROTO_HTCP,

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -193,9 +193,6 @@ uriParseScheme(Parser::Tokenizer &tok)
      * Scheme names consist of a sequence of characters beginning with a
      * letter and followed by any combination of letters, digits, plus
      * ("+"), period ("."), or hyphen ("-").
-     *
-     * The underscore ("_") required to match "cache_object://" squid
-     * special URI scheme.
      */
     static const auto schemeChars =
 #if USE_HTTP_VIOLATIONS
@@ -859,7 +856,6 @@ urlCheckRequest(const HttpRequest * r)
 
     case AnyP::PROTO_URN:
     case AnyP::PROTO_HTTP:
-    case AnyP::PROTO_CACHE_OBJECT:
         return true;
 
     case AnyP::PROTO_FTP:

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -194,11 +194,7 @@ uriParseScheme(Parser::Tokenizer &tok)
      * letter and followed by any combination of letters, digits, plus
      * ("+"), period ("."), or hyphen ("-").
      */
-    static const auto schemeChars =
-#if USE_HTTP_VIOLATIONS
-        CharacterSet("special", "_") +
-#endif
-        CharacterSet("scheme", "+.-") + CharacterSet::ALPHA + CharacterSet::DIGIT;
+    static const auto schemeChars = CharacterSet("scheme", "+.-") + CharacterSet::ALPHA + CharacterSet::DIGIT;
 
     SBuf str;
     if (tok.prefix(str, schemeChars, 16) && tok.skip(':') && CharacterSet::ALPHA[str.at(0)]) {

--- a/src/anyp/UriScheme.cc
+++ b/src/anyp/UriScheme.cc
@@ -90,9 +90,6 @@ AnyP::UriScheme::defaultPort() const
     case AnyP::PROTO_WAIS:
         return 210;
 
-    case AnyP::PROTO_CACHE_OBJECT:
-        return CACHE_HTTP_PORT;
-
     case AnyP::PROTO_WHOIS:
         return 43;
 

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -227,10 +227,13 @@ CacheManager::ParseHeaders(const HttpRequest * request, Mgr::ActionParams &param
     // TODO: use the authentication system decode to retrieve these details properly.
 
     /* base 64 _decoded_ user:passwd pair */
-    const auto basic_cookie(request->header.getAuthToken(Http::HdrType::PROXY_AUTHORIZATION, "Basic"));
+    auto basic_cookie(request->header.getAuthToken(Http::HdrType::AUTHORIZATION, "Basic"));
 
-    if (basic_cookie.isEmpty())
-        return;
+    if (basic_cookie.isEmpty()) {
+        basic_cookie = request->header.getAuthToken(Http::HdrType::PROXY_AUTHORIZATION, "Basic");
+        if (basic_cookie.isEmpty())
+            return;
+    }
 
     const auto colonPos = basic_cookie.find(':');
     if (colonPos == SBuf::npos) {

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -150,13 +150,6 @@ CacheManager::createRequestedAction(const Mgr::ActionParams &params)
     return cmd->profile->creator->create(cmd);
 }
 
-static const CharacterSet &
-MgrFieldChars()
-{
-    static const CharacterSet actionChars = CharacterSet("mgr-field", "?#").complement();
-    return actionChars;
-}
-
 /**
  * define whether the URL is a cache-manager URL and parse the action
  * requested by the user. Checks via CacheManager::ActionProtection() that the
@@ -182,7 +175,7 @@ CacheManager::ParseUrl(const AnyP::Uri &uri)
     Mgr::Command::Pointer cmd = new Mgr::Command();
     cmd->params.httpUri = SBufToString(uri.absolute());
 
-    const auto &fieldChars = MgrFieldChars();
+    static const auto fieldChars = CharacterSet("mgr-field", "?#").complement();
 
     SBuf action;
     if (!tok.prefix(action, fieldChars)) {
@@ -234,7 +227,7 @@ CacheManager::ParseHeaders(const HttpRequest * request, Mgr::ActionParams &param
     // TODO: use the authentication system decode to retrieve these details properly.
 
     /* base 64 _decoded_ user:passwd pair */
-    const auto basic_cookie(request->header.getAuthToken(Http::HdrType::AUTHORIZATION, "Basic"));
+    const auto basic_cookie(request->header.getAuthToken(Http::HdrType::PROXY_AUTHORIZATION, "Basic"));
 
     if (basic_cookie.isEmpty())
         return;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1068,7 +1068,7 @@ DEFAULT: ssl::certUntrusted ssl_error X509_V_ERR_INVALID_CA X509_V_ERR_SELF_SIGN
 DEFAULT: ssl::certSelfSigned ssl_error X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
 ENDIF
 DEFAULT: all src all
-DEFAULT: manager url_regex -i ^cache_object:// +i ^[^:]+://[^/]+/squid-internal-mgr/
+DEFAULT: manager url_regex +i ^[^:]+://[^/]+/squid-internal-mgr/
 DEFAULT: localhost src 127.0.0.1/32 ::1
 DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1/128 ::/128
 DEFAULT: to_linklocal dst 169.254.0.0/16 fe80::/10

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1120,10 +1120,6 @@ prepareAcceleratedURL(ConnStateData * conn, const Http1::RequestParserPointer &h
 
     /* BUG: Squid cannot deal with '*' URLs (RFC2616 5.1.2) */
 
-    static const SBuf cache_object("cache_object://");
-    if (hp->requestUri().startsWith(cache_object))
-        return nullptr; /* already in good shape */
-
     // XXX: re-use proper URL parser for this
     SBuf url = hp->requestUri(); // use full provided URI if we abort
     do { // use a loop so we can break out of it

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -909,9 +909,6 @@ clientHierarchical(ClientHttpRequest * http)
     if (request->url.getScheme() == AnyP::PROTO_HTTP)
         return method.respMaybeCacheable();
 
-    if (request->url.getScheme() == AnyP::PROTO_CACHE_OBJECT)
-        return 0;
-
     return 1;
 }
 

--- a/src/tests/testCacheManager.cc
+++ b/src/tests/testCacheManager.cc
@@ -82,7 +82,6 @@ testCacheManager::testParseUrl()
     CPPUNIT_ASSERT(mgr != nullptr);
 
     std::vector<AnyP::ProtocolType> validSchemes = {
-        AnyP::PROTO_CACHE_OBJECT,
         AnyP::PROTO_HTTP,
         AnyP::PROTO_HTTPS,
         AnyP::PROTO_FTP
@@ -162,8 +161,8 @@ testCacheManager::testParseUrl()
 
         for (const auto *magic : magicPrefixes) {
 
-            // all schemes except cache_object require magic path prefix bytes
-            if (scheme != AnyP::PROTO_CACHE_OBJECT && strlen(magic) <= 2)
+            // all schemes require magic path prefix bytes
+            if (strlen(magic) <= 2)
                 continue;
 
             /* Check the parser accepts all the valid cases */

--- a/src/tests/testUriScheme.cc
+++ b/src/tests/testUriScheme.cc
@@ -96,7 +96,7 @@ testUriScheme::testEqualprotocol_t()
     CPPUNIT_ASSERT(AnyP::UriScheme() == AnyP::PROTO_NONE);
     CPPUNIT_ASSERT(not (AnyP::UriScheme(AnyP::PROTO_WAIS) == AnyP::PROTO_HTTP));
     CPPUNIT_ASSERT(AnyP::PROTO_HTTP == AnyP::UriScheme(AnyP::PROTO_HTTP));
-    CPPUNIT_ASSERT(not (AnyP::PROTO_FTP == AnyP::UriScheme(AnyP::PROTO_HTTP)));
+    CPPUNIT_ASSERT(not (AnyP::PROTO_HTTPS == AnyP::UriScheme(AnyP::PROTO_HTTP)));
 }
 
 /*

--- a/src/tests/testUriScheme.cc
+++ b/src/tests/testUriScheme.cc
@@ -69,7 +69,7 @@ testUriScheme::testConstructprotocol_t()
     AnyP::UriScheme lhs_none(AnyP::PROTO_NONE), rhs_none(AnyP::PROTO_NONE);
     CPPUNIT_ASSERT_EQUAL(lhs_none, rhs_none);
 
-    AnyP::UriScheme lhs_cacheobj(AnyP::PROTO_CACHE_OBJECT), rhs_cacheobj(AnyP::PROTO_CACHE_OBJECT);
+    AnyP::UriScheme lhs_cacheobj(AnyP::PROTO_HTTP), rhs_cacheobj(AnyP::PROTO_HTTP);
     CPPUNIT_ASSERT_EQUAL(lhs_cacheobj, rhs_cacheobj);
     CPPUNIT_ASSERT(lhs_none != rhs_cacheobj);
 }
@@ -96,7 +96,7 @@ testUriScheme::testEqualprotocol_t()
     CPPUNIT_ASSERT(AnyP::UriScheme() == AnyP::PROTO_NONE);
     CPPUNIT_ASSERT(not (AnyP::UriScheme(AnyP::PROTO_WAIS) == AnyP::PROTO_HTTP));
     CPPUNIT_ASSERT(AnyP::PROTO_HTTP == AnyP::UriScheme(AnyP::PROTO_HTTP));
-    CPPUNIT_ASSERT(not (AnyP::PROTO_CACHE_OBJECT == AnyP::UriScheme(AnyP::PROTO_HTTP)));
+    CPPUNIT_ASSERT(not (AnyP::PROTO_FTP == AnyP::UriScheme(AnyP::PROTO_HTTP)));
 }
 
 /*

--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -861,6 +861,11 @@ process_request(cachemgr_request * req)
 
     Ip::Address::FreeAddr(AI);
 
+    // XXX: This Squid does not support receiving cache_object requests, but
+    // very old Squid versions do not support cache manager requests with an
+    // http scheme. We are using cache_object here per "be very conservative"
+    // recommendation archived at
+    // http://lists.squid-cache.org/pipermail/squid-dev/2023-January/009848.html
     l = snprintf(buf, sizeof(buf),
                  "GET cache_object://%s/%s%s%s HTTP/1.0\r\n"
                  "User-Agent: cachemgr.cgi/%s\r\n"

--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -865,7 +865,7 @@ process_request(cachemgr_request * req)
     // Squid-3.1 and older do not support http scheme manager requests.
     // Squid-3.2 versions have bugs with https scheme manager requests.
     l = snprintf(buf, sizeof(buf),
-                 "GET /squid-internal-mgr/%s%s%s HTTP/1.0\r\n" // HTTP/1.0 because Transfer-Encoding is not supported by the CGI tool
+                 "GET /squid-internal-mgr/%s%s%s HTTP/1.0\r\n" // HTTP/1.0 because this tool does not support Transfer-Encoding
                  "Host: %s\r\n"
                  "User-Agent: cachemgr.cgi/%s\r\n"
                  "Accept: */*\r\n"

--- a/tools/squidclient/squidclient.cc
+++ b/tools/squidclient/squidclient.cc
@@ -436,7 +436,6 @@ main(int argc, char *argv[])
         snprintf(url, sizeof(url), "http://%s:%hu/squid-internal-mgr/%.*s", Transport::Config.hostname, Transport::Config.port, pathLen, pathCopy);
         xfree(pathCopy);
     }
-
     if (put_file) {
         put_fd = open(put_file, O_RDONLY);
         set_our_signal();

--- a/tools/squidclient/squidclient.cc
+++ b/tools/squidclient/squidclient.cc
@@ -431,7 +431,7 @@ main(int argc, char *argv[])
         // XXX: Bail on snprintf() failures
         snprintf(url, sizeof(url), "http://%s:%hu/squid-internal-mgr/%s", Transport::Config.hostname, Transport::Config.port, t);
         if (const auto at = strrchr(url, '@')) {
-            *at = 0; // send password in Proxy-Authorization header, not URL
+            *at = 0; // send password in Authorization header, not URL
             pathPassword = at + 1; // embedded @password overwrites -w password further below
         }
         xfree(t);
@@ -508,15 +508,15 @@ main(int argc, char *argv[])
         if (max_forwards > -1) {
             msg << "Max-Forwards: " << max_forwards << "\r\n";
         }
-        if (ProxyAuthorization.user) {
-            const auto savedPassword = ProxyAuthorization.password;
-            if (pathPassword)
-                ProxyAuthorization.password = pathPassword;
+        if (ProxyAuthorization.user)
             ProxyAuthorization.commit(msg);
-            ProxyAuthorization.password = savedPassword; // restore the global password setting
-        }
-        if (OriginAuthorization.user)
+        if (OriginAuthorization.user) {
+            const auto savedPassword = OriginAuthorization.password;
+            if (pathPassword)
+                OriginAuthorization.password = pathPassword;
             OriginAuthorization.commit(msg);
+            OriginAuthorization.password = savedPassword; // restore the global password setting
+        }
 #if HAVE_GSSAPI
         if (www_neg) {
             if (host) {


### PR DESCRIPTION
Removing this non-standard protocol (already mentioned as deprecated
in Squid sources) would eliminate duplication and simplify the
existing error-prone forwarding logic (causing CVEs).