### PR TITLE
Add %transport::>connection_id logformat code

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4684,6 +4684,19 @@ DOC_START
 		>qos    Client connection TOS/DSCP value set by Squid
 		>nfmark Client connection netfilter packet MARK set by Squid
 
+		transport::>connection_id Identifies a transport connection
+			accepted by Squid (e.g., a connection carrying the
+			logged HTTP request). Currently, Squid only supports
+			TCP transport connections.
+
+			The logged identifier is an unsigned integer. These
+			IDs are guaranteed to monotonically increase within a
+			single worker process lifetime, with higher values
+			corresponding to connections that were accepted later.
+			Many IDs are skipped (i.e. never logged). Concurrent
+			workers and restarted workers use similar, partially
+			overlapping sequences of IDs.
+
 		la	Local listening IP address the client connection was connected to.
 		lp	Local listening port number the client connection was connected to.
 

--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -20,7 +20,7 @@
 
 #include <ostream>
 
-InstanceIdDefinitions(Comm::Connection, "conn");
+InstanceIdDefinitions(Comm::Connection, "conn", uint64_t);
 
 class CachePeer;
 bool

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -178,7 +178,7 @@ public:
     Eui::Eui64 remoteEui64;
 #endif
 
-    InstanceId<Connection> id;
+    InstanceId<Connection, uint64_t> id;
 
 private:
     /** cache_peer data object (if any) */

--- a/src/format/ByteCode.h
+++ b/src/format/ByteCode.h
@@ -46,6 +46,8 @@ typedef enum {
     LFT_CLIENT_LOCAL_TOS,
     LFT_CLIENT_LOCAL_NFMARK,
 
+    LFT_TRANSPORT_CLIENT_CONNECTION_ID,
+
     LFT_CLIENT_HANDSHAKE,
 
     /* client connection local squid.conf details */

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -485,6 +485,13 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
                 out = al->tcpClient->local.toStr(tmp, sizeof(tmp));
             break;
 
+        case LFT_TRANSPORT_CLIENT_CONNECTION_ID:
+            if (al->tcpClient) {
+                outUint64 = al->tcpClient->id.value;
+                doUint64 = true;
+            }
+            break;
+
         case LFT_CLIENT_LOCAL_TOS:
             if (al->tcpClient) {
                 sb.appendf("0x%x", static_cast<uint32_t>(al->tcpClient->tos));

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -184,6 +184,10 @@ static TokenTableEntry TokenTableProxyProtocol[] = {
     TokenTableEntry(">h", LFT_PROXY_PROTOCOL_RECEIVED_HEADER),
 };
 
+static TokenTableEntry TokenTableTransport[] = {
+    TokenTableEntry(">connection_id", LFT_TRANSPORT_CLIENT_CONNECTION_ID),
+};
+
 #if USE_ADAPTATION
 static TokenTableEntry TokenTableAdapt[] = {
     TokenTableEntry("all_trs", LFT_ADAPTATION_ALL_XACT_TIMES),
@@ -260,6 +264,7 @@ Format::Token::Init()
     TheConfig.registerTokens(SBuf("ssl"),::Format::TokenTableSsl);
 #endif
     TheConfig.registerTokens(SBuf("proxy_protocol"), ::Format::TokenTableProxyProtocol);
+    TheConfig.registerTokens(SBuf("transport"), ::Format::TokenTableTransport);
 }
 
 /// Scans a token table to see if the next token exists there

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -29,7 +29,7 @@ CachePeer * Comm::Connection::getPeer() const STUB_RETVAL(nullptr)
 void Comm::Connection::setPeer(CachePeer *) STUB
 ScopedId Comm::Connection::codeContextGist() const STUB_RETVAL(id.detach())
 std::ostream &Comm::Connection::detailCodeContext(std::ostream &os) const STUB_RETVAL(os)
-InstanceIdDefinitions(Comm::Connection, "conn");
+InstanceIdDefinitions(Comm::Connection, "conn", uint64_t);
 
 #include "comm/ConnOpener.h"
 CBDATA_NAMESPACED_CLASS_INIT(Comm, ConnOpener);


### PR DESCRIPTION
Knowing client transport connection ID can be very helpful in triage,
especially when dealing with multiple requests associated with a
problematic connection (e.g., two access log records associated with a
single TLS connection bumping failure).

The "transport" namespace was added in hope to reduce confusion when/if
other connection_id %codes are added. The shorter and more familiar
"tcp::" namespace was rejected because we want configurations using the
new %code to continue to work well after Squid gains HTTP/3 support, and
HTTP/3 uses UDP for transport connections. Other UDP-based protocols may
have similar "connection" concepts.

----

Cherry-picked master/v6 commit a120b7a8793b8b1fadd97063dd5c20485a3ab1f1.