### PR TITLE
Add %byte{value} logformat code for logging or sending arbitrary bytes

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4685,6 +4685,13 @@ DOC_START
 	Format codes:
 
 		%	a literal % character
+
+		byte{value}	Adds a single byte with the given value (e.g., %byte{10}
+			adds an ASCII LF character a.k.a. "new line" or "\n"). The value
+			parameter is required and must be a positive decimal integer not
+			exceeding 255. Zero-valued bytes (i.e. ASCII NUL characters) are
+			not yet supported.
+
 		sn	Unique sequence number per log line entry
 		err_code    The ID of an error response served by Squid or
 				a similar internal error identifier.

--- a/src/format/ByteCode.h
+++ b/src/format/ByteCode.h
@@ -30,6 +30,8 @@ namespace Format
 typedef enum {
     LFT_NONE,           /* dummy */
 
+    LFT_BYTE, ///< %byte{value}
+
     /* arbitrary string between tokens */
     LFT_STRING,
 

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -399,6 +399,12 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             out = "";
             break;
 
+        case LFT_BYTE:
+            tmp[0] = static_cast<char>(fmt->data.byteValue);
+            tmp[1] = '\0';
+            out = tmp;
+            break;
+
         case LFT_STRING:
             out = fmt->data.string;
             break;

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -11,6 +11,7 @@
 #include "format/Token.h"
 #include "format/TokenTableEntry.h"
 #include "globals.h"
+#include "parser/Tokenizer.h"
 #include "proxyp/Elements.h"
 #include "sbuf/Stream.h"
 #include "SquidConfig.h"
@@ -139,6 +140,7 @@ static TokenTableEntry TokenTable2C[] = {
 
 /// Miscellaneous >2 byte tokens
 static TokenTableEntry TokenTableMisc[] = {
+    TokenTableEntry("byte", LFT_BYTE),
     TokenTableEntry(">eui", LFT_CLIENT_EUI),
     TokenTableEntry(">qos", LFT_CLIENT_LOCAL_TOS),
     TokenTableEntry("<qos", LFT_SERVER_LOCAL_TOS),
@@ -283,6 +285,61 @@ Format::Token::scanForToken(TokenTableEntry const table[], const char *cur)
         }
     }
     return cur;
+}
+
+/// parses a decimal integer that fits the specified Integer type
+template <typename Integer>
+static Integer
+ParseInteger(const char *description, const SBuf &rawInput)
+{
+    Parser::Tokenizer tok(rawInput);
+    if (tok.skip('0')) {
+        if (!tok.atEnd()) {
+            // e.g., 077, 0xFF, 0b101, or 0.1
+            throw TextException(ToSBuf("Malformed ", description,
+                                ": Expected a decimal integer without leading zeros but got '",
+                                rawInput, "'"), Here());
+        }
+        return Integer(0);
+    }
+    // else the value might still be zero (e.g., -0)
+
+    const auto lowerLimit = std::numeric_limits<Integer>::min();
+    const auto upperLimit = std::numeric_limits<Integer>::max();
+
+    // check that our caller is compatible with Tokenizer::int64() use below
+    using ParsedInteger = int64_t;
+    static_assert(lowerLimit >= std::numeric_limits<ParsedInteger>::min());
+    static_assert(upperLimit <= std::numeric_limits<ParsedInteger>::max());
+
+    ParsedInteger rawInteger = 0;
+    if (!tok.int64(rawInteger, 10, true)) {
+        // e.g., FF
+        throw TextException(ToSBuf("Malformed ", description,
+                            ": Expected a decimal integer but got '",
+                            rawInput, "'"), Here());
+    }
+
+    if (!tok.atEnd()) {
+        // e.g., 1,000, 1.0, or 1e6
+        throw TextException(ToSBuf("Malformed ", description,
+                            ": Trailing garbage after ", rawInteger, " in '",
+                            rawInput, "'"), Here());
+    }
+
+    if (rawInteger > upperLimit) {
+        throw TextException(ToSBuf("Malformed ", description,
+                            ": Expected an integer value not exceeding ", upperLimit,
+                            " but got ", rawInteger), Here());
+    }
+
+    if (rawInteger < lowerLimit) {
+        throw TextException(ToSBuf("Malformed ", description,
+                            ": Expected an integer value not below ", lowerLimit,
+                            " but got ", rawInteger), Here());
+    }
+
+    return Integer(rawInteger);
 }
 
 /* parses a single token. Returns the token length in characters,
@@ -475,6 +532,16 @@ Format::Token::parse(const char *def, Quoting *quoting)
     }
 
     switch (type) {
+
+    case LFT_BYTE:
+        if (!data.string)
+            throw TextException("logformat %byte requires a parameter (e.g., %byte{10})", Here());
+        // TODO: Convert Format::Token::data.string to SBuf.
+        if (const auto v = ParseInteger<uint8_t>("logformat %byte{value}", SBuf(data.string)))
+            data.byteValue = v;
+        else
+            throw TextException("logformat %byte{n} does not support zero n values yet", Here());
+        break;
 
 #if USE_ADAPTATION
     case LFT_ADAPTATION_LAST_HEADER:
@@ -682,6 +749,7 @@ Format::Token::Token() : type(LFT_NONE),
     data.header.element = nullptr;
     data.header.separator = ',';
     data.headerId = ProxyProtocol::Two::htUnknown;
+    data.byteValue = 0;
 }
 
 Format::Token::~Token()

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -287,61 +287,6 @@ Format::Token::scanForToken(TokenTableEntry const table[], const char *cur)
     return cur;
 }
 
-/// parses a decimal integer that fits the specified Integer type
-template <typename Integer>
-static Integer
-ParseInteger(const char *description, const SBuf &rawInput)
-{
-    Parser::Tokenizer tok(rawInput);
-    if (tok.skip('0')) {
-        if (!tok.atEnd()) {
-            // e.g., 077, 0xFF, 0b101, or 0.1
-            throw TextException(ToSBuf("Malformed ", description,
-                                ": Expected a decimal integer without leading zeros but got '",
-                                rawInput, "'"), Here());
-        }
-        return Integer(0);
-    }
-    // else the value might still be zero (e.g., -0)
-
-    const auto lowerLimit = std::numeric_limits<Integer>::min();
-    const auto upperLimit = std::numeric_limits<Integer>::max();
-
-    // check that our caller is compatible with Tokenizer::int64() use below
-    using ParsedInteger = int64_t;
-    static_assert(lowerLimit >= std::numeric_limits<ParsedInteger>::min());
-    static_assert(upperLimit <= std::numeric_limits<ParsedInteger>::max());
-
-    ParsedInteger rawInteger = 0;
-    if (!tok.int64(rawInteger, 10, true)) {
-        // e.g., FF
-        throw TextException(ToSBuf("Malformed ", description,
-                            ": Expected a decimal integer but got '",
-                            rawInput, "'"), Here());
-    }
-
-    if (!tok.atEnd()) {
-        // e.g., 1,000, 1.0, or 1e6
-        throw TextException(ToSBuf("Malformed ", description,
-                            ": Trailing garbage after ", rawInteger, " in '",
-                            rawInput, "'"), Here());
-    }
-
-    if (rawInteger > upperLimit) {
-        throw TextException(ToSBuf("Malformed ", description,
-                            ": Expected an integer value not exceeding ", upperLimit,
-                            " but got ", rawInteger), Here());
-    }
-
-    if (rawInteger < lowerLimit) {
-        throw TextException(ToSBuf("Malformed ", description,
-                            ": Expected an integer value not below ", lowerLimit,
-                            " but got ", rawInteger), Here());
-    }
-
-    return Integer(rawInteger);
-}
-
 /* parses a single token. Returns the token length in characters,
  * and fills in the lt item with the token information.
  * def is for sure null-terminated

--- a/src/format/Token.h
+++ b/src/format/Token.h
@@ -60,6 +60,8 @@ public:
             char *element;
             char separator;
         } header;
+
+        uint8_t byteValue; // %byte{} parameter or zero
     } data;
     int widthMin; ///< minimum field width
     int widthMax; ///< maximum field width

--- a/src/proxyp/Elements.cc
+++ b/src/proxyp/Elements.cc
@@ -72,29 +72,7 @@ ProxyProtocol::NameToFieldType(const SBuf &name)
 ProxyProtocol::Two::FieldType
 ProxyProtocol::IntegerToFieldType(const SBuf &rawInteger)
 {
-    int64_t tlvType = 0;
-
-    Parser::Tokenizer ptok(rawInteger);
-    if (ptok.skip('0')) {
-        if (!ptok.atEnd())
-            throw TexcHere(ToSBuf("Invalid PROXY protocol TLV type value. ",
-                                  "Expected a decimal integer without leading zeros but got '",
-                                  rawInteger, "'")); // e.g., 077, 0xFF, or 0b101
-        // tlvType stays zero
-    } else {
-        Must(ptok.int64(tlvType, 10, false)); // the first character is a DIGIT
-        if (!ptok.atEnd())
-            throw TexcHere(ToSBuf("Invalid PROXY protocol TLV type value. ",
-                                  "Trailing garbage after ", tlvType, " in '",
-                                  rawInteger, "'")); // e.g., 1.0 or 5e0
-    }
-
-    const auto limit = std::numeric_limits<uint8_t>::max();
-    if (tlvType > limit)
-        throw TexcHere(ToSBuf("Invalid PROXY protocol TLV type value. ",
-                              "Expected an integer less than ", limit,
-                              " but got '", tlvType, "'"));
-
+    const auto tlvType = ParseInteger<int64_t>("proxy protocol TLV type value", rawInteger);
     return Two::FieldType(tlvType);
 }
 


### PR DESCRIPTION
No support for zero byte values yet because existing Format::assemble()
code does not support that out of the box, and there is no known _need_
for such support. It can be added later (without backward compatibility
problems) if needed.