### PR TITLE
Run cache_peer probes without transaction context

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1145,7 +1145,10 @@ int
 neighborUp(const CachePeer * p)
 {
     if (!p->tcp_up) {
-        peerProbeConnect(const_cast<CachePeer*>(p));
+        // TODO: add and pass the CachePeer context here instead of nullptr
+        CallService(nullptr, [&] {
+            peerProbeConnect(const_cast<CachePeer*>(p));
+        });
         return 0;
     }
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1145,7 +1145,7 @@ int
 neighborUp(const CachePeer * p)
 {
     if (!p->tcp_up) {
-        // TODO: add and pass the CachePeer context here instead of nullptr
+        // TODO: When CachePeer gets its own CodeContext, pass that context instead of nullptr
         CallService(nullptr, [&] {
             peerProbeConnect(const_cast<CachePeer*>(p));
         });


### PR DESCRIPTION
These probes are running in a background mode and should not relate to
the triggering master transaction.