### PR TITLE
Store only idle entries in replacement policy purge lists

### DIFF
--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -285,13 +285,8 @@ MemStore::maxObjectSize() const
     return min(Config.Store.maxInMemObjSize, Config.memMaxSize);
 }
 
-void
-MemStore::reference(StoreEntry &)
-{
-}
-
 bool
-MemStore::dereference(StoreEntry &)
+MemStore::keepIdle() const
 {
     // no need to keep e in the global store_table for us; we have our own map
     return false;

--- a/src/MemStore.h
+++ b/src/MemStore.h
@@ -55,8 +55,7 @@ public:
     int64_t maxObjectSize() const override;
     void getStats(StoreInfoStats &stats) const override;
     void stat(StoreEntry &e) const override;
-    void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle() const override;
     void updateHeaders(StoreEntry *e) override;
     void maintain() override;
     bool anchorToCache(StoreEntry &) override;

--- a/src/RemovalPolicy.h
+++ b/src/RemovalPolicy.h
@@ -70,7 +70,7 @@ class RemovalPurgeWalker
 public:
     RemovalPolicy *_policy;
     void *_data;
-    int scanned, max_scan, locked;
+    int scanned, max_scan;
     StoreEntry *(*Next) (RemovalPurgeWalker * walker);
     void (*Done) (RemovalPurgeWalker * walker);
 };

--- a/src/Store.h
+++ b/src/Store.h
@@ -218,8 +218,14 @@ public:
     /// allow or forbid collapsed requests feeding
     void setCollapsingRequirement(const bool required);
 
+    /// (re)insert the (unlocked) entry into the memory replacement policy
+    void ensureInMemReplacementPurgePolicy();
+    /// delete the entry from the memory replacement policy
+    void removeFromMemReplacementPurgePolicy();
+
     MemObject *mem_obj;
-    RemovalPolicyNode repl;
+    RemovalPolicyNode replWalk;
+    RemovalPolicyNode replPurge;
     /* START OF ON-DISK STORE_META_STD TLV field */
     time_t timestamp;
     time_t lastref;

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -129,14 +129,8 @@ Transients::maxObjectSize() const
     return std::numeric_limits<uint64_t>::max();
 }
 
-void
-Transients::reference(StoreEntry &)
-{
-    // no replacement policy (but the cache(s) storing the entry may have one)
-}
-
 bool
-Transients::dereference(StoreEntry &)
+Transients::keepIdle() const
 {
     // no need to keep e in the global store_table for us; we have our own map
     return false;

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -68,8 +68,7 @@ public:
     int64_t maxObjectSize() const override;
     void getStats(StoreInfoStats &stats) const override;
     void stat(StoreEntry &e) const override;
-    void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle() const override;
     void evictCached(StoreEntry &) override;
     void evictIfFound(const cache_key *) override;
     void maintain() override;

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -333,7 +333,7 @@ Rock::SwapDir::parse(int anIndex, char *aPath)
 
     // Current openForWriting() code overwrites the old slot if needed
     // and possible, so proactively removing old slots is probably useless.
-    assert(!repl); // repl = createRemovalPolicy(Config.replPolicy);
+    assert(!replWalk); // repl = createRemovalPolicy(Config.replPolicy);
 
     validateOptions();
 }
@@ -975,21 +975,9 @@ Rock::SwapDir::maintain()
     // TODO: Disable maintain() requests when they are pointless.
 }
 
-void
-Rock::SwapDir::reference(StoreEntry &e)
-{
-    debugs(47, 5, &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
-    if (repl && repl->Referenced)
-        repl->Referenced(repl, &e, &e.repl);
-}
-
 bool
-Rock::SwapDir::dereference(StoreEntry &e)
+Rock::SwapDir::keepIdle() const
 {
-    debugs(47, 5, &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
-    if (repl && repl->Dereferenced)
-        repl->Dereferenced(repl, &e, &e.repl);
-
     // no need to keep e in the global store_table for us; we have our own map
     return false;
 }
@@ -1026,16 +1014,16 @@ void
 Rock::SwapDir::trackReferences(StoreEntry &e)
 {
     debugs(47, 5, e);
-    if (repl)
-        repl->Add(repl, &e, &e.repl);
+    if (replWalk)
+        replWalk->Add(replWalk, &e, &e.replWalk);
 }
 
 void
 Rock::SwapDir::ignoreReferences(StoreEntry &e)
 {
     debugs(47, 5, e);
-    if (repl)
-        repl->Remove(repl, &e, &e.repl);
+    if (replWalk)
+        replWalk->Remove(replWalk, &e, &e.replWalk);
 }
 
 void

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -97,8 +97,11 @@ protected:
     StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
     void maintain() override;
     void diskFull() override;
-    void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle() const override;
+    void addToReplacementWalkPolicy(StoreEntry &) override {}
+    void addToReplacementPurgePolicy(StoreEntry &) override {}
+    void removeFromReplacementWalkPolicy(StoreEntry &) override {}
+    void removeFromReplacementPurgePolicy(StoreEntry &) override {}
     void updateHeaders(StoreEntry *e) override;
     bool unlinkdUseful() const override;
     void statfs(StoreEntry &e) const override;

--- a/src/fs/ufs/StoreSearchUFS.cc
+++ b/src/fs/ufs/StoreSearchUFS.cc
@@ -17,7 +17,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Fs::Ufs,StoreSearchUFS);
 
 Fs::Ufs::StoreSearchUFS::StoreSearchUFS(RefCount<UFSSwapDir> aSwapDir) :
     sd(aSwapDir),
-    walker(sd->repl->WalkInit(sd->repl)),
+    walker(sd->replWalk->WalkInit(sd->replWalk)),
     cbdata(nullptr),
     current(nullptr),
     _done(false)

--- a/src/fs/ufs/UFSStrategy.cc
+++ b/src/fs/ufs/UFSStrategy.cc
@@ -132,7 +132,7 @@ Fs::Ufs::UFSStrategy::create(SwapDir * SD, StoreEntry * e, StoreIOState::STFNCB 
     }
 
     /* now insert into the replacement policy */
-    ((UFSSwapDir *)SD)->replacementAdd(e);
+    SD->addToReplacementWalkPolicy(*e);
 
     return sio;
 }

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -54,8 +54,11 @@ public:
     void evictCached(StoreEntry &) override;
     void evictIfFound(const cache_key *) override;
     bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
-    void reference(StoreEntry &) override;
-    bool dereference(StoreEntry &) override;
+    bool keepIdle() const override;
+    void addToReplacementWalkPolicy(StoreEntry &) override;
+    void addToReplacementPurgePolicy(StoreEntry &) override;
+    void removeFromReplacementWalkPolicy(StoreEntry &) override;
+    void removeFromReplacementPurgePolicy(StoreEntry &) override;
     StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
     StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
     void openLog() override;
@@ -110,10 +113,6 @@ public:
 
     bool validL2(int) const;
     bool validL1(int) const;
-
-    /** Add and remove the given StoreEntry from the replacement policy in use */
-    void replacementAdd(StoreEntry *e);
-    void replacementRemove(StoreEntry *e);
 
 protected:
     FileMap *map;

--- a/src/store/Controlled.h
+++ b/src/store/Controlled.h
@@ -24,12 +24,8 @@ public:
     /// This method must not trigger slow I/O operations (e.g., disk swap in).
     virtual StoreEntry *get(const cache_key *) = 0;
 
-    /// somebody needs this entry (many cache replacement policies need to know)
-    virtual void reference(StoreEntry &e) = 0;
-
-    /// somebody no longer needs this entry (usually after calling reference())
-    /// return false iff the idle entry should be destroyed
-    virtual bool dereference(StoreEntry &e) = 0;
+    /// whether an idle entry belonging to this storage should not be destroyed
+    virtual bool keepIdle() const = 0;
 
     /// make stored metadata and HTTP headers the same as in the given entry
     virtual void updateHeaders(StoreEntry *) {}

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -135,8 +135,8 @@ public:
 private:
     bool memoryCacheHasSpaceFor(const int pagesRequired) const;
 
-    void referenceBusy(StoreEntry &e);
-    bool dereferenceIdle(StoreEntry &, bool wantsLocalMemory);
+    bool keepIdle(StoreEntry &, bool wantsLocalMemory) const;
+    void removeFromReplacementPurgePolicies(StoreEntry &);
 
     void allowSharing(StoreEntry &, const cache_key *);
     StoreEntry *peekAtLocal(const cache_key *);

--- a/src/store/Disk.h
+++ b/src/store/Disk.h
@@ -36,6 +36,15 @@ public:
     /// whether SwapDir may benefit from unlinkd
     virtual bool unlinkdUseful() const = 0;
 
+    /// add the StoreEntry to the replacement policy for all entries
+    virtual void addToReplacementWalkPolicy(StoreEntry &) = 0;
+    /// add the StoreEntry to the replacement policy for idle entries
+    virtual void addToReplacementPurgePolicy(StoreEntry &) = 0;
+    /// remove the StoreEntry from the replacement policy for all entries
+    virtual void removeFromReplacementWalkPolicy(StoreEntry &) = 0;
+    /// remove the StoreEntry from the replacement policy for idle entries
+    virtual void removeFromReplacementPurgePolicy(StoreEntry &) = 0;
+
     /**
      * Notify this disk that it is full.
      * XXX move into a protected api call between store files and their stores, rather than a top level api call
@@ -50,8 +59,7 @@ public:
     int64_t maxObjectSize() const override;
     void getStats(StoreInfoStats &stats) const override;
     void stat(StoreEntry &) const override;
-    void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle() const override;
     void maintain() override;
     /// whether this disk storage is capable of serving multiple workers
     virtual bool smpAware() const = 0;
@@ -102,7 +110,8 @@ public:
     char *path;
     int index;          /* This entry's index into the swapDirs array */
     int disker; ///< disker kid id dedicated to this SwapDir or -1
-    RemovalPolicy *repl;
+    RemovalPolicy *replWalk; ///< contains all entries (idle and locked)
+    RemovalPolicy *replPurge; ///< contains idle entries only
     int removals;
     int scanned;
 

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -541,16 +541,33 @@ Store::Disks::stat(StoreEntry & output) const
     }
 }
 
-void
-Store::Disks::reference(StoreEntry &e)
+bool
+Store::Disks::keepIdle() const
 {
-    e.disk().reference(e);
+    for (int i = 0; i < Config.cacheSwap.n_configured; ++i) {
+        if (Dir(i).keepIdle())
+            return true;
+    }
+    return false;
 }
 
-bool
-Store::Disks::dereference(StoreEntry &e)
+void
+Store::Disks::ensureInReplacementPurgePolicy(StoreEntry &e)
 {
-    return e.disk().dereference(e);
+    assert(!e.locked());
+    assert(e.hasDisk());
+    for (int i = 0; i < Config.cacheSwap.n_configured; ++i) {
+        Dir(i).removeFromReplacementPurgePolicy(e);
+        Dir(i).addToReplacementPurgePolicy(e);
+    }
+}
+
+void
+Store::Disks::removeFromReplacementPurgePolicy(StoreEntry &e)
+{
+    assert(e.hasDisk());
+    for (int i = 0; i < Config.cacheSwap.n_configured; ++i)
+        Dir(i).removeFromReplacementPurgePolicy(e);
 }
 
 void

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -32,8 +32,7 @@ public:
     void getStats(StoreInfoStats &stats) const override;
     void stat(StoreEntry &) const override;
     void sync() override;
-    void reference(StoreEntry &) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle() const;
     void updateHeaders(StoreEntry *) override;
     void maintain() override;
     bool anchorToCache(StoreEntry &) override;
@@ -57,6 +56,10 @@ public:
     static SwapDir *SelectSwapDir(const StoreEntry *);
     /// whether any of disk caches has entry with e.key
     bool hasReadableEntry(const StoreEntry &) const;
+    /// (re)insert the (unlocked) entry into the replacement policy for idle entries
+    void ensureInReplacementPurgePolicy(StoreEntry &);
+    /// delete the entry from the replacement policy for idle entries
+    void removeFromReplacementPurgePolicy(StoreEntry &);
 
 private:
     /* migration logic */


### PR DESCRIPTION
This allowed to optimize two loops purging idle entries:

* memory entries in freeMemorySpace()

* disk entries in UFSSwapDir::maintain()