### PR TITLE
Optimize iterating over replacement policy purge lists

### DIFF
--- a/src/RemovalPolicy.h
+++ b/src/RemovalPolicy.h
@@ -30,9 +30,13 @@ class RemovalPolicyNode
 {
 
 public:
-    RemovalPolicyNode() : data(nullptr) {}
+    RemovalPolicyNode() : data(nullptr), owner(nullptr) {}
+
+    bool inited() const { assert(valid()); return bool(data); }
+    bool valid() const { return (data && owner) || (!data && !owner); }
 
     void *data;
+    void *owner;
 };
 
 class RemovalPolicy
@@ -41,12 +45,13 @@ class RemovalPolicy
 
 public:
     const char *_type;
-    void *_data;
+    void *_dataIdle;
+    void *_dataBusy;
     void (*Free) (RemovalPolicy * policy);
     void (*Add) (RemovalPolicy * policy, StoreEntry * entry, RemovalPolicyNode * node);
     void (*Remove) (RemovalPolicy * policy, StoreEntry * entry, RemovalPolicyNode * node);
-    void (*Referenced) (RemovalPolicy * policy, const StoreEntry * entry, RemovalPolicyNode * node);
-    void (*Dereferenced) (RemovalPolicy * policy, const StoreEntry * entry, RemovalPolicyNode * node);
+    void (*Referenced) (RemovalPolicy * policy, StoreEntry * entry, RemovalPolicyNode * node);
+    void (*Dereferenced) (RemovalPolicy * policy, StoreEntry * entry, RemovalPolicyNode * node);
     RemovalPolicyWalker *(*WalkInit) (RemovalPolicy * policy);
     RemovalPurgeWalker *(*PurgeInit) (RemovalPolicy * policy, int max_scan);
     void (*Stats) (RemovalPolicy * policy, StoreEntry * entry);
@@ -58,7 +63,8 @@ class RemovalPolicyWalker
 
 public:
     RemovalPolicy *_policy;
-    void *_data;
+    void *_dataIdle;
+    void *_dataBusy;
     const StoreEntry *(*Next) (RemovalPolicyWalker * walker);
     void (*Done) (RemovalPolicyWalker * walker);
 };
@@ -69,8 +75,8 @@ class RemovalPurgeWalker
 
 public:
     RemovalPolicy *_policy;
-    void *_data;
-    int scanned, max_scan, locked;
+    void *_dataIdle;
+    int scanned, max_scan;
     StoreEntry *(*Next) (RemovalPurgeWalker * walker);
     void (*Done) (RemovalPurgeWalker * walker);
 };

--- a/src/fs/ufs/UFSStrategy.cc
+++ b/src/fs/ufs/UFSStrategy.cc
@@ -132,7 +132,7 @@ Fs::Ufs::UFSStrategy::create(SwapDir * const SD, StoreEntry * const e,
     }
 
     /* now insert into the replacement policy */
-    ((UFSSwapDir *)SD)->replacementAdd(e);
+    ((UFSSwapDir *)SD)->replacementAdd(e, true);
 
     return sio;
 }

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -818,7 +818,7 @@ Fs::Ufs::UFSSwapDir::addDiskRestore(const cache_key * key,
     cur_size += fs.blksize * sizeInBlocks(e->swap_file_sz);
     ++n_disk_objects;
     e->hashInsert(key);
-    replacementAdd (e);
+    replacementAdd(e, false);
     return e;
 }
 
@@ -1206,10 +1206,12 @@ Fs::Ufs::UFSSwapDir::evictIfFound(const cache_key *)
 }
 
 void
-Fs::Ufs::UFSSwapDir::replacementAdd(StoreEntry * e)
+Fs::Ufs::UFSSwapDir::replacementAdd(StoreEntry *e, const bool referenced)
 {
     debugs(47, 4, "added node " << e << " to dir " << index);
     repl->Add(repl, e, &e->repl);
+    if (referenced)
+        repl->Referenced(repl, e, &e->repl);
 }
 
 void

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -112,7 +112,7 @@ public:
     bool validL1(int) const;
 
     /** Add and remove the given StoreEntry from the replacement policy in use */
-    void replacementAdd(StoreEntry *e);
+    void replacementAdd(StoreEntry *e, bool referenced);
     void replacementRemove(StoreEntry *e);
 
 protected:


### PR DESCRIPTION
Before this change RemovalPolicy kept a single list for all entries,
busy (locked) and idle. When entries were purged (by means of
RemovalPurgeWalker), the locked entries were just skipped. Now
we remove this overhead by keeping idle and locked entries 
separately.

The optimization should cover two loops purging idle entries:

* memory entries in freeMemorySpace()

* disk entries in UFSSwapDir::maintain()