### PR TITLE
Update Host, Via, and other headers in-place when possible

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1029,10 +1029,7 @@ HttpHeader::addVia(const AnyP::ProtocolVersion &ver, const HttpHeader *from)
         if (!strVia.isEmpty())
             strVia.append(", ", 2);
         strVia.append(buf);
-        // XXX: putStr() still suffers from String size limits
-        Must(strVia.length() < String::SizeMaxXXX());
-        delById(Http::HdrType::VIA);
-        putStr(Http::HdrType::VIA, strVia.c_str());
+        updateOrAddStr(Http::HdrType::VIA, strVia);
     }
 }
 
@@ -1158,6 +1155,46 @@ HttpHeader::putExt(const char *name, const char *value)
     assert(name && value);
     debugs(55, 8, this << " adds ext entry " << name << " : " << value);
     addEntry(new HttpHeaderEntry(Http::HdrType::OTHER, SBuf(name), value));
+}
+
+void
+HttpHeader::updateOrAddStr(const Http::HdrType id, const SBuf &newValue)
+{
+    assert(any_registered_header(id));
+    assert(Http::HeaderLookupTable.lookup(id).type == Http::HdrFieldType::ftStr);
+
+    // XXX: HttpHeaderEntry::value suffers from String size limits
+    if (newValue.length() >= String::SizeMaxXXX()) {
+        debugs(55, DBG_IMPORTANT, "too long " <<  Http::HeaderLookupTable.lookup(id).name << " header value");
+        throw TextException("too long header value", Here());
+    }
+
+    if (!CBIT_TEST(mask, id)) {
+        auto newValueCopy = newValue; // until HttpHeaderEntry::value becomes SBuf
+        addEntry(new HttpHeaderEntry(id, SBuf(), newValueCopy.c_str()));
+        return;
+    }
+
+    auto foundSameName = false;
+    for (auto &e: entries) {
+        if (!e || e->id != id)
+            continue;
+
+        if (foundSameName) {
+            // get rid of this repeated same-name entry
+            delete e;
+            e = nullptr;
+            continue;
+        }
+
+        if (newValue.cmp(e->value.termedBuf()) != 0)
+            e->value.assign(newValue.rawContent(), newValue.plength());
+
+        foundSameName = true;
+        // continue to delete any repeated same-name entries
+    }
+    assert(foundSameName);
+    debugs(55, 5, "synced: " << Http::HeaderLookupTable.lookup(id).name << ": " << newValue);
 }
 
 int

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1165,8 +1165,10 @@ HttpHeader::updateOrAddStr(const Http::HdrType id, const SBuf &newValue)
 
     // XXX: HttpHeaderEntry::value suffers from String size limits
     if (newValue.length() >= String::SizeMaxXXX()) {
-        debugs(55, DBG_IMPORTANT, "too long " <<  Http::HeaderLookupTable.lookup(id).name << " header value");
-        throw TextException("too long header value", Here());
+        // emulate Assure(newValue.length() < String::SizeMaxXXX());
+        const TextException ex("assurance failed: newValue.length() < String::SizeMaxXXX()", Here());
+        debugs(0, DBG_CRITICAL, "ERROR: Squid BUG: " << ex);
+        throw ex;
     }
 
     if (!CBIT_TEST(mask, id)) {

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -144,6 +144,11 @@ public:
     void putSc(HttpHdrSc *sc);
     void putWarning(const int code, const char *const text); ///< add a Warning header
     void putExt(const char *name, const char *value);
+
+    /// Ensures that the header has the given field, removing or replacing any
+    /// same-name fields with conflicting values as needed.
+    void updateOrAddStr(Http::HdrType, const SBuf &);
+
     int getInt(Http::HdrType id) const;
     int64_t getInt64(Http::HdrType id) const;
     time_t getTime(Http::HdrType id) const;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1323,8 +1323,8 @@ ErrorState::BuildHttpReply()
          */
         if (!Config.errorDirectory) {
             /* We 'negotiated' this ONLY from the Accept-Language. */
-            rep->header.delById(Http::HdrType::VARY);
-            rep->header.putStr(Http::HdrType::VARY, "Accept-Language");
+            static const SBuf acceptLanguage("Accept-Language");
+            rep->header.updateOrAddStr(Http::HdrType::VARY, acceptLanguage);
         }
 
         /* add the Content-Language header according to RFC section 14.12 */

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1644,10 +1644,10 @@ Ftp::Server::setDataCommand()
     HttpRequest *const request = http->request;
     assert(request != NULL);
     HttpHeader &header = request->header;
-    header.delById(Http::HdrType::FTP_COMMAND);
-    header.putStr(Http::HdrType::FTP_COMMAND, "PASV");
-    header.delById(Http::HdrType::FTP_ARGUMENTS);
-    header.putStr(Http::HdrType::FTP_ARGUMENTS, "");
+    static const SBuf pasvValue("PASV");
+    header.updateOrAddStr(Http::HdrType::FTP_COMMAND, pasvValue);
+    static const SBuf emptyValue("");
+    header.updateOrAddStr(Http::HdrType::FTP_ARGUMENTS, emptyValue);
     debugs(9, 5, "client data command converted to fake PASV");
 }
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -189,11 +189,8 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     // some code still uses Host directly so normalize it using the previously
     // sanitized URL authority value.
     // For now preserve the case where Host is completely absent. That matters.
-    if (const auto x = request->header.delById(Http::HOST)) {
-        debugs(33, 5, "normalize " << x << " Host header using " << request->url.authority());
-        SBuf tmp(request->url.authority());
-        request->header.putStr(Http::HOST, tmp.c_str());
-    }
+    if (request->header.has(Http::HdrType::HOST))
+        request->header.updateOrAddStr(Http::HdrType::HOST, request->url.authority());
 
     // TODO: We fill request notes here until we find a way to verify whether
     // no ACL checking is performed before ClientHttpRequest::doCallouts().

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -65,6 +65,7 @@ void HttpHeader::putRange(const HttpHdrRange *) STUB
 void HttpHeader::putSc(HttpHdrSc *) STUB
 void HttpHeader::putWarning(const int, const char *const) STUB
 void HttpHeader::putExt(const char *, const char *) STUB
+void HttpHeader::updateOrAddStr(Http::HdrType, const SBuf &) STUB
 int HttpHeader::getInt(Http::HdrType) const STUB_RETVAL(0)
 int64_t HttpHeader::getInt64(Http::HdrType) const STUB_RETVAL(0)
 time_t HttpHeader::getTime(Http::HdrType) const STUB_RETVAL(0)


### PR DESCRIPTION
This change optimizes Host header synchronization code that usually does
not need to change the Host header field but was always deleting the old
field and generating/appending a new one. Appending Host also violated
an RFC 9110 section 7.2 rule (on behalf of the user agent whose Host we
were rewriting): "A user agent that sends Host SHOULD send it as the
first field in the header section".

Also, removing old header fields and appending new ones introduced HTTP
header changes that broke otherwise working peers. For example, some
origins denied Squid-proxied messages exclusively due to an unusual
(from those origins point of view) Host header position. This change
reduces (but does not eliminate) such unnecessary and risky changes.

----

Cherry-picked master/v6 commit 05ba40fc1059ffe75c9a15a4e0c2923eca6801b2
and adjusted the code due to lack of Assure macro.