### PR TITLE
Remove RemovalPolicy::Dereferenced()

### DIFF
--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -290,13 +290,6 @@ MemStore::reference(StoreEntry &)
 {
 }
 
-bool
-MemStore::dereference(StoreEntry &)
-{
-    // no need to keep e in the global store_table for us; we have our own map
-    return false;
-}
-
 StoreEntry *
 MemStore::get(const cache_key *key)
 {

--- a/src/MemStore.h
+++ b/src/MemStore.h
@@ -56,7 +56,7 @@ public:
     void getStats(StoreInfoStats &stats) const override;
     void stat(StoreEntry &e) const override;
     void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle(const StoreEntry &) const override { return false; }
     void updateHeaders(StoreEntry *e) override;
     void maintain() override;
     bool anchorToCache(StoreEntry &) override;

--- a/src/RemovalPolicy.h
+++ b/src/RemovalPolicy.h
@@ -46,7 +46,6 @@ public:
     void (*Add) (RemovalPolicy * policy, StoreEntry * entry, RemovalPolicyNode * node);
     void (*Remove) (RemovalPolicy * policy, StoreEntry * entry, RemovalPolicyNode * node);
     void (*Referenced) (RemovalPolicy * policy, const StoreEntry * entry, RemovalPolicyNode * node);
-    void (*Dereferenced) (RemovalPolicy * policy, const StoreEntry * entry, RemovalPolicyNode * node);
     RemovalPolicyWalker *(*WalkInit) (RemovalPolicy * policy);
     RemovalPurgeWalker *(*PurgeInit) (RemovalPolicy * policy, int max_scan);
     void (*Stats) (RemovalPolicy * policy, StoreEntry * entry);

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -135,13 +135,6 @@ Transients::reference(StoreEntry &)
     // no replacement policy (but the cache(s) storing the entry may have one)
 }
 
-bool
-Transients::dereference(StoreEntry &)
-{
-    // no need to keep e in the global store_table for us; we have our own map
-    return false;
-}
-
 StoreEntry *
 Transients::get(const cache_key *key)
 {

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -69,7 +69,7 @@ public:
     void getStats(StoreInfoStats &stats) const override;
     void stat(StoreEntry &e) const override;
     void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle(const StoreEntry &) const override { return false; }
     void evictCached(StoreEntry &) override;
     void evictIfFound(const cache_key *) override;
     void maintain() override;

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -984,17 +984,6 @@ Rock::SwapDir::reference(StoreEntry &e)
 }
 
 bool
-Rock::SwapDir::dereference(StoreEntry &e)
-{
-    debugs(47, 5, &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
-    if (repl && repl->Dereferenced)
-        repl->Dereferenced(repl, &e, &e.repl);
-
-    // no need to keep e in the global store_table for us; we have our own map
-    return false;
-}
-
-bool
 Rock::SwapDir::unlinkdUseful() const
 {
     // no entry-specific files to unlink

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -98,7 +98,7 @@ protected:
     void maintain() override;
     void diskFull() override;
     void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle(const StoreEntry &) const override { return false; }
     void updateHeaders(StoreEntry *e) override;
     bool unlinkdUseful() const override;
     void statfs(StoreEntry &e) const override;

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -529,18 +529,6 @@ Fs::Ufs::UFSSwapDir::reference(StoreEntry &e)
         repl->Referenced(repl, &e, &e.repl);
 }
 
-bool
-Fs::Ufs::UFSSwapDir::dereference(StoreEntry & e)
-{
-    debugs(47, 3, "dereferencing " << &e << " " <<
-           e.swap_dirn << "/" << e.swap_filen);
-
-    if (repl->Dereferenced)
-        repl->Dereferenced(repl, &e, &e.repl);
-
-    return true; // keep e in the global store_table
-}
-
 StoreIOState::Pointer
 Fs::Ufs::UFSSwapDir::createStoreIO(StoreEntry &e, StoreIOState::STIOCB * const aCallback, void * const callback_data)
 {

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -55,7 +55,7 @@ public:
     void evictIfFound(const cache_key *) override;
     bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
     void reference(StoreEntry &) override;
-    bool dereference(StoreEntry &) override;
+    bool keepIdle(const StoreEntry &) const override { return true; }
     StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STIOCB *, void *) override;
     StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STIOCB *, void *) override;
     void openLog() override;

--- a/src/repl/heap/store_repl_heap.cc
+++ b/src/repl/heap/store_repl_heap.cc
@@ -114,19 +114,6 @@ heap_remove(RemovalPolicy * policy, StoreEntry *,
     h->count -= 1;
 }
 
-static void
-heap_referenced(RemovalPolicy * policy, const StoreEntry * entry,
-                RemovalPolicyNode * node)
-{
-    HeapPolicyData *h = (HeapPolicyData *)policy->_data;
-    heap_node *hnode = (heap_node *)node->data;
-
-    if (!hnode)
-        return;
-
-    heap_update(h->theHeap, hnode, (StoreEntry *) entry);
-}
-
 /** RemovalPolicyWalker **/
 
 typedef struct _HeapWalkData HeapWalkData;
@@ -332,8 +319,6 @@ createRemovalPolicy_heap(wordlist * args)
     policy->Remove = heap_remove;
 
     policy->Referenced = nullptr;
-
-    policy->Dereferenced = heap_referenced;
 
     policy->WalkInit = heap_walkInit;
 

--- a/src/repl/lru/store_repl_lru.cc
+++ b/src/repl/lru/store_repl_lru.cc
@@ -323,8 +323,6 @@ createRemovalPolicy_lru(wordlist * args)
 
     policy->Referenced = lru_referenced;
 
-    policy->Dereferenced = lru_referenced;
-
     policy->WalkInit = lru_walkInit;
 
     policy->PurgeInit = lru_purgeInit;

--- a/src/store/Controlled.h
+++ b/src/store/Controlled.h
@@ -27,9 +27,8 @@ public:
     /// somebody needs this entry (many cache replacement policies need to know)
     virtual void reference(StoreEntry &e) = 0;
 
-    /// somebody no longer needs this entry (usually after calling reference())
-    /// return false iff the idle entry should be destroyed
-    virtual bool dereference(StoreEntry &e) = 0;
+    /// whether this this idle entry should be kept in store_table
+    virtual bool keepIdle(const StoreEntry &) const = 0;
 
     /// make stored metadata and HTTP headers the same as in the given entry
     virtual void updateHeaders(StoreEntry *) {}

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -136,7 +136,7 @@ private:
     bool memoryCacheHasSpaceFor(const int pagesRequired) const;
 
     void referenceBusy(StoreEntry &e);
-    bool dereferenceIdle(StoreEntry &, bool wantsLocalMemory);
+    bool keepIdle(StoreEntry &, bool wantsLocalMemory);
 
     void allowSharing(StoreEntry &, const cache_key *);
     StoreEntry *peekAtLocal(const cache_key *);

--- a/src/store/Disk.cc
+++ b/src/store/Disk.cc
@@ -135,12 +135,6 @@ Store::Disk::maxObjectSize(int64_t newMax)
 void
 Store::Disk::reference(StoreEntry &) {}
 
-bool
-Store::Disk::dereference(StoreEntry &)
-{
-    return true; // keep in global store_table
-}
-
 void
 Store::Disk::diskFull()
 {

--- a/src/store/Disk.h
+++ b/src/store/Disk.h
@@ -51,7 +51,7 @@ public:
     void getStats(StoreInfoStats &stats) const override;
     void stat(StoreEntry &) const override;
     void reference(StoreEntry &e) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle(const StoreEntry &) const override { return true; }
     void maintain() override;
     /// whether this disk storage is capable of serving multiple workers
     virtual bool smpAware() const = 0;

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -548,10 +548,11 @@ Store::Disks::reference(StoreEntry &e)
 }
 
 bool
-Store::Disks::dereference(StoreEntry &e)
+Store::Disks::keepIdle(const StoreEntry &e) const
 {
-    return e.disk().dereference(e);
+    return e.disk().keepIdle(e);
 }
+
 
 void
 Store::Disks::updateHeaders(StoreEntry *e)

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -33,7 +33,7 @@ public:
     void stat(StoreEntry &) const override;
     void sync() override;
     void reference(StoreEntry &) override;
-    bool dereference(StoreEntry &e) override;
+    bool keepIdle(const StoreEntry &) const;
     void updateHeaders(StoreEntry *) override;
     void maintain() override;
     bool anchorToCache(StoreEntry &) override;

--- a/src/tests/stub_MemStore.cc
+++ b/src/tests/stub_MemStore.cc
@@ -33,7 +33,6 @@ uint64_t MemStore::minSize() const STUB_RETVAL(0)
 uint64_t MemStore::currentSize() const STUB_RETVAL(0)
 uint64_t MemStore::currentCount() const STUB_RETVAL(0)
 int64_t MemStore::maxObjectSize() const STUB_RETVAL(0)
-bool MemStore::dereference(StoreEntry &) STUB_RETVAL(false)
 void MemStore::evictCached(StoreEntry&) STUB
 void MemStore::evictIfFound(const cache_key *) STUB
 bool MemStore::anchorToCache(StoreEntry&) STUB_RETVAL(false)

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -77,7 +77,6 @@ int64_t Disk::maxObjectSize() const STUB_RETVAL(0)
 void Disk::getStats(StoreInfoStats &) const STUB
 void Disk::stat(StoreEntry &) const STUB
 void Disk::reference(StoreEntry &) STUB
-bool Disk::dereference(StoreEntry &) STUB_RETVAL(false)
 void Disk::maintain() STUB
 int64_t Disk::minObjectSize() const STUB_RETVAL(0)
 void Disk::maxObjectSize(int64_t) STUB
@@ -112,7 +111,6 @@ void Disks::getStats(StoreInfoStats &) const STUB
 void Disks::stat(StoreEntry &) const STUB
 void Disks::sync() STUB
 void Disks::reference(StoreEntry &) STUB
-bool Disks::dereference(StoreEntry &) STUB_RETVAL(false)
 void Disks::updateHeaders(StoreEntry *) STUB
 void Disks::maintain() STUB
 bool Disks::anchorToCache(StoreEntry &) STUB_RETVAL(false)

--- a/src/tests/testStore.h
+++ b/src/tests/testStore.h
@@ -73,8 +73,6 @@ public:
 
     virtual void reference(StoreEntry &) {} /* Reference this object */
 
-    virtual bool dereference(StoreEntry &) { return true; }
-
     virtual StoreSearch *search();
 };
 


### PR DESCRIPTION
This method was used by Store::Storage subclasses to signal
the Policy that the StoreEntry became idle. Actually, in both lru and
heap policies it it was implemented as RemovalPolicy::Referenced(),
merely updating/refreshing the element order in the Policy storage.

However, with heap policy, calling Referenced() when the entry becomes
idle looks useless because its position in the underlying tree storage
would not change. With lru policy, calling this method when the entry
becomes idle also looks unnecessary because we should have called it
while acquiring the entry from Store.