### PR TITLE
Stop leaking PeerDigests on reconfiguration

### DIFF
--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -81,7 +81,7 @@ public:
 
     CbcPointer<CachePeer> peer;           /**< pointer back to peer structure, argh */
     CacheDigest *cd = nullptr;            /**< actual digest structure */
-    SBuf host;                        ///< copy of peer->host
+    const SBuf host;                      ///< copy of peer->host
     const char *req_result = nullptr;     /**< text status of the last request */
 
     struct {

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -79,7 +79,7 @@ public:
     PeerDigest(CachePeer *);
     ~PeerDigest();
 
-    CachePeer *peer = nullptr;          /**< pointer back to peer structure, argh */
+    CbcPointer<CachePeer> peer;           /**< pointer back to peer structure, argh */
     CacheDigest *cd = nullptr;            /**< actual digest structure */
     SBuf host;                        ///< copy of peer->host
     const char *req_result = nullptr;     /**< text status of the last request */

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -79,9 +79,9 @@ public:
     PeerDigest(CachePeer *);
     ~PeerDigest();
 
-    CbcPointer<CachePeer> peer;           /**< pointer back to peer structure, argh */
+    CbcPointer<CachePeer> peer; ///< pointer back to peer structure, argh
     CacheDigest *cd = nullptr;            /**< actual digest structure */
-    const SBuf host;                      ///< copy of peer->host
+    const SBuf host; ///< copy of peer->host
     const char *req_result = nullptr;     /**< text status of the last request */
 
     struct {

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -115,7 +115,6 @@ public:
 
 extern const Version CacheDigestVer;
 
-void peerDigestCreate(CachePeer * p);
 void peerDigestNeeded(PeerDigest * pd);
 void peerDigestNotePeerGone(PeerDigest * pd);
 void peerDigestStatsReport(const PeerDigest * pd, StoreEntry * e);

--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -1555,7 +1555,7 @@ MainSafe(int argc, char **argv)
         /* BINARY DEBUGGING *
                     local_printfx("while() -> bufa[%" PRIuSIZE "]: %s", k, bufa);
                     for (i = 0; i < k; ++i)
-                      local_printfx("%02X", bufa[i]);
+                      local_printfx("%02X", static_cast<unsigned int>(static_cast<unsigned char>(bufa[i])));
                     local_printfx("\n");
         * BINARY DEBUGGING */
         /* Check for CRLF */

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -71,7 +71,7 @@ AnyP::Uri::Encode(const SBuf &buf, const CharacterSet &ignore)
     while (!tk.atEnd()) {
         // TODO: Add Tokenizer::parseOne(void).
         const auto ch = tk.remaining()[0];
-        output.appendf("%%%02X", static_cast<unsigned int>(ch)); // TODO: Optimize using a table
+        output.appendf("%%%02X", static_cast<unsigned int>(static_cast<unsigned char>(ch))); // TODO: Optimize using a table
         (void)tk.skip(ch);
 
         if (tk.prefix(goodSection, ignore))

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2391,8 +2391,7 @@ parse_peer(CachePeer ** head)
 
 #if USE_CACHE_DIGESTS
     if (!p->options.no_digest) {
-        auto pd = new PeerDigest(p);
-        p->digest = pd;
+        p->digest = new PeerDigest(p);
     }
 #endif
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2391,9 +2391,8 @@ parse_peer(CachePeer ** head)
 
 #if USE_CACHE_DIGESTS
     if (!p->options.no_digest) {
-        PeerDigest *pd = new PeerDigest(p);
-        // TODO: make CachePeer member a CbcPointer
-        p->digest = cbdataReference(pd);
+        auto pd = new PeerDigest(p);
+        p->digest = pd;
     }
 #endif
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2390,9 +2390,8 @@ parse_peer(CachePeer ** head)
         p->connect_fail_limit = 10;
 
 #if USE_CACHE_DIGESTS
-    if (!p->options.no_digest) {
+    if (!p->options.no_digest)
         p->digest = new PeerDigest(p);
-    }
 #endif
 
     if (p->secure.encryptTransport)

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2390,8 +2390,11 @@ parse_peer(CachePeer ** head)
         p->connect_fail_limit = 10;
 
 #if USE_CACHE_DIGESTS
-    if (!p->options.no_digest)
-        peerDigestCreate(p);
+    if (!p->options.no_digest) {
+        PeerDigest *pd = new PeerDigest(p);
+        // TODO: make CachePeer member a CbcPointer
+        p->digest = cbdataReference(pd);
+    }
 #endif
 
     if (p->secure.encryptTransport)

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -66,9 +66,9 @@ static const time_t GlobDigestReqMinGap = 1 * 60;   /* seconds */
 
 static time_t pd_last_req_time = 0; /* last call to Check */
 
-PeerDigest::PeerDigest(CachePeer *p) :
+PeerDigest::PeerDigest(CachePeer * const p):
     peer(p),
-    host(peer->host) // if peer disappears, we will know it's name
+    host(peer->host) // if peer disappears, we will know its name
 {
     times.initialized = squid_curtime;
 }
@@ -200,7 +200,7 @@ peerDigestCheck(void *data)
         return;
     }
 
-    debugs(72, 3, "cache_peer " << RawPointer(pd->peer.raw()).orNil());
+    debugs(72, 3, "cache_peer " << RawPointer(pd->peer).orNil());
     debugs(72, 3, "peerDigestCheck: time: " << squid_curtime <<
            ", last received: " << (long int) pd->times.received << "  (" <<
            std::showpos << (int) (squid_curtime - pd->times.received) << ")");

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -131,14 +131,6 @@ peerDigestCreate(CachePeer * p)
     p->digest = cbdataReference(pd);
 }
 
-/* call Clean and free/unlock everything */
-static void
-peerDigestDestroy(PeerDigest * pd)
-{
-    assert(pd);
-    delete pd;
-}
-
 PeerDigest::~PeerDigest()
 {
     delete cd;
@@ -202,7 +194,7 @@ peerDigestNotePeerGone(PeerDigest * pd)
         /* do nothing now, the fetching chain will notice and take action */
     } else {
         debugs(72, 2, "peerDigest: peer " << pd->host << " is gone, destroying now.");
-        peerDigestDestroy(pd);
+        delete pd;
     }
 }
 

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -119,18 +119,6 @@ DigestFetchState::~DigestFetchState()
     assert(pd == nullptr);
 }
 
-/* allocate new peer digest, call Init, and lock everything */
-void
-peerDigestCreate(CachePeer * p)
-{
-    assert(p);
-
-    PeerDigest *pd = new PeerDigest(p);
-
-    // TODO: make CachePeer member a CbcPointer
-    p->digest = cbdataReference(pd);
-}
-
 PeerDigest::~PeerDigest()
 {
     delete cd;


### PR DESCRIPTION
peerDigestCreate() cbdata-locked the digest twice. The second lock was a
"self lock" -- a lock without storing the locked pointer somewhere. That
self lock was introduced (with an XXX) in 2002 commit fa80a8e. It did
not have the corresponding unlock, and Squid leaked the digest object.
That leak became conditional in 2018 commit b56b37c: Since then, Squid
was missing one digest unlock _only_ when the CachePeer object was gone
before a peerDigestDestroy() call, as happens during reconfiguration.

Also removed a pair of excessive cbdata locks/unlocks (that triggered
this leak): Long-term users should lock when they start storing a
pointer to the cbdata-protected object and unlock when they stop.
