### PR TITLE
Upgrade ACL::name to SBuf

### DIFF
--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -133,8 +133,6 @@ AccessLogEntry::~AccessLogEntry()
     safe_free(headers.adapted_request);
     HTTPMSGUNLOCK(adapted_request);
 
-    safe_free(lastAclName);
-
     HTTPMSGUNLOCK(request);
 #if ICAP_CLIENT
     HTTPMSGUNLOCK(icap.reply);

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -188,7 +188,7 @@ public:
     } adapt;
 #endif
 
-    const char *lastAclName = nullptr; ///< string for external_acl_type %ACL format code
+    SBuf lastAclName; ///< string for external_acl_type %ACL format code
     SBuf lastAclData; ///< string for external_acl_type %DATA format code
 
     HierarchyLogEntry hier;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -357,7 +357,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         ch.src_addr = request->client_addr;
         ch.syncAle(request, nullptr);
         if (ch.fastCheck().denied()) {
-            auto page_id = aclGetDenyInfoPage(Config.denyInfoList, ch.currentAnswer(), true);
+            auto page_id = FindDenyInfoPage(ch.currentAnswer(), true);
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -358,7 +358,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         ch.syncAle(request, nullptr);
         if (ch.fastCheck().denied()) {
             err_type page_id;
-            page_id = aclGetDenyInfoPage(&Config.denyInfoList, (AclMatchedName ? AclMatchedName.value().c_str() : nullptr), 1);
+            page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName.value_or(SBuf()), 1);
 
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -358,7 +358,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         ch.syncAle(request, nullptr);
         if (ch.fastCheck().denied()) {
             err_type page_id;
-            page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName.value_or(SBuf()), 1);
+            page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, 1);
 
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -358,7 +358,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         ch.syncAle(request, nullptr);
         if (ch.fastCheck().denied()) {
             err_type page_id;
-            page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, 1);
+            page_id = aclGetDenyInfoPage(&Config.denyInfoList, (AclMatchedName ? AclMatchedName.value().c_str() : nullptr), 1);
 
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -357,8 +357,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         ch.src_addr = request->client_addr;
         ch.syncAle(request, nullptr);
         if (ch.fastCheck().denied()) {
-            auto page_id = aclGetDenyInfoPage(&Config.denyInfoList, ch.currentAnswer(), 1);
-
+            auto page_id = aclGetDenyInfoPage(Config.denyInfoList, ch.currentAnswer(), true);
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -357,8 +357,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         ch.src_addr = request->client_addr;
         ch.syncAle(request, nullptr);
         if (ch.fastCheck().denied()) {
-            err_type page_id;
-            page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, 1);
+            auto page_id = aclGetDenyInfoPage(&Config.denyInfoList, ch.currentAnswer(), 1);
 
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -149,18 +149,32 @@ void Acl::Node::operator delete(void *)
     fatal ("unusable Acl::Node::delete");
 }
 
+/// implements both Acl::Node::FindByName() variations
+template <typename SBufOrCString>
+static Acl::Node *
+FindByNameT(const SBufOrCString name)
+{
+    for (auto a = Config.aclList; a; a = a->next) {
+        if (a->name.caseCmp(name) == 0) {
+            debugs(28, 8, "found " << a->name);
+            return a;
+        }
+    }
+
+    debugs(28, 8, "cannot find " << name);
+    return nullptr;
+}
+
 Acl::Node *
 Acl::Node::FindByName(const SBuf &name)
 {
-    debugs(28, 9, "name=" << name);
+    return FindByNameT<const SBuf &>(name);
+}
 
-    for (auto *a = Config.aclList; a; a = a->next)
-        if (!a->name.caseCmp(name))
-            return a;
-
-    debugs(28, 9, "found no match");
-
-    return nullptr;
+Acl::Node *
+Acl::Node::FindByName(const char *name)
+{
+    return FindByNameT<const char *>(name);
 }
 
 Acl::Node::Node() :

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -116,8 +116,8 @@ Acl::SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey)
 SBuf
 Acl::Answer::lastCheckDescription() const
 {
-    static const SBuf none("[no-ACL]");
-    return lastCheckedName.value_or(none);
+    static const auto none = new SBuf("[no-ACL]");
+    return lastCheckedName.value_or(*none);
 }
 
 /* Acl::ParsingContext */

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -113,11 +113,12 @@ Acl::SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey)
                         Here());
 }
 
-SBuf
+const SBuf &
 Acl::Answer::lastCheckDescription() const
 {
     static const auto none = new SBuf("[no-ACL]");
-    return lastCheckedName.value_or(*none);
+    // no value_or() because it would create a new SBuf object here
+    return lastCheckedName ? *lastCheckedName : *none;
 }
 
 /* Acl::ParsingContext */

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -204,11 +204,9 @@ Acl::Node::matches(ACLChecklist *checklist) const
 }
 
 void
-Acl::Node::context(const char *aName, const char *aCfgLine)
+Acl::Node::context(const SBuf &aName, const char *aCfgLine)
 {
-    name.clear();
-    if (aName)
-        name = SBuf(aName);
+    name = aName;
     safe_free(cfgline);
     if (aCfgLine)
         cfgline = xstrdup(aCfgLine);
@@ -290,7 +288,7 @@ Acl::Node::ParseNamed(ConfigParser &parser, Node ** const head, const SBuf &acln
     if ((A = FindByName(aclname)) == nullptr) {
         debugs(28, 3, "aclParseAclLine: Creating ACL '" << aclname << "'");
         A = Acl::Make(theType);
-        A->context(SBuf(aclname).c_str(), config_input_line);
+        A->context(aclname, config_input_line);
         new_acl = 1;
     } else {
         if (strcmp (A->typeString(),theType) ) {

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <ostream>
+#include <optional>
 
 namespace Acl {
 
@@ -138,7 +139,7 @@ public:
 
 /// \ingroup ACLAPI
 /// XXX: find a way to remove or at least use a refcounted Acl::Node pointer
-extern const char *AclMatchedName;  /* NULL */
+extern std::optional<SBuf> AclMatchedName;
 
 #endif /* SQUID_SRC_ACL_ACL_H */
 

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -12,7 +12,7 @@
 #include "acl/forward.h"
 #include "defines.h"
 #include "dlink.h"
-#include "sbuf/forward.h"
+#include "sbuf/SBuf.h"
 
 #include <algorithm>
 #include <optional>
@@ -90,6 +90,9 @@ public:
     /// whether Squid is uncertain about the allowed() or denied() answer
     bool conflicted() const { return !allowed() && !denied(); }
 
+    /// the description of an ACL that was evaluated last
+    SBuf lastCheckDescription() const;
+
     aclMatchCode code = ACCESS_DUNNO; ///< ACCESS_* code
 
     /// the matched custom access list verb (or zero)
@@ -97,6 +100,9 @@ public:
 
     /// whether we were computed by the "negate the last explicit action" rule
     bool implicit = false;
+
+    /// the name of the ACL that was evaluated last (if any)
+    std::optional<SBuf> lastCheckedName;
 };
 
 inline std::ostream &
@@ -136,10 +142,6 @@ public:
     int matchrv;
     void *acl_data;
 };
-
-/// \ingroup ACLAPI
-/// XXX: find a way to remove or at least use a refcounted Acl::Node pointer
-extern std::optional<SBuf> AclMatchedName;
 
 #endif /* SQUID_SRC_ACL_ACL_H */
 

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -101,7 +101,7 @@ public:
     /// whether we were computed by the "negate the last explicit action" rule
     bool implicit = false;
 
-    /// the name of the ACL that was evaluated last (if any)
+    /// the name of the ACL (if any) that was evaluated last while obtaining this answer
     std::optional<SBuf> lastCheckedName;
 };
 

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -67,7 +67,7 @@ public:
         return !(*this == aCode);
     }
 
-    bool operator ==(const Answer allow) const {
+    bool operator ==(const Answer &allow) const {
         return code == allow.code && kind == allow.kind;
     }
 
@@ -106,7 +106,7 @@ public:
 };
 
 inline std::ostream &
-operator <<(std::ostream &o, const Answer a)
+operator <<(std::ostream &o, const Answer &a)
 {
     switch (a) {
     case ACCESS_DENIED:

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -90,8 +90,8 @@ public:
     /// whether Squid is uncertain about the allowed() or denied() answer
     bool conflicted() const { return !allowed() && !denied(); }
 
-    /// the description of an ACL that was evaluated last
-    SBuf lastCheckDescription() const;
+    /// describes the ACL that was evaluated last while obtaining this answer (for debugging)
+    const SBuf &lastCheckDescription() const;
 
     aclMatchCode code = ACCESS_DUNNO; ///< ACCESS_* code
 

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -15,8 +15,8 @@
 #include "sbuf/forward.h"
 
 #include <algorithm>
-#include <ostream>
 #include <optional>
+#include <ostream>
 
 namespace Acl {
 

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -58,7 +58,7 @@ Acl::AllOf::parse()
 
         MemBuf wholeCtx;
         wholeCtx.init();
-        wholeCtx.appendf("(%s lines)", name);
+        wholeCtx.appendf("(%s lines)", name.c_str());
         wholeCtx.terminate();
 
         Acl::OrNode *newWhole = new Acl::OrNode;
@@ -76,7 +76,7 @@ Acl::AllOf::parse()
 
     MemBuf lineCtx;
     lineCtx.init();
-    lineCtx.appendf("(%s line #%d)", name, lineId);
+    lineCtx.appendf("(%s line #%d)", name.c_str(), lineId);
     lineCtx.terminate();
 
     Acl::AndNode *line = new AndNode;

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -14,6 +14,7 @@
 #include "cache_cf.h"
 #include "MemBuf.h"
 #include "sbuf/SBuf.h"
+#include "sbuf/Stream.h"
 
 char const *
 Acl::AllOf::typeString() const
@@ -56,13 +57,8 @@ Acl::AllOf::parse()
     } else if (oldNode) {
         // this acl saw a single line before; create a new OR inner node
 
-        MemBuf wholeCtx;
-        wholeCtx.init();
-        wholeCtx.appendf("(%s lines)", name.c_str());
-        wholeCtx.terminate();
-
         Acl::OrNode *newWhole = new Acl::OrNode;
-        newWhole->context(wholeCtx.content(), oldNode->cfgline);
+        newWhole->context(ToSBuf('(', name, " lines)"), oldNode->cfgline);
         newWhole->add(oldNode); // old (i.e. first) line
         nodes.front() = whole = newWhole;
         aclRegister(newWhole);
@@ -74,13 +70,8 @@ Acl::AllOf::parse()
     assert(whole);
     const int lineId = whole->childrenCount() + 1;
 
-    MemBuf lineCtx;
-    lineCtx.init();
-    lineCtx.appendf("(%s line #%d)", name.c_str(), lineId);
-    lineCtx.terminate();
-
     Acl::AndNode *line = new AndNode;
-    line->context(lineCtx.content(), config_input_line);
+    line->context(ToSBuf('(', name, " line #", lineId), config_input_line);
     line->lineParse();
 
     whole->add(line);

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -71,7 +71,7 @@ Acl::AllOf::parse()
     const int lineId = whole->childrenCount() + 1;
 
     Acl::AndNode *line = new AndNode;
-    line->context(ToSBuf('(', name, " line #", lineId), config_input_line);
+    line->context(ToSBuf('(', name, " line #", lineId, ')'), config_input_line);
     line->lineParse();
 
     whole->add(line);

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -17,10 +17,8 @@
 Acl::NotNode::NotNode(Acl::Node *acl)
 {
     assert(acl);
-    Must(strlen(acl->name) <= sizeof(name)-2);
-    name[0] = '!';
-    name[1] = '\0';
-    xstrncpy(&name[1], acl->name, sizeof(name)-1); // -1 for '!'
+    name.append('!');
+    name.append(acl->name);
     add(acl);
 }
 
@@ -56,7 +54,7 @@ SBufList
 Acl::NotNode::dump() const
 {
     SBufList text;
-    text.push_back(SBuf(name));
+    text.push_back(name);
     return text;
 }
 

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -17,6 +17,7 @@
 Acl::NotNode::NotNode(Acl::Node *acl)
 {
     assert(acl);
+    name.reserveCapacity(1 + acl->name.length());
     name.append('!');
     name.append(acl->name);
     add(acl);

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -155,7 +155,7 @@ ACLChecklist::goAsync(AsyncStarter starter, const Acl::Node &acl)
 // ACLFilledChecklist overwrites this to unclock something before we
 // "delete this"
 void
-ACLChecklist::checkCallback(Acl::Answer answer)
+ACLChecklist::checkCallback(const Acl::Answer &answer)
 {
     ACLCB *callback_;
     void *cbdata_;

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -60,6 +60,7 @@ ACLChecklist::markFinished(const Acl::Answer &finalAnswer, const char *reason)
     assert (!finished() && !asyncInProgress());
     finished_ = true;
     answer_ = finalAnswer;
+    answer_.lastCheckedName = lastCheckedName;
     debugs(28, 3, this << " answer " << answer_ << " for " << reason);
 }
 
@@ -73,8 +74,6 @@ ACLChecklist::preCheck(const char *what)
     assert(!occupied_);
     occupied_ = true;
     asyncLoopDepth_ = 0;
-
-    AclMatchedName.reset();
     finished_ = false;
 }
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -74,7 +74,7 @@ ACLChecklist::preCheck(const char *what)
     occupied_ = true;
     asyncLoopDepth_ = 0;
 
-    AclMatchedName = nullptr;
+    AclMatchedName.reset();
     finished_ = false;
 }
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -60,7 +60,7 @@ ACLChecklist::markFinished(const Acl::Answer &finalAnswer, const char *reason)
     assert (!finished() && !asyncInProgress());
     finished_ = true;
     answer_ = finalAnswer;
-    answer_.lastCheckedName = lastCheckedName;
+    answer_.lastCheckedName = lastCheckedName_;
     debugs(28, 3, this << " answer " << answer_ << " for " << reason);
 }
 
@@ -75,7 +75,7 @@ ACLChecklist::preCheck(const char *what)
     occupied_ = true;
     asyncLoopDepth_ = 0;
 
-    lastCheckedName.reset();
+    lastCheckedName_.reset();
     finished_ = false;
 }
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -74,6 +74,8 @@ ACLChecklist::preCheck(const char *what)
     assert(!occupied_);
     occupied_ = true;
     asyncLoopDepth_ = 0;
+
+    lastCheckedName.reset();
     finished_ = false;
 }
 

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -159,7 +159,7 @@ public:
 
 private:
     /// Calls non-blocking check callback with the answer and destroys self.
-    void checkCallback(Acl::Answer answer);
+    void checkCallback(const Acl::Answer &answer);
 
     void matchAndFinish();
 

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -155,7 +155,7 @@ public:
     }
 
     /// remember the name of the last ACL being evaluated
-    void setLastCheckedName(const SBuf &name) { lastCheckedName = name; }
+    void setLastCheckedName(const SBuf &name) { lastCheckedName_ = name; }
 
 private:
     /// Calls non-blocking check callback with the answer and destroys self.
@@ -216,7 +216,7 @@ private: /* internal methods */
     std::vector<Acl::Answer> bannedActions_;
 
     /// the name of the last evaluated ACL (if any ACLs were evaluated)
-    std::optional<SBuf> lastCheckedName;
+    std::optional<SBuf> lastCheckedName_;
 };
 
 #endif /* SQUID_SRC_ACL_CHECKLIST_H */

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -12,6 +12,8 @@
 #include "acl/Acl.h"
 #include "acl/InnerNode.h"
 #include "cbdata.h"
+
+#include <optional>
 #include <stack>
 #include <vector>
 
@@ -152,6 +154,8 @@ public:
         return old;
     }
 
+    void setLastCheckedName(const SBuf &name) { lastCheckedName = std::make_optional(name); }
+
 private:
     /// Calls non-blocking check callback with the answer and destroys self.
     void checkCallback(Acl::Answer answer);
@@ -209,6 +213,8 @@ private: /* internal methods */
     std::stack<Breadcrumb> matchPath;
     /// the list of actions which must ignored during acl checks
     std::vector<Acl::Answer> bannedActions_;
+    /// the name of the ACL that was evaluated last (if any)
+    std::optional<SBuf> lastCheckedName;
 };
 
 #endif /* SQUID_SRC_ACL_CHECKLIST_H */

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -154,6 +154,7 @@ public:
         return old;
     }
 
+    /// remember the name of the last ACL being evaluated
     void setLastCheckedName(const SBuf &name) { lastCheckedName = std::make_optional(name); }
 
 private:

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -155,7 +155,7 @@ public:
     }
 
     /// remember the name of the last ACL being evaluated
-    void setLastCheckedName(const SBuf &name) { lastCheckedName = std::make_optional(name); }
+    void setLastCheckedName(const SBuf &name) { lastCheckedName = name; }
 
 private:
     /// Calls non-blocking check callback with the answer and destroys self.

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -213,7 +213,8 @@ private: /* internal methods */
     std::stack<Breadcrumb> matchPath;
     /// the list of actions which must ignored during acl checks
     std::vector<Acl::Answer> bannedActions_;
-    /// the name of the ACL that was evaluated last (if any)
+
+    /// the name of the last evaluated ACL (if any ACLs were evaluated)
     std::optional<SBuf> lastCheckedName;
 };
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -76,7 +76,7 @@ aclIsProxyAuth(const std::optional<SBuf> &name)
 
     debugs(28, 5, "aclIsProxyAuth: called for " << name.value());
 
-    if (const auto *a = Acl::Node::FindByName(name.value())) {
+    if (const auto a = Acl::Node::FindByName(name.value())) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -68,7 +68,7 @@ aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &answer, const int
 }
 
 /* does name lookup, returns if it is a proxy_auth acl */
-int
+bool
 aclIsProxyAuth(const std::optional<SBuf> &name)
 {
     if (!name) {

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -36,14 +36,14 @@ static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
 /* does name lookup, returns page_id */
 err_type
-aclGetDenyInfoPage(AclDenyInfoList ** head, const std::optional<SBuf> &optionalName, const int redirect_allowed)
+aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &answer, const int redirect_allowed)
 {
-    if (!optionalName) {
+    if (!answer.lastCheckedName) {
         debugs(28, 3, "ERR_NONE due to a NULL name");
         return ERR_NONE;
     }
 
-    const auto &name = optionalName.value();
+    const auto &name = answer.lastCheckDescription();
 
     AclDenyInfoList *A = nullptr;
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -76,9 +76,9 @@ aclIsProxyAuth(const std::optional<SBuf> &name)
         return false;
     }
 
-    debugs(28, 5, "aclIsProxyAuth: called for " << name.value());
+    debugs(28, 5, "aclIsProxyAuth: called for " << *name);
 
-    if (const auto a = Acl::Node::FindByName(name.value())) {
+    if (const auto a = Acl::Node::FindByName(*name)) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -63,7 +63,6 @@ FindDenyInfoPage(const Acl::Answer &answer, const bool redirect_allowed)
     return ERR_NONE;
 }
 
-/* does name lookup, returns if it is a proxy_auth acl */
 bool
 aclIsProxyAuth(const std::optional<SBuf> &name)
 {

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -67,16 +67,16 @@ aclGetDenyInfoPage(AclDenyInfoList ** head, const char *name, int redirect_allow
 
 /* does name lookup, returns if it is a proxy_auth acl */
 int
-aclIsProxyAuth(const char *name)
+aclIsProxyAuth(const std::optional<SBuf> &name)
 {
     if (!name) {
         debugs(28, 3, "false due to a NULL name");
         return false;
     }
 
-    debugs(28, 5, "aclIsProxyAuth: called for " << name);
+    debugs(28, 5, "aclIsProxyAuth: called for " << name.value());
 
-    if (const auto *a = Acl::Node::FindByName(name)) {
+    if (const auto *a = Acl::Node::FindByName(name.value())) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -157,7 +157,7 @@ aclParseAccessLine(const char *directive, ConfigParser &, acl_access **treep)
     const int ruleId = ((treep && *treep) ? (*treep)->childrenCount() : 0) + 1;
 
     Acl::AndNode *rule = new Acl::AndNode;
-    rule->context(ToSBuf(directive ,'#', ruleId), config_input_line);
+    rule->context(ToSBuf(directive, '#', ruleId), config_input_line);
     rule->lineParse();
     if (rule->empty()) {
         debugs(28, DBG_CRITICAL, "aclParseAccessLine: " << cfg_filename << " line " << config_lineno << ": " << config_input_line);

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -36,9 +36,9 @@ static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
 /* does name lookup, returns page_id */
 err_type
-aclGetDenyInfoPage(AclDenyInfoList ** head, const char *name, int redirect_allowed)
+aclGetDenyInfoPage(AclDenyInfoList ** head, const SBuf &name, const int redirect_allowed)
 {
-    if (!name) {
+    if (name.isEmpty()) {
         debugs(28, 3, "ERR_NONE due to a NULL name");
         return ERR_NONE;
     }

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -43,7 +43,7 @@ aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &answer, const int
         return ERR_NONE;
     }
 
-    const auto &name = answer.lastCheckDescription();
+    const auto &name = *answer.lastCheckedName;
 
     AclDenyInfoList *A = nullptr;
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -36,12 +36,14 @@ static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
 /* does name lookup, returns page_id */
 err_type
-aclGetDenyInfoPage(AclDenyInfoList ** head, const SBuf &name, const int redirect_allowed)
+aclGetDenyInfoPage(AclDenyInfoList ** head, const std::optional<SBuf> &optionalName, const int redirect_allowed)
 {
-    if (name.isEmpty()) {
+    if (!optionalName) {
         debugs(28, 3, "ERR_NONE due to a NULL name");
         return ERR_NONE;
     }
+
+    const auto &name = optionalName.value();
 
     AclDenyInfoList *A = nullptr;
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -39,7 +39,7 @@ err_type
 aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &answer, const int redirect_allowed)
 {
     if (!answer.lastCheckedName) {
-        debugs(28, 3, "ERR_NONE due to a NULL name");
+        debugs(28, 3, "ERR_NONE because access was denied without evaluating ACLs");
         return ERR_NONE;
     }
 
@@ -72,18 +72,16 @@ bool
 aclIsProxyAuth(const std::optional<SBuf> &name)
 {
     if (!name) {
-        debugs(28, 3, "false due to a NULL name");
+        debugs(28, 3, "no; caller did not supply an ACL name");
         return false;
     }
 
-    debugs(28, 5, "aclIsProxyAuth: called for " << *name);
-
     if (const auto a = Acl::Node::FindByName(*name)) {
-        debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
+        debugs(28, 5, "returning " << a->isProxyAuth() << " for ACL " << *name);
         return a->isProxyAuth();
     }
 
-    debugs(28, 3, "aclIsProxyAuth: WARNING, called for nonexistent ACL");
+    debugs(28, 3, "WARNING: Called for nonexistent ACL " << *name);
     return false;
 }
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -36,7 +36,7 @@ static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
 /* does name lookup, returns page_id */
 err_type
-aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &answer, const int redirect_allowed)
+aclGetDenyInfoPage(const AclDenyInfoList * const head, const Acl::Answer &answer, const bool redirect_allowed)
 {
     if (!answer.lastCheckedName) {
         debugs(28, 3, "ERR_NONE because access was denied without evaluating ACLs");
@@ -45,11 +45,9 @@ aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &answer, const int
 
     const auto &name = *answer.lastCheckedName;
 
-    AclDenyInfoList *A = nullptr;
-
     debugs(28, 8, "got called for " << name);
 
-    for (A = *head; A; A = A->next) {
+    for (auto A = head; A; A = A->next) {
         if (!redirect_allowed && strchr(A->err_page_name, ':') ) {
             debugs(28, 8, "Skip '" << A->err_page_name << "' 30x redirects not allowed as response here.");
             continue;

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -50,7 +50,7 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 /// \ingroup ACLAPI
 bool aclIsProxyAuth(const std::optional<SBuf> &name);
 /// \ingroup ACLAPI
-err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &, int redirect_allowed);
+err_type aclGetDenyInfoPage(const AclDenyInfoList *, const Acl::Answer &, bool redirect_allowed);
 /// \ingroup ACLAPI
 void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -11,7 +11,9 @@
 
 #include "acl/forward.h"
 #include "error/forward.h"
+#include "sbuf/forward.h"
 
+#include <optional>
 #include <sstream>
 
 class ConfigParser;
@@ -46,7 +48,7 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 }
 
 /// \ingroup ACLAPI
-int aclIsProxyAuth(const char *name);
+int aclIsProxyAuth(const std::optional<SBuf> &name);
 /// \ingroup ACLAPI
 err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const char *name, int redirect_allowed);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -50,7 +50,7 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 /// \ingroup ACLAPI
 int aclIsProxyAuth(const std::optional<SBuf> &name);
 /// \ingroup ACLAPI
-err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const SBuf &name, int redirect_allowed);
+err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const std::optional<SBuf> &name, int redirect_allowed);
 /// \ingroup ACLAPI
 void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -48,7 +48,7 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 }
 
 /// \ingroup ACLAPI
-int aclIsProxyAuth(const std::optional<SBuf> &name);
+bool aclIsProxyAuth(const std::optional<SBuf> &name);
 /// \ingroup ACLAPI
 err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &, int redirect_allowed);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -47,7 +47,8 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
     return aclParseAclList(parser, tree, buf.str().c_str());
 }
 
-/// \ingroup ACLAPI
+/// Whether the given name names an Acl::Node object with true isProxyAuth() result.
+/// This is a safe variation of Acl::Node::FindByName(*name)->isProxyAuth().
 bool aclIsProxyAuth(const std::optional<SBuf> &name);
 
 /// The first configured deny_info error page ID matching the given access check outcome (or ERR_NONE).

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -50,7 +50,7 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 /// \ingroup ACLAPI
 int aclIsProxyAuth(const std::optional<SBuf> &name);
 /// \ingroup ACLAPI
-err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const char *name, int redirect_allowed);
+err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const SBuf &name, int redirect_allowed);
 /// \ingroup ACLAPI
 void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -50,7 +50,7 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 /// \ingroup ACLAPI
 int aclIsProxyAuth(const std::optional<SBuf> &name);
 /// \ingroup ACLAPI
-err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const std::optional<SBuf> &name, int redirect_allowed);
+err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const Acl::Answer &, int redirect_allowed);
 /// \ingroup ACLAPI
 void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -49,8 +49,11 @@ aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 
 /// \ingroup ACLAPI
 bool aclIsProxyAuth(const std::optional<SBuf> &name);
-/// \ingroup ACLAPI
-err_type aclGetDenyInfoPage(const AclDenyInfoList *, const Acl::Answer &, bool redirect_allowed);
+
+/// The first configured deny_info error page ID matching the given access check outcome (or ERR_NONE).
+/// \param allowCustomStatus whether to consider deny_info rules containing custom HTTP response status code
+err_type FindDenyInfoPage(const Acl::Answer &, bool allowCustomStatus);
+
 /// \ingroup ACLAPI
 void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -57,7 +57,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        auto *a = Acl::Node::FindByName(SBuf(t));
+        auto a = Acl::Node::FindByName(SBuf(t));
 
         if (a == nullptr) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -57,7 +57,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        auto *a = Acl::Node::FindByName(t);
+        auto *a = Acl::Node::FindByName(SBuf(t));
 
         if (a == nullptr) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);
@@ -82,7 +82,7 @@ Acl::InnerNode::dump() const
 {
     SBufList rv;
     for (Nodes::const_iterator i = nodes.begin(); i != nodes.end(); ++i)
-        rv.push_back(SBuf((*i)->name));
+        rv.push_back((*i)->name);
     return rv;
 }
 

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -57,7 +57,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        auto a = Acl::Node::FindByName(SBuf(t));
+        auto *a = Acl::Node::FindByName(t);
 
         if (a == nullptr) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);

--- a/src/acl/Node.h
+++ b/src/acl/Node.h
@@ -12,6 +12,7 @@
 #include "acl/forward.h"
 #include "acl/Options.h"
 #include "dlink.h"
+#include "sbuf/SBuf.h"
 
 class ConfigParser;
 
@@ -30,7 +31,7 @@ public:
 
     static void ParseAclLine(ConfigParser &parser, Acl::Node **head);
     static void Initialize();
-    static Acl::Node *FindByName(const char *name);
+    static Acl::Node *FindByName(const SBuf &name);
 
     Node();
     Node(Node &&) = delete;  // no copying of any kind
@@ -67,7 +68,7 @@ public:
     /// printed parameters are collected from all same-name "acl" directives.
     void dumpWhole(const char *directiveName, std::ostream &);
 
-    char name[ACL_NAME_SZ];
+    SBuf name;
     char *cfgline;
     Acl::Node *next;  // XXX: remove or at least use refcounting
     bool registered;  ///< added to the global list of ACLs via aclRegister()
@@ -91,7 +92,7 @@ private:
     /// \see Acl::Node::options()
     virtual const Acl::Options &lineOptions() { return Acl::NoOptions(); }
 
-    static void ParseNamed(ConfigParser &, Node **head, const char *name);
+    static void ParseNamed(ConfigParser &, Node **head, const SBuf &name);
 };
 
 } // namespace Acl

--- a/src/acl/Node.h
+++ b/src/acl/Node.h
@@ -38,7 +38,7 @@ public:
     virtual ~Node();
 
     /// sets user-specified ACL name and squid.conf context
-    void context(const char *name, const char *configuration);
+    void context(const SBuf &name, const char *configuration);
 
     /// Orchestrates matching checklist against the Acl::Node using match(),
     /// after checking preconditions and while providing debugging.

--- a/src/acl/Node.h
+++ b/src/acl/Node.h
@@ -43,7 +43,7 @@ public:
     virtual ~Node();
 
     /// sets user-specified ACL name and squid.conf context
-    void context(const SBuf &name, const char *configuration);
+    void context(const SBuf &aName, const char *configuration);
 
     /// Orchestrates matching checklist against the Acl::Node using match(),
     /// after checking preconditions and while providing debugging.
@@ -73,7 +73,12 @@ public:
     /// printed parameters are collected from all same-name "acl" directives.
     void dumpWhole(const char *directiveName, std::ostream &);
 
+    /// Either aclname parameter from the explicitly configured acl directive or
+    /// a label generated for an internal ACL tree node. All Node objects
+    /// corresponding to one Squid configuration have unique names.
+    /// See also: context() and FindByName().
     SBuf name;
+
     char *cfgline;
     Acl::Node *next;  // XXX: remove or at least use refcounting
     bool registered;  ///< added to the global list of ACLs via aclRegister()

--- a/src/acl/Node.h
+++ b/src/acl/Node.h
@@ -31,7 +31,12 @@ public:
 
     static void ParseAclLine(ConfigParser &parser, Acl::Node **head);
     static void Initialize();
-    static Acl::Node *FindByName(const SBuf &name);
+
+    /// A configured ACL with a given name or nil.
+    static Acl::Node *FindByName(const SBuf &);
+    /// \copydoc FindByName()
+    /// \deprecated Use to avoid performance regressions; remove with the last caller.
+    static Acl::Node *FindByName(const char *name);
 
     Node();
     Node(Node &&) = delete;  // no copying of any kind

--- a/src/adaptation/Answer.cc
+++ b/src/adaptation/Answer.cc
@@ -32,7 +32,7 @@ Adaptation::Answer::Forward(Http::Message *aMsg)
 }
 
 Adaptation::Answer
-Adaptation::Answer::Block(const String &aRule)
+Adaptation::Answer::Block(const SBuf &aRule)
 {
     Answer answer(akBlock);
     answer.ruleId = aRule;

--- a/src/adaptation/Answer.cc
+++ b/src/adaptation/Answer.cc
@@ -40,6 +40,15 @@ Adaptation::Answer::Block(const SBuf &aRule)
     return answer;
 }
 
+Acl::Answer
+Adaptation::Answer::blockedToChecklistAnswer() const
+{
+    assert(kind == akBlock);
+    Acl::Answer answer(ACCESS_DENIED);
+    answer.lastCheckedName = ruleId;
+    return answer;
+}
+
 std::ostream &
 Adaptation::Answer::print(std::ostream &os) const
 {

--- a/src/adaptation/Answer.h
+++ b/src/adaptation/Answer.h
@@ -37,7 +37,7 @@ public:
 
 public:
     Http::MessagePointer message; ///< HTTP request or response to forward
-    SBuf ruleId; ///< ACL (or similar rule) name that blocked forwarding
+    std::optional<SBuf> ruleId; ///< ACL (or similar rule) name that blocked forwarding
     bool final; ///< whether the error, if any, cannot be bypassed
     Kind kind; ///< the type of the answer
 

--- a/src/adaptation/Answer.h
+++ b/src/adaptation/Answer.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_SRC_ADAPTATION_ANSWER_H
 #define SQUID_SRC_ADAPTATION_ANSWER_H
 
+#include "acl/Acl.h"
 #include "adaptation/forward.h"
 #include "http/forward.h"
 #include "sbuf/SBuf.h"
@@ -33,6 +34,9 @@ public:
     static Answer Error(bool final); ///< create an akError answer
     static Answer Forward(Http::Message *aMsg); ///< create an akForward answer
     static Answer Block(const SBuf &aRule); ///< create an akBlock answer
+
+    /// creates an Acl::Answer from akBlock answer
+    Acl::Answer blockedToChecklistAnswer() const;
 
     std::ostream &print(std::ostream &os) const;
 

--- a/src/adaptation/Answer.h
+++ b/src/adaptation/Answer.h
@@ -11,7 +11,7 @@
 
 #include "adaptation/forward.h"
 #include "http/forward.h"
-#include "SquidString.h"
+#include "sbuf/SBuf.h"
 
 #include <iosfwd>
 
@@ -31,13 +31,13 @@ public:
 
     static Answer Error(bool final); ///< create an akError answer
     static Answer Forward(Http::Message *aMsg); ///< create an akForward answer
-    static Answer Block(const String &aRule); ///< create an akBlock answer
+    static Answer Block(const SBuf &aRule); ///< create an akBlock answer
 
     std::ostream &print(std::ostream &os) const;
 
 public:
     Http::MessagePointer message; ///< HTTP request or response to forward
-    String ruleId; ///< ACL (or similar rule) name that blocked forwarding
+    SBuf ruleId; ///< ACL (or similar rule) name that blocked forwarding
     bool final; ///< whether the error, if any, cannot be bypassed
     Kind kind; ///< the type of the answer
 

--- a/src/adaptation/Answer.h
+++ b/src/adaptation/Answer.h
@@ -14,6 +14,7 @@
 #include "sbuf/SBuf.h"
 
 #include <iosfwd>
+#include <optional>
 
 namespace Adaptation
 {

--- a/src/adaptation/ecap/XactionRep.cc
+++ b/src/adaptation/ecap/XactionRep.cc
@@ -24,6 +24,7 @@
 #include "HttpReply.h"
 #include "HttpRequest.h"
 #include "MasterXaction.h"
+#include "sbuf/StringConvert.h"
 
 CBDATA_NAMESPACED_CLASS_INIT(Adaptation::Ecap::XactionRep, XactionRep);
 
@@ -449,7 +450,7 @@ Adaptation::Ecap::XactionRep::blockVirgin()
     sinkVb("blockVirgin");
 
     updateHistory(nullptr);
-    sendAnswer(Answer::Block(service().cfg().key));
+    sendAnswer(Answer::Block(StringToSBuf(service().cfg().key)));
     Must(done());
 }
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -4724,7 +4724,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
             static const SBuf all("all");
-            if (auto *a = Acl::Node::FindByName(all))
+            if (auto a = Acl::Node::FindByName(all))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -4724,7 +4724,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
             static const auto all = new SBuf("all");
-            if (auto a = Acl::Node::FindByName(*all))
+            if (const auto a = Acl::Node::FindByName(*all))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2029,15 +2029,12 @@ static void
 ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::Node *acl)
 {
     assert(access);
-    SBuf name;
     if (!*access) {
         *access = new Acl::Tree;
-        name.Printf("(%s rules)", desc);
-        (*access)->context(name.c_str(), config_input_line);
+        (*access)->context(ToSBuf('(', desc, " rules"), config_input_line);
     }
     Acl::AndNode *rule = new Acl::AndNode;
-    name.Printf("(%s rule)", desc);
-    rule->context(name.c_str(), config_input_line);
+    rule->context(ToSBuf(desc, " rule"), config_input_line);
     if (acl)
         rule->add(acl);
     else

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2031,10 +2031,10 @@ ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *d
     assert(access);
     if (!*access) {
         *access = new Acl::Tree;
-        (*access)->context(ToSBuf('(', desc, " rules"), config_input_line);
+        (*access)->context(ToSBuf('(', desc, " rules)"), config_input_line);
     }
     Acl::AndNode *rule = new Acl::AndNode;
-    rule->context(ToSBuf(desc, " rule"), config_input_line);
+    rule->context(ToSBuf('(', desc, " rule)"), config_input_line);
     if (acl)
         rule->add(acl);
     else

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -4723,8 +4723,8 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         *ftp_epsv = nullptr;
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
-            static const SBuf all("all");
-            if (auto a = Acl::Node::FindByName(all))
+            static const auto all = new SBuf("all");
+            if (auto a = Acl::Node::FindByName(*all))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -4726,7 +4726,8 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         *ftp_epsv = nullptr;
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
-            if (auto *a = Acl::Node::FindByName("all"))
+            static const SBuf all("all");
+            if (auto *a = Acl::Node::FindByName(all))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1861,7 +1861,7 @@ clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
     if (!accessAllowed.allowed()) {
         ErrorState *err;
         err_type page_id;
-        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName.value_or(SBuf()), 1);
+        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, 1);
 
         http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1859,8 +1859,7 @@ clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
 
     if (!accessAllowed.allowed()) {
         ErrorState *err;
-        err_type page_id;
-        page_id = aclGetDenyInfoPage(Config.denyInfoList, accessAllowed, true);
+        auto page_id = FindDenyInfoPage(accessAllowed, true);
 
         http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1860,7 +1860,7 @@ clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
     if (!accessAllowed.allowed()) {
         ErrorState *err;
         err_type page_id;
-        page_id = aclGetDenyInfoPage(&Config.denyInfoList, accessAllowed, 1);
+        page_id = aclGetDenyInfoPage(Config.denyInfoList, accessAllowed, true);
 
         http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1853,15 +1853,14 @@ clientReplyContext::ProcessReplyAccessResult(Acl::Answer rv, void *voidMe)
 void
 clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
 {
-    static const SBuf noAcl("NO ACL's");
     debugs(88, 2, "The reply for " << http->request->method
            << ' ' << http->uri << " is " << accessAllowed << ", because it matched "
-           << AclMatchedName.value_or(noAcl));
+           << accessAllowed.lastCheckDescription());
 
     if (!accessAllowed.allowed()) {
         ErrorState *err;
         err_type page_id;
-        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, 1);
+        page_id = aclGetDenyInfoPage(&Config.denyInfoList, accessAllowed, 1);
 
         http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1853,14 +1853,15 @@ clientReplyContext::ProcessReplyAccessResult(Acl::Answer rv, void *voidMe)
 void
 clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
 {
+    const auto aclMatchedName = AclMatchedName ? AclMatchedName.value().c_str() : nullptr;
     debugs(88, 2, "The reply for " << http->request->method
            << ' ' << http->uri << " is " << accessAllowed << ", because it matched "
-           << (AclMatchedName ? AclMatchedName : "NO ACL's"));
+           << (aclMatchedName ? aclMatchedName : "NO ACL's"));
 
     if (!accessAllowed.allowed()) {
         ErrorState *err;
         err_type page_id;
-        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, 1);
+        page_id = aclGetDenyInfoPage(&Config.denyInfoList, aclMatchedName, 1);
 
         http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1853,15 +1853,15 @@ clientReplyContext::ProcessReplyAccessResult(Acl::Answer rv, void *voidMe)
 void
 clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
 {
-    const auto aclMatchedName = AclMatchedName ? AclMatchedName.value().c_str() : nullptr;
+    static const SBuf noAcl("NO ACL's");
     debugs(88, 2, "The reply for " << http->request->method
            << ' ' << http->uri << " is " << accessAllowed << ", because it matched "
-           << (aclMatchedName ? aclMatchedName : "NO ACL's"));
+           << AclMatchedName.value_or(noAcl));
 
     if (!accessAllowed.allowed()) {
         ErrorState *err;
         err_type page_id;
-        page_id = aclGetDenyInfoPage(&Config.denyInfoList, aclMatchedName, 1);
+        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName.value_or(SBuf()), 1);
 
         http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -738,7 +738,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
             debugs(33, 5, "Proxy Auth Message = " << (proxy_auth_msg ? proxy_auth_msg : "<null>"));
 #endif
 
-        auto page_id = aclGetDenyInfoPage(&Config.denyInfoList, answer, answer != ACCESS_AUTH_REQUIRED);
+        auto page_id = aclGetDenyInfoPage(Config.denyInfoList, answer, answer != ACCESS_AUTH_REQUIRED);
 
         http->updateLoggingTags(LOG_TCP_DENIED);
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -738,7 +738,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
             debugs(33, 5, "Proxy Auth Message = " << (proxy_auth_msg ? proxy_auth_msg : "<null>"));
 #endif
 
-        auto page_id = aclGetDenyInfoPage(Config.denyInfoList, answer, answer != ACCESS_AUTH_REQUIRED);
+        auto page_id = FindDenyInfoPage(answer, answer != ACCESS_AUTH_REQUIRED);
 
         http->updateLoggingTags(LOG_TCP_DENIED);
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -748,7 +748,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
          * the clientCreateStoreEntry() call just below.  Pedro Ribeiro
          * <pribeiro@isel.pt>
          */
-        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName.value_or(SBuf()), answer != ACCESS_AUTH_REQUIRED);
+        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, answer != ACCESS_AUTH_REQUIRED);
 
         http->updateLoggingTags(LOG_TCP_DENIED);
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -713,12 +713,10 @@ void
 ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
 {
     acl_checklist = nullptr;
-    err_type page_id;
     Http::StatusCode status;
-    const SBuf none("[none]");
     debugs(85, 2, "The request " << http->request->method << ' ' <<
            http->uri << " is " << answer <<
-           "; last ACL checked: " << AclMatchedName.value_or(none));
+           "; last ACL checked: " << answer.lastCheckDescription());
 
 #if USE_AUTH
     char const *proxy_auth_msg = "<null>";
@@ -733,22 +731,14 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
 
         /* Send an auth challenge or error */
         // XXX: do we still need aclIsProxyAuth() ?
-        bool auth_challenge = (answer == ACCESS_AUTH_REQUIRED || aclIsProxyAuth(AclMatchedName));
+        bool auth_challenge = (answer == ACCESS_AUTH_REQUIRED || aclIsProxyAuth(answer.lastCheckedName));
         debugs(85, 5, "Access Denied: " << http->uri);
-        const SBuf nil("<null>");
-        debugs(85, 5, "AclMatchedName = " << AclMatchedName.value_or(nil));
 #if USE_AUTH
         if (auth_challenge)
             debugs(33, 5, "Proxy Auth Message = " << (proxy_auth_msg ? proxy_auth_msg : "<null>"));
 #endif
 
-        /*
-         * NOTE: get page_id here, based on AclMatchedName because if
-         * USE_DELAY_POOLS is enabled, then AclMatchedName gets clobbered in
-         * the clientCreateStoreEntry() call just below.  Pedro Ribeiro
-         * <pribeiro@isel.pt>
-         */
-        page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, answer != ACCESS_AUTH_REQUIRED);
+        auto page_id = aclGetDenyInfoPage(&Config.denyInfoList, answer, answer != ACCESS_AUTH_REQUIRED);
 
         http->updateLoggingTags(LOG_TCP_DENIED);
 
@@ -2052,10 +2042,8 @@ ClientHttpRequest::handleAdaptationBlock(const Adaptation::Answer &answer)
 {
     static const auto d = MakeNamedErrorDetail("REQMOD_BLOCK");
     request->detailError(ERR_ACCESS_DENIED, d);
-    AclMatchedName = answer.ruleId;
     assert(calloutContext);
-    calloutContext->clientAccessCheckDone(ACCESS_DENIED);
-    AclMatchedName.reset();
+    calloutContext->clientAccessCheckDone(answer.blockedToChecklistAnswer());
 }
 
 void

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -731,7 +731,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
 
         /* Send an auth challenge or error */
         // XXX: do we still need aclIsProxyAuth() ?
-        bool auth_challenge = (answer == ACCESS_AUTH_REQUIRED || aclIsProxyAuth(answer.lastCheckedName));
+        const auto auth_challenge = (answer == ACCESS_AUTH_REQUIRED || aclIsProxyAuth(answer.lastCheckedName));
         debugs(85, 5, "Access Denied: " << http->uri);
 #if USE_AUTH
         if (auth_challenge)

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -923,7 +923,9 @@ Client::handledEarlyAdaptationAbort()
 void
 Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
 {
-    debugs(11,5, answer.ruleId.value_or(SBuf()));
+    const auto blockedAnswer = answer.blockedToChecklistAnswer();
+
+    debugs(11,5, blockedAnswer.lastCheckDescription());
 
     if (abortOnBadEntry("entry went bad while ICAP aborted"))
         return;
@@ -940,7 +942,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
     debugs(11,7, "creating adaptation block response");
 
     err_type page_id =
-        aclGetDenyInfoPage(&Config.denyInfoList, answer.ruleId, 1);
+        aclGetDenyInfoPage(&Config.denyInfoList, blockedAnswer, 1);
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -923,7 +923,7 @@ Client::handledEarlyAdaptationAbort()
 void
 Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
 {
-    debugs(11,5, answer.ruleId);
+    debugs(11,5, answer.ruleId.value_or(SBuf()));
 
     if (abortOnBadEntry("entry went bad while ICAP aborted"))
         return;

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -941,7 +941,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
 
     debugs(11,7, "creating adaptation block response");
 
-    auto page_id = aclGetDenyInfoPage(Config.denyInfoList, blockedAnswer, true);
+    auto page_id = FindDenyInfoPage(blockedAnswer, true);
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -941,8 +941,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
 
     debugs(11,7, "creating adaptation block response");
 
-    err_type page_id =
-        aclGetDenyInfoPage(&Config.denyInfoList, blockedAnswer, 1);
+    auto page_id = aclGetDenyInfoPage(Config.denyInfoList, blockedAnswer, true);
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -940,7 +940,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
     debugs(11,7, "creating adaptation block response");
 
     err_type page_id =
-        aclGetDenyInfoPage(&Config.denyInfoList, answer.ruleId.termedBuf(), 1);
+        aclGetDenyInfoPage(&Config.denyInfoList, answer.ruleId, 1);
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -486,7 +486,7 @@ class external_acl_data
     CBDATA_CLASS(external_acl_data);
 
 public:
-    explicit external_acl_data(external_acl *aDef) : def(cbdataReference(aDef)), arguments(nullptr) {}
+    explicit external_acl_data(external_acl * const aDef): def(cbdataReference(aDef)), arguments(nullptr) {}
     ~external_acl_data();
 
     external_acl *def;

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -486,11 +486,11 @@ class external_acl_data
     CBDATA_CLASS(external_acl_data);
 
 public:
-    explicit external_acl_data(external_acl *aDef) : def(cbdataReference(aDef)), name(nullptr), arguments(nullptr) {}
+    explicit external_acl_data(external_acl *aDef) : def(cbdataReference(aDef)), arguments(nullptr) {}
     ~external_acl_data();
 
     external_acl *def;
-    const char *name;
+    SBuf name;
     wordlist *arguments;
 };
 
@@ -498,7 +498,6 @@ CBDATA_CLASS_INIT(external_acl_data);
 
 external_acl_data::~external_acl_data()
 {
-    xfree(name);
     wordlistDestroy(&arguments);
     cbdataReferenceDone(def);
 }
@@ -528,7 +527,7 @@ ACLExternal::parse()
 
     // def->name is the name of the external_acl_type.
     // this is the name of the 'acl' directive being tested
-    data->name = xstrdup(name);
+    data->name = name;
 
     while ((token = ConfigParser::strtokFile())) {
         wordlistAdd(&data->arguments, token);
@@ -768,8 +767,7 @@ ACLExternal::makeExternalAclKey(ACLFilledChecklist * ch, external_acl_data * acl
 
         if (t->type == Format::LFT_EXT_ACL_NAME) {
             // setup for %ACL
-            safe_free(ch->al->lastAclName);
-            ch->al->lastAclName = xstrdup(acl_data->name);
+            ch->al->lastAclName = acl_data->name;
         }
 
         if (t->type == Format::LFT_EXT_ACL_DATA) {

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1438,7 +1438,8 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_EXT_ACL_NAME:
-            out = al->lastAclName;
+            if (!al->lastAclName.isEmpty())
+                out = al->lastAclName.c_str();
             break;
 
         case LFT_EXT_ACL_DATA:

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -427,7 +427,8 @@ icpCreateAndSend(icp_opcode opcode, int flags, char const *url, int reqnum, int 
 void
 icpDenyAccess(Ip::Address &from, char *url, int reqnum, int fd)
 {
-    debugs(12, 2, "icpDenyAccess: Access Denied for " << from << " by " << (AclMatchedName ? AclMatchedName.value().c_str() : "none") << ".");
+    static const SBuf none("none");
+    debugs(12, 2, "icpDenyAccess: Access Denied for " << from << " by " << AclMatchedName.value_or(none) << ".");
 
     if (clientdbCutoffDenied(from)) {
         /*

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -427,7 +427,7 @@ icpCreateAndSend(icp_opcode opcode, int flags, char const *url, int reqnum, int 
 void
 icpDenyAccess(Ip::Address &from, char *url, int reqnum, int fd)
 {
-    debugs(12, 2, "icpDenyAccess: Access Denied for " << from << " by " << AclMatchedName << ".");
+    debugs(12, 2, "icpDenyAccess: Access Denied for " << from << " by " << (AclMatchedName ? AclMatchedName.value().c_str() : "none") << ".");
 
     if (clientdbCutoffDenied(from)) {
         /*

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -449,10 +449,11 @@ icpAccessAllowed(Ip::Address &from, HttpRequest * icp_request)
     ACLFilledChecklist checklist(Config.accessList.icp, icp_request, nullptr);
     checklist.src_addr = from;
     checklist.my_addr.setNoAddr();
-    if (checklist.fastCheck().allowed())
+    const auto &answer = checklist.fastCheck();
+    if (answer.allowed())
         return true;
 
-    debugs(12, 2, "Access Denied for " << from << " by " << checklist.currentAnswer().lastCheckDescription() << ".");
+    debugs(12, 2, "Access Denied for " << from << " by " << answer.lastCheckDescription() << ".");
     return false;
 }
 

--- a/src/tests/stub_acl.cc
+++ b/src/tests/stub_acl.cc
@@ -13,8 +13,7 @@
 #define STUB_API "acl/"
 #include "tests/STUB.h"
 
-#include "acl/Acl.h"
-#include "sbuf/SBuf.h"
+#include "acl/forward.h"
 
 #include "acl/Gadgets.h"
 size_t aclParseAclList(ConfigParser &, Acl::Tree **, const char *) STUB_RETVAL(0)

--- a/src/tests/stub_acl.cc
+++ b/src/tests/stub_acl.cc
@@ -16,8 +16,6 @@
 #include "acl/Acl.h"
 #include "sbuf/SBuf.h"
 
-std::optional<SBuf> AclMatchedName;
-
 #include "acl/Gadgets.h"
 size_t aclParseAclList(ConfigParser &, Acl::Tree **, const char *) STUB_RETVAL(0)
 

--- a/src/tests/stub_acl.cc
+++ b/src/tests/stub_acl.cc
@@ -14,7 +14,9 @@
 #include "tests/STUB.h"
 
 #include "acl/Acl.h"
-const char *AclMatchedName = nullptr;
+#include "sbuf/SBuf.h"
+
+std::optional<SBuf> AclMatchedName;
 
 #include "acl/Gadgets.h"
 size_t aclParseAclList(ConfigParser &, Acl::Tree **, const char *) STUB_RETVAL(0)


### PR DESCRIPTION
Also removed AclMatchedName global and resolved a couple of XXXs
associated with it. Another problem with AclMatchedName was that
clearing it in Acl::Node::~Node() (to avoid creating a dangling
pointer) also made the last checked ACL name unavailable.

No functionality changes are expected.
