### PR TITLE
CI: Extend GitHub Actions build-tests to doc/release-notes/

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -106,6 +106,7 @@ jobs:
           sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
+          sudo apt-get --quiet=2 install linuxdoc-tools
 
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
"make dist[check]" does nothing in doc/release-notes unless a linuxdoc tool has been detected during ./configure, missing errors like this:

    make[6]: Entering directory /squid/doc/release-notes
    linuxdoc -B html -T 2 --split=0 release-6.sgml
    Processing file release-6.sgml
    onsgmls: ...E: end tag for element "E" which is not open