### PR TITLE
repair_http_framing hack for Squid v6

### DIFF
--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -170,6 +170,20 @@ public:
     /// whether message used an unsupported and/or invalid Transfer-Encoding
     bool unsupportedTe() const { return teUnsupported_; }
 
+    /// whether the message is marked to prevent forwarding due to the presence
+    /// of a header field that we could not parse; TODO: Rename.
+    bool hasMalformedField() const { return hasMalformedField_; }
+
+    /// makes hasMalformedField() false
+    void ignoreMalformedField() { hasMalformedField_ = false; }
+
+    /// aggregates framing-related errors (for caller convenience)
+    bool badFraming() const { return unsupportedTe() || conflictingContentLength(); }
+
+    /// replaces existing Transfer-Encoding and/or Content-Length-based framing
+    /// with either chunked or identity encoding (without Content-Length)
+    void forceFraming(const bool useChunked);
+
     /* protected, do not use these, use interface functions instead */
     std::vector<HttpHeaderEntry*, PoolingAllocator<HttpHeaderEntry*> > entries; /**< parsed fields in raw format */
     HttpHeaderMask mask;    /**< bit set <=> entry present */
@@ -194,6 +208,8 @@ private:
     /// unsupported encoding, unnecessary syntax characters, and/or
     /// invalid field-value found in Transfer-Encoding header
     bool teUnsupported_ = false;
+    /// \copydoc hasMalformedField()
+    bool hasMalformedField_ = false;
 };
 
 int httpHeaderParseQuotedString(const char *start, const int len, String *val);

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -402,6 +402,7 @@ public:
         acl_access *forceRequestBodyContinuation;
         acl_access *serverPconnForNonretriable;
         acl_access *collapsedForwardingAccess;
+        acl_access *repairHttpFraming; ///< repair_http_framing
     } accessList;
     AclDenyInfoList *denyInfoList;
 

--- a/src/SquidString.h
+++ b/src/SquidString.h
@@ -105,6 +105,11 @@ public:
     /// returns String::npos if ch is not found
     size_type find(char const ch) const;
     size_type find(char const *aString) const;
+
+    /// case-insensitive search for ASCII strings
+    /// this method should not be used because its implementation is too slow
+    size_type findCaseXXX(char const *aString) const;
+
     const char * rpos(char const ch) const;
     size_type rfind(char const ch) const;
     int cmp(char const *) const;

--- a/src/String.cc
+++ b/src/String.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "base/TextException.h"
 #include "mgr/Registration.h"
+#include "sbuf/SBuf.h"
 #include "Store.h"
 
 #include <climits>
@@ -522,6 +523,25 @@ String::find(char const *aString) const
     if (c==nullptr)
         return npos;
     return c-rawBuf();
+}
+
+String::size_type
+String::findCaseXXX(const char *needle) const
+{
+    assert(needle);
+
+    // (poor) optimization: start by quickly checking the common case
+    const auto sameCasePos = find(needle);
+    if (sameCasePos != npos)
+        return sameCasePos;
+
+    // XXX: implement strcasestr() logic instead
+    const auto lowerBuf = ToLower(SBuf(rawBuf(), size()));
+    const auto lowerNeedle = ToLower(SBuf(needle));
+    const auto otherCasePos = lowerBuf.find(lowerNeedle);
+    if (otherCasePos == SBuf::npos)
+        return npos;
+    return otherCasePos;
 }
 
 String::size_type

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -70,6 +70,7 @@ peer_access		cache_peer acl
 pipelinePrefetch
 PortCfg
 QosConfig
+repair_http_framing     acl
 TokenOrQuotedString
 refreshpattern
 removalpolicy

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7159,6 +7159,51 @@ DOC_START
 	or response to be rejected.
 DOC_END
 
+NAME: repair_http_framing
+IFDEF: USE_HTTP_VIOLATIONS
+TYPE: acl_access
+LOC: Config.accessList.repairHttpFraming
+DEFAULT: none
+DEFAULT_DOC: Terminate connection due to bad HTTP framing.
+DOC_START
+	WARNING: Allowing Squid to muddle through HTTP framing errors may
+	expose your Squid instance (and other HTTP agents) to message
+	smuggling attacks, cache poisoning, and other security risks. This
+	directive is meant as a temporary workaround for broken HTTP agents
+	that are known to send no malicious traffic and to be compatible with
+	this directive manipulation of received HTTP headers.
+
+	Squid consults this directive in these cases:
+
+	* Upon discovering an "unsupported Transfer-Encoding" framing error:
+	  An allow match treats that encoding as either "chunked" or
+	  "identity" (depending on whether the bad encoding had the letters
+	  "chunk" in it). The Content-Length header field, if any, is ignored
+	  in this case.
+
+	* Upon discovering a "bad Content-Length" framing error: An allow
+	  match treats this case as if no Content-Length header fields were
+	  present. This treatment stalls responses if the server does not
+	  close the connection shortly after delivering the broken response.
+	  TODO: Do not repair at all?
+
+	* Upon discovering an HTTP 999 response status code: An allow match treats
+	  this case as if a 502 status code was received. Per HTTP WG consensus,
+	  any 3-digit code above 599 is considered semantically invalid:
+	  https://lists.w3.org/Archives/Public/ietf-http-wg/2010AprJun/0354.html
+
+	* Upon discovering an HTTP header field name that is not a token: An allow
+	  match treats this case as if an "X-Name: value" field was received. See
+	  RFC 9110 for the list of token characters (a.k.a. "tchar"):
+	  https://httpwg.org/specs/rfc9110.html#rule.token.separators
+
+	The directive is checked once per badly framed message, but if multiple
+	violations are detected in a message, then an allow match enables multiple
+	repairs.
+
+	This directive supports fast ACLs only.
+DOC_END
+
 NAME: collapsed_forwarding
 COMMENT: (on|off)
 TYPE: onoff

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1673,9 +1673,12 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         request->http_ver.minor = http_ver.minor;
     }
 
+    if (request->header.hasMalformedField() || request->header.badFraming())
+        http->repairFraming();
+
     mustReplyToOptions = (request->method == Http::METHOD_OPTIONS) &&
                          (request->header.getInt64(Http::HdrType::MAX_FORWARDS) == 0);
-    if (!urlCheckRequest(request.getRaw()) || mustReplyToOptions) {
+    if (!urlCheckRequest(request.getRaw()) || mustReplyToOptions || request->header.hasMalformedField()) {
         clientStreamNode *node = context->getClientReplyContext();
         conn->quitAfterError(request.getRaw());
         clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -163,6 +163,50 @@ ClientHttpRequest::onlyIfCached()const
            request->cache_control->hasOnlyIfCached();
 }
 
+void
+ClientHttpRequest::repairFraming()
+{
+#if !USE_HTTP_VIOLATIONS
+    return; // no HTTP-violating repairs in this build
+#endif
+
+    if (!Config.accessList.repairHttpFraming)
+        return; // no repairs by default
+
+    ACLFilledChecklist checklist(Config.accessList.repairHttpFraming, nullptr);
+    clientAclChecklistFill(checklist, this);
+    if (!checklist.fastCheck().allowed())
+        return; // repairs prohibited by the admin
+
+    debugs(11, 3, "problems:" <<
+           (request->header.hasMalformedField() ? " field" : "") <<
+           (request->header.unsupportedTe() ? " te" : "") <<
+           (request->header.conflictingContentLength() ? " clen" : ""));
+
+    if (request->header.hasMalformedField())
+        request->header.ignoreMalformedField();
+
+    if (request->header.unsupportedTe()) {
+        String rawTe;
+        const auto gotTe = request->header.getByIdIfPresent(Http::HdrType::TRANSFER_ENCODING, &rawTe);
+        assert(gotTe); // HttpHeader preserves malformed Transfer-Encoding value
+        const auto possiblyChunked = rawTe.findCaseXXX("chunk") != String::npos;
+        request->header.forceFraming(possiblyChunked);
+        // "removed" Transfer-Encoding (and any Content-Length) problems
+    } else if (request->header.conflictingContentLength()) {
+        // we should only be called when the caller knows that repairs are needed
+        request->header.forceFraming(false);
+        // "removed" Content-Length problems
+    }
+
+    // reduce cache poisoning risks posed by this malformed request
+    auto &requestFlags = request->flags;
+    requestFlags.noCache = true;
+    requestFlags.cachable.veto(); // XXX: may be overwritten by maybeCacheable()
+    requestFlags.proxyKeepalive = false;
+    requestFlags.mustKeepalive = false; // XXX: may be overwritten by auth code
+}
+
 /**
  * This function is designed to serve a fairly specific purpose.
  * Occasionally our vBNS-connected caches can talk to each other, but not

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -82,6 +82,9 @@ public:
     /// the request. To set the virgin request, use initRequest().
     void resetRequest(HttpRequest *);
 
+    /// fixes a subset of request framing problems if allowed to do so
+    void repairFraming();
+
     /// update the code in the transaction processing tags
     void updateLoggingTags(const LogTags_ot code) { al->cache.code.update(code); }
 

--- a/src/http.h
+++ b/src/http.h
@@ -104,6 +104,7 @@ private:
     void checkDateSkew(HttpReply *);
 
     bool continueAfterParsingHeader();
+    void repairFraming(HttpReply &);
     void truncateVirginBody();
 
     void start() override;
@@ -151,6 +152,9 @@ private:
     int64_t payloadSeen = 0;
     /// positive when we read more than we wanted
     int64_t payloadTruncated = 0;
+
+    /// Whether a badly framed response was massaged enough to become usable.
+    bool repairedBadFraming = false;
 
     /// Whether we received a Date header older than that of a matching
     /// cached response.

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -35,6 +35,12 @@ void
 Http::StatusLine::set(const AnyP::ProtocolVersion &newVersion, const Http::StatusCode newStatus, const char *newReason)
 {
     version = newVersion;
+    resetStatus(newStatus, newReason);
+}
+
+void
+Http::StatusLine::resetStatus(const Http::StatusCode newStatus, const char * const newReason)
+{
     status_ = newStatus;
     /* Note: no xstrdup for 'reason', assumes constant 'reasons' */
     reason_ = newReason;

--- a/src/http/StatusLine.h
+++ b/src/http/StatusLine.h
@@ -44,6 +44,10 @@ public:
     /// retrieve the status code for this status line
     Http::StatusCode status() const { return status_; }
 
+    bool hasKnownStatusClass() const { return 100 <= status_ && status_ < 600; }
+
+    void resetStatus(Http::StatusCode, const char *newReason = nullptr);
+
     /// retrieve the reason string for this status line
     const char *reason() const;
 

--- a/src/http/one/ResponseParser.cc
+++ b/src/http/one/ResponseParser.cc
@@ -94,6 +94,12 @@ Http::One::ResponseParser::ParseResponseStatus(Tokenizer &tok, StatusCode &code)
         if (code <= 99)
             throw TextException(ToSBuf("status-code too short: ", code), Here());
 
+        // e.g., 999 Request denied ... X-Li-Proto: http/1.1
+        if (code == 999 && Config.accessList.repairHttpFraming) {
+            // risk leaking this unknown-class status code to general code
+            return;
+        }
+
         // Codes with a non-standard first digit (a.k.a. response class) are
         // considered semantically invalid per the following HTTP WG discussion:
         // https://lists.w3.org/Archives/Public/ietf-http-wg/2010AprJun/0354.html


### PR DESCRIPTION
repair_http_framing hack for Squid v6

This version contains support for repairing HTTP header fields with
names containing non-token characters.

Also: Allow using just-parsed HTTP responses with ACLFilledChecklist.
The lack of HttpReply locking meant that we could not (safely) use the
freshly created reply object for ACLs checks because ACLFilledChecklist
destructor would unwittingly destroy the object (by unlocking it). There
was at least one such ACL check (in handle1xx()), but we got lucky
because that method also added the reply object to ALE, increasing its
reference counter.

TODO: That above addition to ALE should probably happen earlier and
unconditionally.

This change also protects from HttpReply memory leaks when an exception
is thrown between HttpReply creation and a setVirginReply() call.