### PR TITLE
Do not collapse ssl_crtd requests across reconfigurations 2

### DIFF
--- a/src/helper.h
+++ b/src/helper.h
@@ -70,7 +70,7 @@ public:
     /// \param name admin-visible helper category (with this process lifetime)
     static Pointer Make(const char *name);
 
-    ~helper();
+    virtual ~helper();
 
     /// \returns next request in the queue, or nil.
     Helper::Xaction *nextRequest();
@@ -97,6 +97,9 @@ public:
     /// and an unexpected exit of a previously started server. \sa handleKilledServer()
     /// \param madeProgress whether the died server(s) responded to any requests
     void handleFewerServers(bool madeProgress);
+
+    /// informs the request initiator with helper response
+    virtual void callBack(HLPCB *, void *, const Helper::Reply &);
 
 public:
     wordlist *cmdline = nullptr;
@@ -196,6 +199,9 @@ public:
     /// dequeues and sends a Helper::Unknown answer to all queued requests
     virtual void dropQueued();
 
+    /// the corresponding helper object
+    virtual helper *parentHelper() = 0;
+
 public:
     /// Helper program identifier; does not change when contents do,
     ///   including during assignment
@@ -278,6 +284,7 @@ public:
     /*HelperServerBase API*/
     bool reserved() override {return false;}
     void dropQueued() override;
+    helper *parentHelper() override { assert(parent); return parent.getRaw(); }
 
     /// Read timeout handler
     static void requestTimeout(const CommTimeoutCbParams &io);
@@ -296,6 +303,8 @@ public:
     ~helper_stateful_server() override;
     void reserve();
     void clearReservation();
+
+    helper *parentHelper() override { assert(parent); return parent.getRaw(); }
 
     /* HelperServerBase API */
     bool reserved() override {return reservationId.reserved();}


### PR DESCRIPTION
With this new approach each Ssl::Helper object has its own
GeneratorRequests map (used for collapsing).  Since a reconfiguration
creates a new Sll::Helper, collapsed requests are not shared across
reconfigurations.