### PR TITLE
Fix PeerDigest lifetime management

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -41,9 +41,7 @@ CachePeer::~CachePeer()
     aclDestroyAccessList(&access);
 
 #if USE_CACHE_DIGESTS
-    void *digestTmp = nullptr;
-    if (cbdataReferenceValidDone(digest, &digestTmp))
-        peerDigestNotePeerGone(static_cast<PeerDigest *>(digestTmp));
+    delete digest;
     xfree(digest_url);
 #endif
 

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -80,7 +80,7 @@ public:
     ~PeerDigest();
 
     /// updates stats when digest transfer is complete
-    void noteFetchFinished(const DigestFetchState &, const char *reason, int err);
+    void noteFetchFinished(const DigestFetchState &, int err);
 
     CbcPointer<CachePeer> peer; ///< pointer back to peer structure, argh
     CacheDigest *cd = nullptr;            /**< actual digest structure */

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -80,6 +80,7 @@ public:
     ~PeerDigest();
 
     /// reacts to digest transfer completion
+    /// \prec DigestFetchState stats were finalized (by calling peerDigestFetchSetStats())
     void noteFetchFinished(const DigestFetchState &, const char *outcomeDescription, bool sawError);
 
     CbcPointer<CachePeer> peer; ///< pointer back to peer structure, argh

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -49,7 +49,7 @@ public:
     DigestFetchState(PeerDigest *,HttpRequest *);
     ~DigestFetchState();
 
-    PeerDigest *pd;
+    CbcPointer<PeerDigest> pd;
     StoreEntry *entry;
     StoreEntry *old_entry;
     store_client *sc;
@@ -78,6 +78,9 @@ class PeerDigest
 public:
     PeerDigest(CachePeer *);
     ~PeerDigest();
+
+    /// updates stats when digest transfer is complete
+    void noteFetchFinished(const DigestFetchState &, const char *reason, int err);
 
     CbcPointer<CachePeer> peer; ///< pointer back to peer structure, argh
     CacheDigest *cd = nullptr;            /**< actual digest structure */

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -79,8 +79,8 @@ public:
     PeerDigest(CachePeer *);
     ~PeerDigest();
 
-    /// updates stats when digest transfer is complete
-    void noteFetchFinished(const DigestFetchState &, int err);
+    /// reacts to digest transfer completion
+    void noteFetchFinished(const DigestFetchState &, const char *outcomeDescription, bool sawError);
 
     CbcPointer<CachePeer> peer; ///< pointer back to peer structure, argh
     CacheDigest *cd = nullptr;            /**< actual digest structure */

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2403,10 +2403,8 @@ parse_peer(CachePeers **peers)
         p->connect_fail_limit = 10;
 
 #if USE_CACHE_DIGESTS
-    if (!p->options.no_digest) {
-        const auto pd = new PeerDigest(p);
-        p->digest = cbdataReference(pd); // CachePeer destructor unlocks
-    }
+    if (!p->options.no_digest)
+        p->digest = new PeerDigest(p);
 #endif
 
     if (p->secure.encryptTransport)

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -633,8 +633,7 @@ peerDigestFetchedEnough(DigestFetchState * fetch, char *buf, ssize_t size, const
     if (reason) {
         const int level = strstr(reason, "?!") ? 1 : 3;
         debugs(72, level, "" << step_name << ": peer " << host << ", exiting after '" << reason << "'");
-        peerDigestReqFinish(fetch, buf,
-                            reason, !no_bug);
+        peerDigestReqFinish(fetch, buf, reason, !no_bug);
     }
 
     return reason != nullptr;

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -667,14 +667,8 @@ peerDigestReqFinish(DigestFetchState * fetch, char * /* buf */,
 
     debugs(72, 2, "peer: " << RawPointer(fetch->pd.valid() ? fetch->pd->peer : nullptr).orNil() << ", reason: " << reason << ", err: " << err);
 
-    if (const auto pd = fetch->pd.get()) {
-        pd->flags.requested = false;
-        pd->req_result = reason;
-    }
-
     /* note: order is significant */
     peerDigestFetchSetStats(fetch);
-
     if (const auto pd = fetch->pd.get())
         pd->noteFetchFinished(*fetch, reason, err);
 
@@ -686,6 +680,9 @@ PeerDigest::noteFetchFinished(const DigestFetchState &finishedFetch, const char 
 {
     const auto pd = this; // TODO: remove this diff reducer
     const auto fetch = &finishedFetch; // TODO: remove this diff reducer
+
+    pd->flags.requested = false;
+    pd->req_result = outcomeDescription;
 
     pd->times.received = squid_curtime;
     pd->times.req_delay = fetch->resp_time;
@@ -703,7 +700,6 @@ PeerDigest::noteFetchFinished(const DigestFetchState &finishedFetch, const char 
         pd->cd = nullptr;
 
         pd->flags.usable = false;
-
     } else {
         pd->flags.usable = true;
         pd->times.retry_delay = 0;

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -670,9 +670,6 @@ peerDigestReqFinish(DigestFetchState * const fetch, char *, const char * const r
     if (const auto pd = fetch->pd.get()) {
         pd->flags.requested = false;
         pd->req_result = reason;
-
-        /* schedule next check if peer is still out there */
-
         if (err) {
             pd->times.retry_delay = peerDigestIncDelay(pd);
             peerDigestSetCheck(pd, pd->times.retry_delay);

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -663,7 +663,7 @@ peerDigestReqFinish(DigestFetchState * const fetch, char *, const char * const r
 {
     assert(reason);
 
-    debugs(72, 2, "peer: " << RawPointer(fetch->pd.valid() ? fetch->pd->peer : nullptr).orNil() << ", reason: " << reason << " err: " << err);
+    debugs(72, 2, "peer: " << RawPointer(fetch->pd.valid() ? fetch->pd->peer : nullptr).orNil() << ", reason: " << reason << ", err: " << err);
 
     /* must go before PeerDigest::noteFetchFinished() */
 

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -681,14 +681,6 @@ PeerDigest::noteFetchFinished(const DigestFetchState &finishedFetch, const char 
 
     pd->flags.requested = false;
     pd->req_result = reason;
-
-    if (err) {
-        pd->times.retry_delay = peerDigestIncDelay(pd);
-        peerDigestSetCheck(pd, pd->times.retry_delay);
-    } else {
-        pd->times.retry_delay = 0;
-        peerDigestSetCheck(pd, peerDigestNewDelay(fetch->entry));
-    }
     pd->times.received = squid_curtime;
     pd->times.req_delay = fetch->resp_time;
     pd->stats.sent.kbytes += fetch->sent.bytes;
@@ -699,6 +691,9 @@ PeerDigest::noteFetchFinished(const DigestFetchState &finishedFetch, const char 
     if (err) {
         debugs(72, DBG_IMPORTANT, "disabling (" << pd->req_result << ") digest from " << host);
 
+        pd->times.retry_delay = peerDigestIncDelay(pd);
+        peerDigestSetCheck(pd, pd->times.retry_delay);
+
         delete pd->cd;
         pd->cd = nullptr;
 
@@ -706,6 +701,9 @@ PeerDigest::noteFetchFinished(const DigestFetchState &finishedFetch, const char 
 
     } else {
         pd->flags.usable = true;
+
+        pd->times.retry_delay = 0;
+        peerDigestSetCheck(pd, peerDigestNewDelay(fetch->entry));
 
         /* XXX: ugly condition, but how? */
 


### PR DESCRIPTION
This change fixes how cbdata is used for managing CachePeer::digest
lifetime. Prior to these changes, cbdata was (ab)used as a reference
counting mechanism: CachePeer::digest object could outlive CachePeer
(effectively its creator), necessitating complex "is it time to delete
this digest?" cleanup logic. Now, CachePeer is an exclusive digest owner
that no longer locks/unlocks its digest field; it just creates/deletes
the object. Digest fetching code no longer needs to cleanup the digest.

"CachePeer::digest is always valid" invariant simplifies digest fetching
code and, hopefully, reduces the probability of bugs similar to Bug 5329
fixed in minimal commit 4657405c (that promised this refactoring).
