### PR TITLE
Add %<sm and %<sd logformat codes

### DIFF
--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -191,6 +191,9 @@ public:
         char *reply;
     } headers;
 
+    uint64_t replyBytesFromDisk = 0; ///< %<sd
+    uint64_t replyBytesFromMemory = 0; ///< %<sm
+
 #if USE_ADAPTATION
     /** \brief This subclass holds general adaptation log info.
      * \todo Inner class declarations should be moved outside.

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_STORECLIENT_H
 #define SQUID_STORECLIENT_H
 
+#include "base/RefCount.h"
 #include "CollapsedStats.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
@@ -18,6 +19,8 @@ typedef void STCB(void *, StoreIOBuffer);   /* store callback */
 
 class StoreEntry;
 class ACLFilledChecklist;
+class AccessLogEntry;
+typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
 
 /// A StoreEntry::getPublic*() caller.
 class StoreClient
@@ -82,6 +85,7 @@ public:
 
     StoreEntry *entry;      /* ptr to the parent StoreEntry, argh! */
     StoreIOState::Pointer swapin_sio;
+    AccessLogEntryPointer ale;
 
     struct {
         bool disk_io_pending;
@@ -127,6 +131,7 @@ public:
 
 void storeClientCopy(store_client *, StoreEntry *, StoreIOBuffer, STCB *, void *);
 store_client* storeClientListAdd(StoreEntry * e, void *data);
+store_client* storeClientListAdd(StoreEntry * e, void *data, const AccessLogEntryPointer &ale);
 int storeClientCopyPending(store_client *, StoreEntry * e, void *data);
 int storeUnregister(store_client * sc, StoreEntry * e, void *data);
 int storePendingNClients(const StoreEntry * e);

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4343,6 +4343,38 @@ DOC_START
 				Generated FTP/Gopher listings are treated as
 				received bodies.
 
+		[http::]<sd Approximate number of response-related bytes read from
+				cache_dir when forming the final response to the client. This
+				counter is incremented after Store removes some cache_dir
+				metadata from the serialized on-disk response entry. Please
+				see %<sm documentation below for more information.
+
+		[http::]<sm The number of response bytes read from Store memory when
+				forming the final response to the client. This counter is
+				incremented when reading hits from local memory cache and when
+				reading (hits, misses, and generated responses) from local
+				memory storage used for in-transit transactions (because Squid
+				Store does not fully distinguish these two sources of
+				in-memory response data yet).
+
+				Pure disk cache hits have a positive %<sd value and zero %<sm
+				value, but that logic does not work in reverse: A transaction
+				that has a positive %<sd value and zero %<sm value may not be
+				a pure hit at all (assuming pure hits are required to have the
+				entire requested resource fresh/usable and present in the
+				cache at the request arrival time). These two counters are
+				useful for monitoring cache-related operations, but, in
+				isolation, they cannot detect disk or memory cache hits.
+
+				If a logged transaction went through a Squid-initiated
+				revalidation of a stale cached response, then %<sd counts the
+				bytes related to the stale response _and_ the bytes related to
+				the revalidation response. Same for %<sm.
+
+				Response bytes counted by these two %codes have passed through
+				pre-cache RESPMOD adaptation (where enabled).
+
+
 	    TIMING
 
 		[http::]<pt	Peer response time in milliseconds. The timer starts

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -162,7 +162,7 @@ clientReplyContext::setReplyToReply(HttpReply *futureReply)
 void clientReplyContext::setReplyToStoreEntry(StoreEntry *entry, const char *reason)
 {
     entry->lock("clientReplyContext::setReplyToStoreEntry"); // removeClientStoreReference() unlocks
-    sc = storeClientListAdd(entry, this);
+    sc = storeClientListAdd(entry, this, http->al);
 #if USE_DELAY_POOLS
     sc->setDelayId(DelayId::DelayClient(http));
 #endif
@@ -327,7 +327,7 @@ clientReplyContext::processExpired()
         }
     }
 
-    sc = storeClientListAdd(entry, this);
+    sc = storeClientListAdd(entry, this, http->al);
 #if USE_DELAY_POOLS
     /* delay_id is already set on original store client */
     sc->setDelayId(DelayId::DelayClient(http));
@@ -991,7 +991,7 @@ clientReplyContext::purgeFoundObject(StoreEntry *entry)
     http->storeEntry()->createMemObject(storeId(), http->log_uri,
                                         http->request->method);
 
-    sc = storeClientListAdd(http->storeEntry(), this);
+    sc = storeClientListAdd(http->storeEntry(), this, http->al);
 
     http->logType.assign(LOG_TCP_HIT, collapsedStats);
 
@@ -1870,7 +1870,7 @@ clientReplyContext::doGetMoreData()
             debugs(88, 3, "storeId: " << http->storeEntry()->mem_obj->storeId());
         }
 
-        sc = storeClientListAdd(http->storeEntry(), this);
+        sc = storeClientListAdd(http->storeEntry(), this, http->al);
 #if USE_DELAY_POOLS
         sc->setDelayId(DelayId::DelayClient(http));
 #endif
@@ -2324,7 +2324,7 @@ clientReplyContext::createStoreEntry(const HttpRequestMethod& m, RequestFlags re
         Store::Root().allowCollapsing(e, reqFlags, m);
     }
 
-    sc = storeClientListAdd(e, this);
+    sc = storeClientListAdd(e, this, http->al);
 
 #if USE_DELAY_POOLS
     sc->setDelayId(DelayId::DelayClient(http));

--- a/src/format/ByteCode.h
+++ b/src/format/ByteCode.h
@@ -120,6 +120,8 @@ typedef enum {
     LFT_HTTP_RECEIVED_STATUS_CODE,
     /*LFT_HTTP_STATUS, */
     LFT_HTTP_BODY_BYTES_READ,
+    LFT_HTTP_REPLY_BYTES_FROM_DISK,
+    LFT_HTTP_REPLY_BYTES_FROM_MEMORY,
 
     /* response header details pre-adaptation */
     LFT_REPLY_HEADER,

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -980,6 +980,16 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             // or internal error messages).
             break;
 
+        case LFT_HTTP_REPLY_BYTES_FROM_DISK:
+            outoff = al->replyBytesFromDisk;
+            dooff = 1;
+            break;
+
+        case LFT_HTTP_REPLY_BYTES_FROM_MEMORY:
+            outoff = al->replyBytesFromMemory;
+            dooff = 1;
+            break;
+
         case LFT_SQUID_STATUS:
             out = al->cache.code.c_str();
             break;

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -81,6 +81,8 @@ static TokenTableEntry TokenTable2C[] = {
     TokenTableEntry("<Hs", LFT_HTTP_RECEIVED_STATUS_CODE),
     /*TokenTableEntry( "Ht", LFT_HTTP_STATUS ), */
     TokenTableEntry("<bs", LFT_HTTP_BODY_BYTES_READ),
+    TokenTableEntry("<sd", LFT_HTTP_REPLY_BYTES_FROM_DISK),
+    TokenTableEntry("<sm", LFT_HTTP_REPLY_BYTES_FROM_MEMORY),
 
     TokenTableEntry("Ss", LFT_SQUID_STATUS),
     TokenTableEntry("Sh", LFT_SQUID_HIERARCHY),

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "acl/FilledChecklist.h"
+#include "AccessLogEntry.h"
 #include "event.h"
 #include "globals.h"
 #include "HttpReply.h"
@@ -142,6 +143,15 @@ storeClientListAdd(StoreEntry * e, void *data)
 
     mem->addClient(sc);
 
+    return sc;
+}
+
+store_client *
+storeClientListAdd(StoreEntry * e, void *data, const AccessLogEntryPointer &ale)
+{
+    assert(ale);
+    const auto sc = storeClientListAdd(e, data);
+    sc->ale = ale;
     return sc;
 }
 
@@ -468,6 +478,10 @@ store_client::scheduleMemRead()
     /* Old style */
     debugs(90, 3, "store_client::doCopy: Copying normal from memory");
     size_t sz = entry->mem_obj->data_hdr.copy(copyInto);
+
+    if (ale && sz > 0)
+        ale->replyBytesFromMemory += sz;
+
     callback(sz);
     flags.store_copying = false;
 }
@@ -498,6 +512,9 @@ void
 store_client::readBody(const char *, ssize_t len)
 {
     int parsed_header = 0;
+
+    if (ale && len > 0 && flags.disk_io_pending)
+        ale->replyBytesFromDisk += len;
 
     // Don't assert disk_io_pending here.. may be called by read_header
     flags.disk_io_pending = false;
@@ -621,6 +638,9 @@ store_client::readHeader(char const *buf, ssize_t len)
 
     if (len < 0)
         return fail();
+
+    if (ale)
+        ale->replyBytesFromDisk += len;
 
     if (!unpackHeader(buf, len)) {
         fail();


### PR DESCRIPTION
These codes are useful, among other things, for analyzing cache operations, especially in environments where TCP_MEM_HIT transactions are rare due to their conservative definition (e.g., excluding some hit responses that were delivered entirely from memory cache) and delay pool complications (i.e. the so called "fix" for Bug 1001 in commit ffdf45f that logs many hits as TCP_MISS transactions).

XXX: This incomplete implementation is missing classification for many esoteric storeClientListAdd() cases (e.g., ASN and URN transactions). We should decide which of those transactions should maintain these counters and probably adjust _all_ storeClientListAdd() accordingly (at least). Note that these %codes may be used in contexts beyond access logging.