### PR TITLE
Add ACL key change tests

### DIFF
--- a/test-suite/squidconf/note-key-change.conf
+++ b/test-suite/squidconf/note-key-change.conf
@@ -1,0 +1,9 @@
+## Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+acl banned note color green
+acl banned note weight heavy

--- a/test-suite/squidconf/note-key-change.conf.instructions
+++ b/test-suite/squidconf/note-key-change.conf.instructions
@@ -1,0 +1,1 @@
+expect-failure ERROR:.configuration.failure:.Attempt.to.change.the.value.of.the.annotation.name.argument

--- a/test-suite/squidconf/req-header-key-change.conf
+++ b/test-suite/squidconf/req-header-key-change.conf
@@ -1,0 +1,9 @@
+## Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+acl barred req_header X-1 bar
+acl barred req_header X-2 bar

--- a/test-suite/squidconf/req-header-key-change.conf.instructions
+++ b/test-suite/squidconf/req-header-key-change.conf.instructions
@@ -1,0 +1,1 @@
+expect-failure ERROR:.configuration.failure:.Attempt.to.change.the.value.of.the.header-name.argument


### PR DESCRIPTION
Squid bans key changes in req_header/rep_header and note ACLs
since 4a3b853.