### PR TITLE
Forget non-peer access details

### DIFF
--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -30,7 +30,7 @@ The Squid-@SQUID_RELEASE@ change history can be <url url="https://github.com/squ
 
 <p>The most important of these new features are:
 <itemize>
-	<item>
+	<item> cache manager non_peers report removal
 </itemize>
 
 Most user-facing changes are reflected in squid.conf (see below).
@@ -60,6 +60,8 @@ This section gives an account of those changes in three categories:
 	<tag>buffered_logs</tag>
 	<p>Honor the <em>off</em> setting in 'udp' access_log module.
 
+	<tag>cachemgr_passwd</tag>
+	<p>Removed the <em>non_peers</em> action.
 </descrip>
 
 <sect1>Removed directives<label id="removeddirectives">

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -52,16 +52,14 @@ public:
 
     /// cache_peer name (if explicitly configured) or hostname (otherwise).
     /// Unique across already configured cache_peers in the current configuration.
-    /// Not necessarily unique across discovered non-peers (see mgr:non_peers).
     /// The value may change during CachePeer configuration.
     /// The value affects various peer selection hashes (e.g., carp.hash).
     /// Preserves configured spelling (i.e. does not lower letters case).
     /// Never nil.
     char *name = nullptr;
 
-    /// The lowercase version of the configured cache_peer hostname or
-    /// the IP address of a non-peer (see mgr:non_peers).
-    /// May not be unique among cache_peers and non-peers.
+    /// The lowercase version of the configured cache_peer hostname.
+    /// May not be unique among cache_peers.
     /// Never nil.
     char *host = nullptr;
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -10354,7 +10354,6 @@ DOC_START
 		mem
 		menu
 		netdb
-		non_peers
 		objects
 		offline_toggle *
 		pconn

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -940,9 +940,9 @@ neighborIgnoreNonPeer(const Ip::Address &from, icp_opcode opcode)
 {
     static uint64_t ignoredReplies = 0;
     if (isPowTen(++ignoredReplies)) {
-        debugs(15, DBG_IMPORTANT, "WARNING: Ignored " << ignoredReplies << " replies overall from non-peers" <<
-               Debug::Extra << "Last ignored address: " << from <<
-               Debug::Extra << "OPPCODE: " << icp_opcode_str[opcode]);
+        debugs(15, DBG_IMPORTANT, "WARNING: Ignored " << ignoredReplies << " ICP replies from non-peers" <<
+               Debug::Extra << "last seen non-peer source address: " << from <<
+               Debug::Extra << "last seen ICP reply opcode: " << icp_opcode_str[opcode]);
     }
 }
 


### PR DESCRIPTION
We were using the CachePeer class to record the address of each non-peer
sending us certain unwanted ICP responses, along with the number of such
responses and a histogram of associated ICP opcodes. Since 1997 commit
e102ebd, these historical records were accumulated without a limit and
linearly searched, endangering a Squid instance that used ICP. Using
CachePeer to store this non-cache_peer information also complicated
cache_peer code.

This change removes these records and the corresponding mgr:non_peers
report, leaving just the cache.log warning about unexpected messages.
The warning is useful because these ICP messages from non-peers indicate
a cache hierarchy misconfiguration or a fairly sophisticated attack.

This is the simplest fix that minimizes Squid and developer resources
spent on handling these errors.
