### PR TITLE
Handle helper program startup failure as its death

### DIFF
--- a/src/helper.cc
+++ b/src/helper.cc
@@ -246,6 +246,8 @@ helperOpenServers(const helper::Pointer &hlp)
 
     assert(nargs <= HELPER_MAX_ARGS);
 
+    auto sawFailures = false;
+
     for (k = 0; k < need_new; ++k) {
         getCurrentTime();
         rfd = wfd = -1;
@@ -260,6 +262,8 @@ helperOpenServers(const helper::Pointer &hlp)
 
         if (pid < 0) {
             debugs(84, DBG_IMPORTANT, "WARNING: Cannot run '" << progname << "' process.");
+            // delay handleLackOfServers(); the loop might start enough helpers
+            sawFailures = true;
             continue;
         }
 
@@ -311,6 +315,13 @@ helperOpenServers(const helper::Pointer &hlp)
                                              CommIoCbPtrFun(helperHandleRead, srv));
         comm_read(srv->readPipe, srv->rbuf, srv->rbuf_sz - 1, call);
     }
+
+    // Call handleLackOfServers() before hlp->last_restart is updated because
+    // that method uses last_restart to measure the delay since previous start.
+    // TODO: Refactor last_restart code to measure failure frequency rather than
+    // detecting a helper X failure that is being close to a helper Y start.
+    if (sawFailures)
+        hlp->handleLackOfServers(false);
 
     hlp->last_restart = squid_curtime;
     safe_free(shortname);
@@ -371,6 +382,8 @@ helperStatefulOpenServers(const statefulhelper::Pointer &hlp)
 
     assert(nargs <= HELPER_MAX_ARGS);
 
+    auto sawFailures = false;
+
     for (int k = 0; k < need_new; ++k) {
         getCurrentTime();
         int rfd = -1;
@@ -387,6 +400,8 @@ helperStatefulOpenServers(const statefulhelper::Pointer &hlp)
 
         if (pid < 0) {
             debugs(84, DBG_IMPORTANT, "WARNING: Cannot run '" << progname << "' process.");
+            // delay handleLackOfServers(); the loop might start enough helpers
+            sawFailures = true;
             continue;
         }
 
@@ -430,6 +445,13 @@ helperStatefulOpenServers(const statefulhelper::Pointer &hlp)
                                              CommIoCbPtrFun(helperStatefulHandleRead, srv));
         comm_read(srv->readPipe, srv->rbuf, srv->rbuf_sz - 1, call);
     }
+
+    // Call handleLackOfServers() before hlp->last_restart is updated because
+    // that method uses last_restart to measure the delay since previous start.
+    // TODO: Refactor last_restart code to measure failure frequency rather than
+    // detecting a helper X failure that is being close to helper Y start.
+    if (sawFailures)
+        hlp->handleLackOfServers(false);
 
     hlp->last_restart = squid_curtime;
     safe_free(shortname);
@@ -848,17 +870,23 @@ helper::handleKilledServer(HelperServerBase *srv, bool &needsNewServers)
         debugs(84, DBG_CRITICAL, "WARNING: " << id_name << " #" << srv->index << " exited");
 
         if (childs.needNew() > 0) {
-            debugs(80, DBG_IMPORTANT, "Too few " << id_name << " processes are running (need " << childs.needNew() << "/" << childs.n_max << ")");
-
-            if (childs.n_active < childs.n_startup && last_restart > squid_curtime - 30) {
-                if (srv->stats.replies < 1)
-                    fatalf("The %s helpers are crashing too rapidly, need help!\n", id_name);
-                else
-                    debugs(80, DBG_CRITICAL, "ERROR: The " << id_name << " helpers are crashing too rapidly, need help!");
-            }
+            handleLackOfServers(srv->stats.replies >= 1);
             srv->flags.shutdown = true;
             needsNewServers = true;
         }
+    }
+}
+
+void
+helper::handleLackOfServers(const bool madeProgress)
+{
+    debugs(80, DBG_IMPORTANT, "Too few " << id_name << " processes are running (need " << childs.needNew() << "/" << childs.n_max << ")");
+    debugs(80, DBG_IMPORTANT, childs.n_active << "<" << childs.n_startup << " && " << squid_curtime - last_restart);
+    if (childs.n_active < childs.n_startup && last_restart > squid_curtime - 30) {
+        if (madeProgress)
+            debugs(80, DBG_CRITICAL, "ERROR: The " << id_name << " helpers are crashing too rapidly, need help!");
+        else
+            fatalf("The %s helpers are crashing too rapidly, need help!", id_name);
     }
 }
 

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -319,7 +319,7 @@ helperOpenServers(const helper::Pointer &hlp)
     // Call handleLackOfServers() before hlp->last_restart is updated because
     // that method uses last_restart to measure the delay since previous start.
     // TODO: Refactor last_restart code to measure failure frequency rather than
-    // detecting a helper X failure that is being close to a helper Y start.
+    // detecting a helper X failure that is being close to the helper Y start.
     if (sawFailures)
         hlp->handleLackOfServers(false);
 
@@ -449,7 +449,7 @@ helperStatefulOpenServers(const statefulhelper::Pointer &hlp)
     // Call handleLackOfServers() before hlp->last_restart is updated because
     // that method uses last_restart to measure the delay since previous start.
     // TODO: Refactor last_restart code to measure failure frequency rather than
-    // detecting a helper X failure that is being close to helper Y start.
+    // detecting a helper X failure that is being close to the helper Y start.
     if (sawFailures)
         hlp->handleLackOfServers(false);
 
@@ -880,8 +880,10 @@ helper::handleKilledServer(HelperServerBase *srv, bool &needsNewServers)
 void
 helper::handleLackOfServers(const bool madeProgress)
 {
-    debugs(80, DBG_IMPORTANT, "Too few " << id_name << " processes are running (need " << childs.needNew() << "/" << childs.n_max << ")");
-    debugs(80, DBG_IMPORTANT, childs.n_active << "<" << childs.n_startup << " && " << squid_curtime - last_restart);
+    debugs(80, DBG_IMPORTANT, "Too few " << id_name << " processes are running (need " << childs.needNew() << "/" << childs.n_max << ")" <<
+           Debug::Extra << "active processes: " << childs.n_active <<
+           Debug::Extra << "startup processes: " << childs.n_startup <<
+           Debug::Extra << "seconds since startup: " << squid_curtime - last_restart);
     if (childs.n_active < childs.n_startup && last_restart > squid_curtime - 30) {
         if (madeProgress)
             debugs(80, DBG_CRITICAL, "ERROR: The " << id_name << " helpers are crashing too rapidly, need help!");

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -319,7 +319,7 @@ helperOpenServers(const helper::Pointer &hlp)
     // Call handleLackOfServers() before hlp->last_restart is updated because
     // that method uses last_restart to measure the delay since previous start.
     // TODO: Refactor last_restart code to measure failure frequency rather than
-    // detecting a helper X failure that is being close to the helper Y start.
+    // detecting a helper #X failure that is being close to the helper #Y start.
     if (sawFailures)
         hlp->handleLackOfServers(false);
 
@@ -449,7 +449,7 @@ helperStatefulOpenServers(const statefulhelper::Pointer &hlp)
     // Call handleLackOfServers() before hlp->last_restart is updated because
     // that method uses last_restart to measure the delay since previous start.
     // TODO: Refactor last_restart code to measure failure frequency rather than
-    // detecting a helper X failure that is being close to the helper Y start.
+    // detecting a helper #X failure that is being close to the helper #Y start.
     if (sawFailures)
         hlp->handleLackOfServers(false);
 
@@ -882,8 +882,7 @@ helper::handleLackOfServers(const bool madeProgress)
 {
     debugs(80, DBG_IMPORTANT, "Too few " << id_name << " processes are running (need " << childs.needNew() << "/" << childs.n_max << ")" <<
            Debug::Extra << "active processes: " << childs.n_active <<
-           Debug::Extra << "startup processes: " << childs.n_startup <<
-           Debug::Extra << "seconds since startup: " << squid_curtime - last_restart);
+           Debug::Extra << "processes configured to start at (re)configuration: " << childs.n_startup);
     if (childs.n_active < childs.n_startup && last_restart > squid_curtime - 30) {
         if (madeProgress)
             debugs(80, DBG_CRITICAL, "ERROR: The " << id_name << " helpers are crashing too rapidly, need help!");

--- a/src/helper.h
+++ b/src/helper.h
@@ -93,6 +93,10 @@ public:
     /// \param needsNewServers true if new servers must started, false otherwise
     void handleKilledServer(HelperServerBase *srv, bool &needsNewServers);
 
+    /// Reacts to an insufficient number of servers after a server death
+    /// \param madeProgress whether the died server responded to any requests
+    void handleLackOfServers(bool madeProgress);
+
 public:
     wordlist *cmdline;
     dlink_list servers;

--- a/src/helper.h
+++ b/src/helper.h
@@ -93,9 +93,10 @@ public:
     /// \param needsNewServers true if new servers must started, false otherwise
     void handleKilledServer(HelperServerBase *srv, bool &needsNewServers);
 
-    /// Reacts to an insufficient number of servers after a server death
+    /// Reacts to unexpected server death(s), including a failure to start server(s)
+    /// and an unexpected exit of a previously started server. \sa handleKilledServer()
     /// \param madeProgress whether the died server responded to any requests
-    void handleLackOfServers(bool madeProgress);
+    void handleFewerServers(bool madeProgress);
 
 public:
     wordlist *cmdline;


### PR DESCRIPTION
Squid quits when started helper programs die too fast without responding
to requests[^1] because such a Squid instance is unlikely to provide
acceptable service (and a full restart may actually fix the problem or,
at the very least, is more likely to bring the needed admin attention).

The same logic now applies when Squid fails to start a helper (i.e. when
ipcCreate() fails). There is no conceptual difference between those two
kinds of failures as far as helper handling code is concerned, so we now
treat them the same way.

Without these changes, helper start failures may result in an unusable
(but running) Squid instance, especially if no helpers can be started at
all, because new transactions get stuck waiting in the queue until
clients timeout. Such persistent ipcCreate() failures may be caused, for
example, by its fork() hitting an overcommit memory limits.

[^1]: The actual condition excludes cases where at least startup=N helpers
are still running. That exclusion and other helper failure handling
details are problematic, but adjusting that code is outside _this_ fix
scope: Here, we only apply _existing_ handling logic to a missed case.