### PR TITLE
Honor flags.noCache in cache manager requests

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -24,6 +24,7 @@
 #include "HttpHeaderTools.h"
 #include "HttpReply.h"
 #include "HttpRequest.h"
+#include "internal.h"
 #include "ip/QosConfig.h"
 #include "ipcache.h"
 #include "log/access_log.h"
@@ -1486,15 +1487,14 @@ clientReplyContext::identifyStoreObject()
 
     // client sent CC:no-cache or some other condition has been
     // encountered which prevents delivering a public/cached object.
-    // XXX: The above text does not match the condition below. It might describe
-    // the opposite condition, but the condition itself should be adjusted
-    // (e.g., to honor flags.noCache in cache manager requests).
-    if (!r->flags.noCache || r->flags.internal) {
+    if (r->flags.noCache) {
+        // no-cache requests skip Store lookups
+        identifyFoundObject(nullptr, "no-cache");
+    } else {
+        // cache manager requests ought to have flags.noCache (handled above)
+        Assure(!ForSomeCacheManager(r->url.path()));
         const auto e = storeGetPublicByRequest(r);
         identifyFoundObject(e, storeLookupString(bool(e)));
-    } else {
-        // "external" no-cache requests skip Store lookups
-        identifyFoundObject(nullptr, "no-cache");
     }
 }
 


### PR DESCRIPTION
Cache Manager requests are not cached since 92a5adb7.
This case was spotted (with an XXX) but not fixed in that revision.