### PR TITLE
Restore errno in %err_detail for ERR_CONNECT_FAIL

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4686,7 +4686,13 @@ DOC_START
 		sn	Unique sequence number per log line entry
 		err_code    The ID of an error response served by Squid or
 				a similar internal error identifier.
-		err_detail  Additional err_code-dependent error information.
+
+		err_detail  Additional err_code-dependent error information. Multiple
+			details are separated by the plus sign ('+'). Admins should not
+			rely on a particular detail listing order, the uniqueness of the
+			entries, or individual detail text stability. All those properties
+			depend on many unstable factors, including external libraries.
+
 		note	The annotation specified by the argument. Also
 			logs the adaptation meta headers set by the
 			adaptation_meta configuration parameter.

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -339,7 +339,7 @@ Http::Tunneler::bailOnResponseError(const char *error, HttpReply *errorReply)
 
     ErrorState *err;
     if (errorReply) {
-        err = new ErrorState(request.getRaw(), errorReply);
+        err = new ErrorState(request.getRaw(), errorReply, al);
     } else {
         // with no reply suitable for relaying, answer with 502 (Bad Gateway)
         err = new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al);

--- a/src/error/Details.cc
+++ b/src/error/Details.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/Details.cc
+++ b/src/error/Details.cc
@@ -87,7 +87,7 @@ SBuf
 ErrorDetails::brief() const
 {
     SBuf buf;
-    for (const auto detail: details) {
+    for (const auto &detail: details) {
         if (buf.length())
             buf.append('+');
         buf.append(detail->brief());
@@ -99,7 +99,7 @@ SBuf
 ErrorDetails::verbose(const HttpRequestPointer &request) const
 {
     SBuf buf;
-    for (const auto detail: details) {
+    for (const auto &detail: details) {
         if (buf.length()) {
             static const SBuf delimiter("; ");
             buf.append(delimiter);

--- a/src/error/Details.cc
+++ b/src/error/Details.cc
@@ -61,7 +61,6 @@ ErrorDetails::Merge(ErrorDetailPointer &storage, const ErrorDetailPointer &lates
         storedGroup->mergeMany(*latestGroup); // x + n
 }
 
-/// adds the given detail unless we already have it
 void
 ErrorDetails::mergeOne(const ErrorDetail &detail)
 {
@@ -78,7 +77,6 @@ ErrorDetails::mergeOne(const ErrorDetail &detail)
     details.emplace_back(&detail);
 }
 
-/// adds unique details (if any) from the given collection
 void
 ErrorDetails::mergeMany(const ErrorDetails &others)
 {

--- a/src/error/Details.cc
+++ b/src/error/Details.cc
@@ -16,9 +16,14 @@ bool
 Same(const ErrorDetail &d1, const ErrorDetail &d2)
 {
     // Duplicate details for the same error typically happen when we update some
-    // error storage (e.g., ALE) twice from the same source or retag the error
-    // with the same context information (e.g., WITH_CLIENT). In all those
-    // cases, comparing detail object addresses is enough to detect duplicates.
+    // error storage (e.g., ALE) twice from the same detail source (e.g., the
+    // same HttpRequest object reachable via two different code/pointer paths)
+    // or retag the error with the same context information (e.g., WITH_CLIENT).
+    // In all those cases, comparing detail object addresses is enough to detect
+    // duplicates. In other cases (if they exist), a duplicate detail would
+    // imply inefficient or buggy error detailing code. Instead of spending ink
+    // and CPU cycles on hiding them, this comparison may expose those (minor)
+    // problems (in hope that they get fixed). Detail consumers should not care.
     return &d1 == &d2;
 }
 

--- a/src/error/Details.cc
+++ b/src/error/Details.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "base/Assure.h"
+#include "error/Details.h"
+#include "sbuf/SBuf.h"
+
+static inline
+bool
+Same(const ErrorDetail &d1, const ErrorDetail &d2)
+{
+    // Duplicate details for the same error typically happen when we update some
+    // error storage (e.g., ALE) twice from the same source or retag the error
+    // with the same context information (e.g., WITH_CLIENT). In all those
+    // cases, comparing detail object addresses is enough to detect duplicates.
+    return &d1 == &d2;
+}
+
+void
+ErrorDetails::Merge(ErrorDetailPointer &storage, const ErrorDetailPointer &latest)
+{
+    // The checks below avoid creating new ErrorDetails storage until we have
+    // multiple _unique_ details to store.
+
+    if (!latest)
+        return; // x + 0
+
+    const auto latestGroup = dynamic_cast<const ErrorDetails*>(latest.getRaw());
+
+    if (!storage && !latestGroup) {
+        storage = latest;
+        return; // 0 + 1
+    }
+
+    if (!storage) {
+        storage = new ErrorDetails(*latestGroup);
+        return; // 0 + n
+    }
+
+    auto storedGroup = dynamic_cast<ErrorDetails*>(storage.getRaw()); // may be set later
+
+    if (!storedGroup && !latestGroup && Same(*storage, *latest))
+        return; // 1 + 1 but both are the same
+
+    if (!storedGroup) {
+        // move a single stored detail into ErrorDetails storage we can merge into
+        storedGroup = new ErrorDetails();
+        storedGroup->mergeOne(*storage);
+        storage = storedGroup;
+    }
+
+    if (!latestGroup)
+        storedGroup->mergeOne(*latest); // x + 1
+    else
+        storedGroup->mergeMany(*latestGroup); // x + n
+}
+
+/// adds the given detail unless we already have it
+void
+ErrorDetails::mergeOne(const ErrorDetail &detail)
+{
+    Assure(!Same(*this, detail)); // nobody should add a detail to itself
+
+    // an error can only have a few details so vector+linear search is faster
+    for (const auto &existingDetail: details) {
+        if (Same(*existingDetail, detail))
+            return; // already covered
+    }
+    details.emplace_back(&detail);
+}
+
+/// adds unique details (if any) from the given collection
+void
+ErrorDetails::mergeMany(const ErrorDetails &others)
+{
+    for (const auto &other: others.details)
+        mergeOne(*other);
+}
+
+SBuf
+ErrorDetails::brief() const
+{
+    SBuf buf;
+    for (const auto detail: details) {
+        if (buf.length())
+            buf.append('+');
+        buf.append(detail->brief());
+    }
+    return buf;
+}
+
+SBuf
+ErrorDetails::verbose(const HttpRequestPointer &request) const
+{
+    SBuf buf;
+    for (const auto detail: details) {
+        if (buf.length()) {
+            static const SBuf delimiter("; ");
+            buf.append(delimiter);
+        }
+        buf.append(detail->verbose(request));
+    }
+    return buf;
+}
+

--- a/src/error/Details.cc
+++ b/src/error/Details.cc
@@ -65,7 +65,10 @@ ErrorDetails::Merge(ErrorDetailPointer &storage, const ErrorDetailPointer &lates
 void
 ErrorDetails::mergeOne(const ErrorDetail &detail)
 {
-    Assure(!Same(*this, detail)); // nobody should add a detail to itself
+    // brief()/verbose() do not support nested details or detail groups (yet?)
+    Assure(!dynamic_cast<const ErrorDetails*>(&detail));
+    // nobody should add a detail to itself
+    Assure(!Same(*this, detail)); // paranoid due to the above Assure()
 
     // an error can only have a few details so vector+linear search is faster
     for (const auto &existingDetail: details) {

--- a/src/error/Details.h
+++ b/src/error/Details.h
@@ -1,13 +1,13 @@
 /*
- * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
  * Please see the COPYING and CONTRIBUTORS files for detailss.
  */
 
-#ifndef _SQUID_SRC_ERROR_DETAILS_H
-#define _SQUID_SRC_ERROR_DETAILS_H
+#ifndef SQUID_SRC_ERROR_DETAILS_H
+#define SQUID_SRC_ERROR_DETAILS_H
 
 #include "error/Detail.h"
 
@@ -43,5 +43,5 @@ private:
     std::vector<ErrorDetailPointer> details;
 };
 
-#endif /* _SQUID_SRC_ERROR_DETAILS_H */
+#endif /* SQUID_SRC_ERROR_DETAILS_H */
 

--- a/src/error/Details.h
+++ b/src/error/Details.h
@@ -14,9 +14,9 @@
 
 #include <vector>
 
-/// Multiple details of a single error, in "canonical" order. Our "canonical"
-/// order is the approximate discovery order (e.g., the order of Error::update()
-/// calls) with no duplicates. This class isolates multi-detail storage
+/// Multiple details of a single error, in "canonical" order without duplicates.
+/// Our "canonical" order is the approximate detail discovery order (e.g., the
+/// order of Error::update() calls). This class isolates multi-detail storage
 /// overheads from a common case of storing a single error detail.
 class ErrorDetails: public ErrorDetail
 {

--- a/src/error/Details.h
+++ b/src/error/Details.h
@@ -10,6 +10,7 @@
 #define SQUID_SRC_ERROR_DETAILS_H
 
 #include "error/Detail.h"
+#include "mem/PoolingAllocator.h"
 
 #include <vector>
 
@@ -40,7 +41,7 @@ protected:
 
 private:
     /// known unique details in canonical order
-    std::vector<ErrorDetailPointer> details;
+    std::vector<ErrorDetailPointer, PoolingAllocator<ErrorDetailPointer> > details;
 };
 
 #endif /* SQUID_SRC_ERROR_DETAILS_H */

--- a/src/error/Details.h
+++ b/src/error/Details.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for detailss.
+ */
+
+#ifndef _SQUID_SRC_ERROR_DETAILS_H
+#define _SQUID_SRC_ERROR_DETAILS_H
+
+#include "error/Detail.h"
+
+#include <vector>
+
+/// Multiple details of a single error, in "canonical" order. Our "canonical"
+/// order is the approximate discovery order (e.g., the order of Error::update()
+/// calls) with no duplicates. This class isolates multi-detail storage
+/// overheads from a common case of storing a single error detail.
+class ErrorDetails: public ErrorDetail
+{
+public:
+    /// Combines the already stored and the latest error details while
+    /// preserving uniqueness and canonical order. Each parameter may point to a
+    /// single detail or to an ErrorDetails object (with multiple details).
+    static void Merge(ErrorDetailPointer &storage, const ErrorDetailPointer &latest);
+
+    virtual ~ErrorDetails() = default;
+
+protected:
+    // use Merge() instead
+    ErrorDetails() = default;
+
+    void mergeOne(const ErrorDetail &);
+    void mergeMany(const ErrorDetails &);
+
+    /* ErrorDetail API */
+    virtual SBuf brief() const override;
+    virtual SBuf verbose(const HttpRequestPointer &) const override;
+
+private:
+    /// known unique details in canonical order
+    std::vector<ErrorDetailPointer> details;
+};
+
+#endif /* _SQUID_SRC_ERROR_DETAILS_H */
+

--- a/src/error/Details.h
+++ b/src/error/Details.h
@@ -32,7 +32,10 @@ protected:
     // use Merge() instead
     ErrorDetails() = default;
 
+    /// adds the given detail unless we already have it
     void mergeOne(const ErrorDetail &);
+
+    /// adds unique details (if any) from the given collection
     void mergeMany(const ErrorDetails &);
 
     /* ErrorDetail API */

--- a/src/error/Error.cc
+++ b/src/error/Error.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "debug/Stream.h"
+#include "error/Details.h"
 #include "error/Error.h"
 
 void
@@ -24,8 +25,7 @@ Error::update(const Error &recent)
     // may result in more details available if they only become available later
     if (category == ERR_NONE)
         category = recent.category; // may still be ERR_NONE
-    if (!detail)
-        detail = recent.detail; // may still be nil
+    ErrorDetails::Merge(detail, recent.detail); // may still be nil
 }
 
 std::ostream &

--- a/src/error/Makefile.am
+++ b/src/error/Makefile.am
@@ -19,6 +19,8 @@ noinst_LTLIBRARIES = liberror.la
 liberror_la_SOURCES = \
 	Detail.cc \
 	Detail.h \
+	Details.cc \
+	Details.h \
 	Error.cc \
 	Error.h \
 	ExceptionErrorDetail.h \

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1350,8 +1350,8 @@ ErrorState::BuildHttpReply()
     if (request) {
         if (detail)
             request->detailError(type, detail);
-        if (const auto errNoDetail = SysErrorDetail::NewIfAny(xerrno))
-            request->detailError(type, errNoDetail);
+        if (const auto errnoDetail = SysErrorDetail::NewIfAny(xerrno))
+            request->detailError(type, errnoDetail);
     }
 
     return rep;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1350,8 +1350,8 @@ ErrorState::BuildHttpReply()
     if (request) {
         if (detail)
             request->detailError(type, detail);
-        else
-            request->detailError(type, SysErrorDetail::NewIfAny(xerrno));
+        if (const auto errNoDetail = SysErrorDetail::NewIfAny(xerrno))
+            request->detailError(type, errNoDetail);
     }
 
     return rep;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -678,15 +678,16 @@ ErrorState::NewForwarding(err_type type, HttpRequestPointer &request, const Acce
     return new ErrorState(type, status, request.getRaw(), ale);
 }
 
-ErrorState::ErrorState(err_type t) :
+ErrorState::ErrorState(const err_type t, const AccessLogEntry::Pointer &anAle):
     type(t),
     page_id(t),
-    callback(nullptr)
+    callback(nullptr),
+    ale(anAle)
 {
 }
 
 ErrorState::ErrorState(err_type t, Http::StatusCode status, HttpRequest * req, const AccessLogEntry::Pointer &anAle) :
-    ErrorState(t)
+    ErrorState(t, anAle)
 {
     if (page_id >= ERR_MAX && ErrorDynamicPages[page_id - ERR_MAX]->page_redirect != Http::scNone)
         httpStatus = ErrorDynamicPages[page_id - ERR_MAX]->page_redirect;
@@ -697,12 +698,10 @@ ErrorState::ErrorState(err_type t, Http::StatusCode status, HttpRequest * req, c
         request = req;
         src_addr = req->client_addr;
     }
-
-    ale = anAle;
 }
 
 ErrorState::ErrorState(HttpRequest * req, HttpReply *errorReply, const AccessLogEntry::Pointer &anAle):
-    ErrorState(ERR_RELAY_REMOTE)
+    ErrorState(ERR_RELAY_REMOTE, anAle)
 {
     Must(errorReply);
     response_ = errorReply;
@@ -712,8 +711,6 @@ ErrorState::ErrorState(HttpRequest * req, HttpReply *errorReply, const AccessLog
         request = req;
         src_addr = req->client_addr;
     }
-
-    ale = anAle;
 }
 
 void

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -701,7 +701,7 @@ ErrorState::ErrorState(err_type t, Http::StatusCode status, HttpRequest * req, c
     ale = anAle;
 }
 
-ErrorState::ErrorState(HttpRequest * req, HttpReply *errorReply) :
+ErrorState::ErrorState(HttpRequest * req, HttpReply *errorReply, const AccessLogEntry::Pointer &anAle):
     ErrorState(ERR_RELAY_REMOTE)
 {
     Must(errorReply);
@@ -712,6 +712,8 @@ ErrorState::ErrorState(HttpRequest * req, HttpReply *errorReply) :
         request = req;
         src_addr = req->client_addr;
     }
+
+    ale = anAle;
 }
 
 void

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -120,7 +120,7 @@ private:
     typedef ErrorPage::Build Build;
 
     /// initializations shared by public constructors
-    ErrorState(err_type, const AccessLogEntry::Pointer &);
+    ErrorState(err_type, const AccessLogEntryPointer &);
 
     /// locates the right error page template for this error and compiles it
     SBuf buildBody();

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -95,7 +95,7 @@ public:
     ErrorState() = delete; // not implemented.
 
     /// creates an ERR_RELAY_REMOTE error
-    ErrorState(HttpRequest * request, HttpReply *);
+    ErrorState(HttpRequest * request, HttpReply *, const AccessLogEntryPointer &);
 
     ~ErrorState();
 

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -120,7 +120,7 @@ private:
     typedef ErrorPage::Build Build;
 
     /// initializations shared by public constructors
-    explicit ErrorState(err_type type);
+    ErrorState(err_type, const AccessLogEntry::Pointer &);
 
     /// locates the right error page template for this error and compiles it
     SBuf buildBody();

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -444,6 +444,9 @@ TunnelStateData::retryOrBail(const char *context)
     // sendNewError() and sendSavedErrorOr(), used in "error detected" cases.
     if (!savedError)
         saveError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al));
+
+    al->updateError(Error(savedError->type, savedError->detail));
+
     const auto canSendError = Comm::IsConnOpen(client.conn) && !client.dirty &&
                               clientExpectsConnectResponse();
     if (canSendError)

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1169,6 +1169,7 @@ tunnelStart(ClientHttpRequest * http)
             debugs(26, 4, "MISS access forbidden.");
             err = new ErrorState(ERR_FORWARDING_DENIED, Http::scForbidden, request, http->al);
             http->al->http.code = Http::scForbidden;
+            http->al->updateError(Error(err->type, err->detail));
             errorSend(http->getConn()->clientConnection, err);
             return;
         }


### PR DESCRIPTION
Squid was sometimes logging %err_code/%err_detail as
ERR_CONNECT_FAIL/WITH_SERVER. It now logs
ERR_CONNECT_FAIL/WITH_SERVER+errno=111.

When dealing with two error details, Squid was ignoring the latter one.
The new ErrorDetails code combines multiple details, reusing the
existing Security::ErrorDetail::brief() "a+b+c" syntax. In hope to add
fewer overheads (and following the "pay only for what you use"
principle), ErrorDetails avoids creating the container for storing
multiple details unless we have multiple error details to store.

The new detail accumulation functionality may help detail other errors.

Also fixes/logs %err_code value for ERR_RELAY_REMOTE transactions.
