### PR TITLE
Upgrade Security::PeerOptions::dumpCfg() to std::ostream

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3897,7 +3897,8 @@ dump_generic_port(StoreEntry * e, const char *n, const AnyP::PortCfgPointer &s)
         storeAppendPrintf(e, " ssl-bump");
 #endif
 
-    s->secure.dumpCfg(e, "tls-");
+    PackableStream os(*e);
+    s->secure.dumpCfg(os, "tls-");
 }
 
 static void

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -13,6 +13,7 @@
 #include "anyp/PortCfg.h"
 #include "base/EnumIterator.h"
 #include "base/IoManip.h"
+#include "base/PackableStream.h"
 #include "CacheDigest.h"
 #include "CachePeer.h"
 #include "comm/Connection.h"
@@ -1546,7 +1547,8 @@ dump_peer_options(StoreEntry * sentry, CachePeer * p)
     else if (p->connection_auth == 2)
         storeAppendPrintf(sentry, " connection-auth=auto");
 
-    p->secure.dumpCfg(sentry,"tls-");
+    PackableStream os(*sentry);
+    p->secure.dumpCfg(os,"tls-");
     storeAppendPrintf(sentry, "\n");
 }
 

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -102,51 +102,51 @@ Security::PeerOptions::parse(const char *token)
 }
 
 void
-Security::PeerOptions::dumpCfg(Packable *p, const char *pfx) const
+Security::PeerOptions::dumpCfg(std::ostream &os, const char *pfx) const
 {
     if (!encryptTransport) {
-        p->appendf(" %sdisable", pfx);
+        os << pfx << "disable";
         return; // no other settings are relevant
     }
 
     for (auto &i : certs) {
         if (!i.certFile.isEmpty())
-            p->appendf(" %scert=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(i.certFile));
+            os << ' ' << pfx << "cert=" << i.certFile;
 
         if (!i.privateKeyFile.isEmpty() && i.privateKeyFile != i.certFile)
-            p->appendf(" %skey=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(i.privateKeyFile));
+            os << ' ' << pfx << "key=" << i.privateKeyFile;
     }
 
     if (!sslOptions.isEmpty())
-        p->appendf(" %soptions=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(sslOptions));
+        os << ' ' << pfx << sslOptions;
 
     if (!sslCipher.isEmpty())
-        p->appendf(" %scipher=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(sslCipher));
+        os << ' ' << pfx << sslCipher;
 
     for (auto i : caFiles) {
-        p->appendf(" %scafile=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(i));
+        os << ' ' << pfx <<  "cafile=" << i;
     }
 
     if (!caDir.isEmpty())
-        p->appendf(" %scapath=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(caDir));
+        os << ' ' << pfx << "capath=" << caDir;
 
     if (!crlFile.isEmpty())
-        p->appendf(" %scrlfile=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(crlFile));
+        os << ' ' << pfx << "crlfile=" << crlFile;
 
     if (!sslFlags.isEmpty())
-        p->appendf(" %sflags=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(sslFlags));
+        os << ' ' << pfx << "flags=" << sslFlags;
 
     if (flags.tlsDefaultCa.configured()) {
         // default ON for peers / upstream servers
         // default OFF for listening ports
         if (flags.tlsDefaultCa)
-            p->appendf(" %sdefault-ca", pfx);
+            os << ' ' << pfx << "default-ca";
         else
-            p->appendf(" %sdefault-ca=off", pfx);
+            os << ' ' << pfx << "default-ca=off";
     }
 
     if (!flags.tlsNpn)
-        p->appendf(" %sno-npn", pfx);
+        os << ' ' << pfx << "no-npn";
 }
 
 void

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -67,7 +67,7 @@ public:
     void updateSessionOptions(Security::SessionPointer &);
 
     /// output squid.conf syntax with 'pfx' prefix on parameters for the stored settings
-    virtual void dumpCfg(Packable *, const char *pfx) const;
+    virtual void dumpCfg(std::ostream &, const char *pfx) const;
 
 private:
     ParsedPortFlags parseFlags();
@@ -153,7 +153,7 @@ extern PeerOptions ProxyOutgoingConfig;
 // parse the tls_outgoing_options directive
 void parse_securePeerOptions(Security::PeerOptions *);
 #define free_securePeerOptions(x) Security::ProxyOutgoingConfig.clear()
-#define dump_securePeerOptions(e,n,x) do { (e)->appendf(n); (x).dumpCfg((e),""); (e)->append("\n",1); } while(false)
+#define dump_securePeerOptions(e,n,x) do { (e)->appendf(n); PackableStream os(*e); (x).dumpCfg(os,""); (e)->append("\n",1); } while(false)
 
 #endif /* SQUID_SRC_SECURITY_PEEROPTIONS_H */
 

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -136,26 +136,26 @@ Security::ServerOptions::parse(const char *token)
 }
 
 void
-Security::ServerOptions::dumpCfg(Packable *p, const char *pfx) const
+Security::ServerOptions::dumpCfg(std::ostream &os, const char *pfx) const
 {
     // dump out the generic TLS options
-    Security::PeerOptions::dumpCfg(p, pfx);
+    Security::PeerOptions::dumpCfg(os, pfx);
 
     if (!encryptTransport)
         return; // no other settings are relevant
 
     // dump the server-only options
     if (!dh.isEmpty())
-        p->appendf(" %sdh=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(dh));
+        os << ' ' << pfx << "dh=" << dh;
 
     if (!generateHostCertificates)
-        p->appendf(" %sgenerate-host-certificates=off", pfx);
+        os << ' ' << pfx << "generate-host-certificates=off";
 
     if (dynamicCertMemCacheSize != 4*1024*1024) // 4MB default, no 'tls-' prefix
-        p->appendf(" dynamic_cert_mem_cache_size=%zubytes", dynamicCertMemCacheSize);
+        os << ' ' << "dynamic_cert_mem_cache_size=" << dynamicCertMemCacheSize << "bytes";
 
     if (!staticContextSessionId.isEmpty())
-        p->appendf(" %scontext=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(staticContextSessionId));
+        os << ' ' << pfx << "context=" << staticContextSessionId;
 }
 
 Security::ContextPointer

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -45,7 +45,7 @@ public:
     void parse(const char *) override;
     void clear() override {*this = ServerOptions();}
     Security::ContextPointer createBlankContext() const override;
-    void dumpCfg(Packable *, const char *pfx) const override;
+    void dumpCfg(std::ostream &, const char *pfx) const override;
 
     /// initialize all server contexts as-needed and load PEM files.
     /// if none can be created this may do nothing.

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -118,7 +118,7 @@ void Security::PeerOptions::updateContextCa(Security::ContextPointer &) STUB
 void Security::PeerOptions::updateContextCrl(Security::ContextPointer &) STUB
 void Security::PeerOptions::updateContextTrust(Security::ContextPointer &) STUB
 void Security::PeerOptions::updateSessionOptions(Security::SessionPointer &) STUB
-void Security::PeerOptions::dumpCfg(Packable*, char const*) const STUB
+void Security::PeerOptions::dumpCfg(std::ostream &, char const*) const STUB
 void Security::PeerOptions::parseOptions() STUB
 void parse_securePeerOptions(Security::PeerOptions *) STUB
 
@@ -126,7 +126,7 @@ void parse_securePeerOptions(Security::PeerOptions *) STUB
 //Security::ServerOptions::ServerOptions(const Security::ServerOptions &) STUB
 Security::ServerOptions &Security::ServerOptions::operator=(Security::ServerOptions const&) STUB_RETVAL(*this);
 void Security::ServerOptions::parse(const char *) STUB
-void Security::ServerOptions::dumpCfg(Packable *, const char *) const STUB
+void Security::ServerOptions::dumpCfg(std::ostream &, const char *) const STUB
 Security::ContextPointer Security::ServerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer())
 void Security::ServerOptions::initServerContexts(AnyP::PortCfg&) STUB
 bool Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &) STUB_RETVAL(false)


### PR DESCRIPTION
With this improvement we can reuse Configuration::Component
printing API in new directives.