### PR TITLE
Order outgoing request headers similar to incoming request headers

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -627,8 +627,11 @@ HttpHeader::sortInto(Packable &p, const HttpHeader &model) const
 {
     debugs(55, 7, this << " following " << &model);
 
-    // form to-do list
-    auto toPack(entries);
+    // Form a to-do list.
+    // No "auto" here to avoid silent copying of (expected) entries changes;
+    // we want this container to be a fast index without entry (de)allocations.
+    using Index = std::vector<HttpHeaderEntry*, PoolingAllocator<HttpHeaderEntry*> >;
+    Index toPack(entries);
 
     // pack those toPack entries that are present in the model, ~in model order
     for (const auto modelE: model.entries) {

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -96,6 +96,8 @@ public:
     /// \returns -1 on error
     int parse(const char *buf, size_t buf_len, bool atEnd, size_t &hdr_sz, Http::ContentLengthInterpreter &interpreter);
     void packInto(Packable * p, bool mask_sensitive_info=false) const;
+    /// pack the fields in the given name order
+    void sortInto(Packable &p, const HttpHeader &model) const;
     HttpHeaderEntry *getEntry(HttpHeaderPos * pos) const;
     HttpHeaderEntry *findEntry(Http::HdrType id) const;
     /// deletes all fields with a given name, if any.

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -60,7 +60,10 @@ public:
     int getInt() const;
     int64_t getInt64() const;
 
+    bool hasId(const Http::HdrType other) const { return other == id || other == alternateId; }
+
     Http::HdrType id;
+    Http::HdrType alternateId;
     SBuf name;
     String value;
 };

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -60,10 +60,7 @@ public:
     int getInt() const;
     int64_t getInt64() const;
 
-    bool hasId(const Http::HdrType other) const { return other == id || other == alternateId; }
-
     Http::HdrType id;
-    Http::HdrType alternateId;
     SBuf name;
     String value;
 };

--- a/src/http.cc
+++ b/src/http.cc
@@ -2362,7 +2362,7 @@ HttpStateData::buildRequestPrefix(MemBuf * mb)
             upgradeHeaderOut = new String(hdr.getList(Http::HdrType::UPGRADE));
         }
 
-        hdr.packInto(mb);
+        hdr.sortInto(*mb, request->header);
         hdr.clean();
     }
     /* append header terminator */


### PR DESCRIPTION
This initial implementation relies on the incoming request headers order
preserved by Squid. Unfortunately, Squid manipulates some of the
original headers as well, distorting the actual original order.
