### PR TITLE
Optimize freeMemorySpace() to not loop in vain

### DIFF
--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -43,6 +43,8 @@ url_checksum(const char *url)
 
 RemovalPolicy * mem_policy = nullptr;
 
+size_t MemObject::IdlePagesCount = 0;
+
 size_t
 MemObject::inUseCount()
 {

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -165,6 +165,12 @@ public:
     static constexpr Io ioWriting = Store::ioWriting;
     static constexpr Io ioDone = Store::ioDone;
 
+    size_t pages() const { return (endOffset() + SM_PAGE_SIZE-1) / SM_PAGE_SIZE; }
+    void markPagesIdle() { IdlePagesCount += pages(); }
+    void markPagesBusy() { assert(IdlePagesCount > pages()); IdlePagesCount -= pages(); }
+
+    static size_t IdlePagesCount;
+
     /// State of an entry with regards to the [shared] in-transit table.
     class XitTable
     {


### PR DESCRIPTION
We should not perform this loop if the total number of idle memory pages
is less than required number of pages.