### PR TITLE
Enable compiler checks for printf-like SBuf methods

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -143,7 +143,8 @@ public:
     void checkUrlpath();
     void buildTitleUrl();
     void writeReplyBody(const char *, size_t len);
-    void printfReplyBody(const char *fmt, ...);
+    // unused
+    void printfReplyBody(const char *fmt, ...) PRINTF_FORMAT_ARG2;
     void completeForwarding() override;
     void processHeadResponse();
     void processReplyBody() override;

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -143,8 +143,7 @@ public:
     void checkUrlpath();
     void buildTitleUrl();
     void writeReplyBody(const char *, size_t len);
-    // unused
-    void printfReplyBody(const char *fmt, ...) PRINTF_FORMAT_ARG2;
+    void printfReplyBody(const char *fmt, ...);
     void completeForwarding() override;
     void processHeadResponse();
     void processReplyBody() override;

--- a/src/sbuf/SBuf.h
+++ b/src/sbuf/SBuf.h
@@ -211,13 +211,13 @@ public:
      * \note arguments may be evaluated more than once, be careful
      *       of side-effects
      */
-    SBuf& Printf(const char *fmt, ...);
+    SBuf& Printf(const char *fmt, ...) PRINTF_FORMAT_ARG2;
 
     /** Append operation with printf-style arguments
      * \note arguments may be evaluated more than once, be careful
      *       of side-effects
      */
-    SBuf& appendf(const char *fmt, ...);
+    SBuf& appendf(const char *fmt, ...)  PRINTF_FORMAT_ARG2;
 
     /** Append operation, with vsprintf(3)-style arguments.
      * \note arguments may be evaluated more than once, be careful


### PR DESCRIPTION
These two are the only known printf()-like functions not already covered
by these compiler checks. Some helper debugging hacks do not have
PRINTF_FORMAT_ARG2 or similar attributes, but they are covered because
their `__GNUC__` variants use standard fprintf().
