### PR TITLE
Ensure ACLChecklist::markFinished() is called

### DIFF
--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -215,7 +215,7 @@ ACLChecklist::nonBlockingCheck(ACLCB * callback_, void *callback_data_)
      * We cannot select a sensible default for all callers here. */
     if (accessList == nullptr) {
         debugs(28, DBG_CRITICAL, "SECURITY ERROR: ACL " << this << " checked with nothing to match against!!");
-        checkCallback("accessList is nil");
+        checkCallback("nonBlockingCheck() without accessList");
         return;
     }
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -156,13 +156,12 @@ ACLChecklist::goAsync(AsyncStarter starter, const Acl::Node &acl)
 void
 ACLChecklist::checkCallback(const char *abortReason)
 {
-    ACLCB *callback_;
-    void *cbdata_;
-
     if (abortReason)
         markFinished(ACCESS_DUNNO, abortReason);
-
     Assure(finished());
+
+    ACLCB *callback_;
+    void *cbdata_;
 
     callback_ = callback;
     callback = nullptr;

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -23,7 +23,7 @@ ACLChecklist::prepNonBlocking()
     assert(accessList);
 
     if (callerGone()) {
-        checkCallback(ACCESS_DUNNO, "caller is gone"); // the answer does not really matter
+        checkCallback("caller is gone"); // the answer does not really matter
         return false;
     }
 
@@ -34,7 +34,7 @@ ACLChecklist::prepNonBlocking()
 
     if (!cbdataReferenceValid(accessList)) {
         cbdataReferenceDone(accessList);
-        checkCallback(ACCESS_DUNNO, "accessList is invalid");
+        checkCallback("accessList is invalid");
         return false;
     }
 
@@ -50,7 +50,7 @@ ACLChecklist::completeNonBlocking()
         calcImplicitAnswer();
 
     cbdataReferenceDone(accessList);
-    checkCallback(currentAnswer(), nullptr);
+    checkCallback(nullptr);
 }
 
 void
@@ -154,19 +154,19 @@ ACLChecklist::goAsync(AsyncStarter starter, const Acl::Node &acl)
 // ACLFilledChecklist overwrites this to unclock something before we
 // "delete this"
 void
-ACLChecklist::checkCallback(const Acl::Answer &answer, const char *reason)
+ACLChecklist::checkCallback(const char *abortReason)
 {
-    debugs(28, 3, this << " answer=" << answer);
+    ACLCB *callback_;
+    void *cbdata_;
 
-    if (!finished()) {
-        Assure(reason);
-        markFinished(answer, reason);
-    }
+    if (abortReason)
+        markFinished(ACCESS_DUNNO, abortReason);
 
-    const auto callback_ = callback;
+    Assure(finished());
+
+    callback_ = callback;
     callback = nullptr;
 
-    void *cbdata_ = nullptr;
     if (cbdataReferenceValidDone(callback_data, &cbdata_))
         callback_(currentAnswer(), cbdata_);
 
@@ -216,7 +216,7 @@ ACLChecklist::nonBlockingCheck(ACLCB * callback_, void *callback_data_)
      * We cannot select a sensible default for all callers here. */
     if (accessList == nullptr) {
         debugs(28, DBG_CRITICAL, "SECURITY ERROR: ACL " << this << " checked with nothing to match against!!");
-        checkCallback(ACCESS_DUNNO, "accessList is nil");
+        checkCallback("accessList is nil");
         return;
     }
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -23,7 +23,7 @@ ACLChecklist::prepNonBlocking()
     assert(accessList);
 
     if (callerGone()) {
-        checkCallback(ACCESS_DUNNO); // the answer does not really matter
+        checkCallback(ACCESS_DUNNO, "caller is gone"); // the answer does not really matter
         return false;
     }
 
@@ -34,8 +34,7 @@ ACLChecklist::prepNonBlocking()
 
     if (!cbdataReferenceValid(accessList)) {
         cbdataReferenceDone(accessList);
-        debugs(28, 4, "ACLChecklist::check: " << this << " accessList is invalid");
-        checkCallback(ACCESS_DUNNO);
+        checkCallback(ACCESS_DUNNO, "accessList is invalid");
         return false;
     }
 
@@ -51,7 +50,7 @@ ACLChecklist::completeNonBlocking()
         calcImplicitAnswer();
 
     cbdataReferenceDone(accessList);
-    checkCallback(currentAnswer());
+    checkCallback(currentAnswer(), nullptr);
 }
 
 void
@@ -155,17 +154,21 @@ ACLChecklist::goAsync(AsyncStarter starter, const Acl::Node &acl)
 // ACLFilledChecklist overwrites this to unclock something before we
 // "delete this"
 void
-ACLChecklist::checkCallback(const Acl::Answer &answer)
+ACLChecklist::checkCallback(const Acl::Answer &answer, const char *reason)
 {
-    ACLCB *callback_;
-    void *cbdata_;
-    debugs(28, 3, "ACLChecklist::checkCallback: " << this << " answer=" << answer);
+    debugs(28, 3, this << " answer=" << answer);
 
-    callback_ = callback;
+    if (!finished()) {
+        Assure(reason);
+        markFinished(answer, reason);
+    }
+
+    const auto callback_ = callback;
     callback = nullptr;
 
+    void *cbdata_ = nullptr;
     if (cbdataReferenceValidDone(callback_data, &cbdata_))
-        callback_(answer, cbdata_);
+        callback_(currentAnswer(), cbdata_);
 
     // not really meaningful just before delete, but here for completeness sake
     occupied_ = false;
@@ -213,7 +216,7 @@ ACLChecklist::nonBlockingCheck(ACLCB * callback_, void *callback_data_)
      * We cannot select a sensible default for all callers here. */
     if (accessList == nullptr) {
         debugs(28, DBG_CRITICAL, "SECURITY ERROR: ACL " << this << " checked with nothing to match against!!");
-        checkCallback(ACCESS_DUNNO);
+        checkCallback(ACCESS_DUNNO, "accessList is nil");
         return;
     }
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -154,7 +154,7 @@ ACLChecklist::goAsync(AsyncStarter starter, const Acl::Node &acl)
 // ACLFilledChecklist overwrites this to unclock something before we
 // "delete this"
 void
-ACLChecklist::checkCallback(const char *abortReason)
+ACLChecklist::checkCallback(const char * const abortReason)
 {
     if (abortReason)
         markFinished(ACCESS_DUNNO, abortReason);

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -158,9 +158,9 @@ public:
     void setLastCheckedName(const SBuf &name) { lastCheckedName_ = name; }
 
 private:
-    /// Sets the final answer (if not set already) and prints the reason for that answer.
+    /// If abortReason is provided, set the final answer to ACCESS_DUNNO.
     /// Calls non-blocking check callback with the answer and destroys self.
-    void checkCallback(const Acl::Answer &answer, const char *reason);
+    void checkCallback(const char *abortReason);
 
     void matchAndFinish();
 

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -158,8 +158,8 @@ public:
     void setLastCheckedName(const SBuf &name) { lastCheckedName_ = name; }
 
 private:
-    /// If abortReason is provided, set the final answer to ACCESS_DUNNO.
     /// Calls non-blocking check callback with the answer and destroys self.
+    /// If abortReason is provided, sets the final answer to ACCESS_DUNNO.
     void checkCallback(const char *abortReason);
 
     void matchAndFinish();

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -158,8 +158,9 @@ public:
     void setLastCheckedName(const SBuf &name) { lastCheckedName_ = name; }
 
 private:
+    /// Sets the final answer (if not set already) and prints the reason for that answer.
     /// Calls non-blocking check callback with the answer and destroys self.
-    void checkCallback(const Acl::Answer &answer);
+    void checkCallback(const Acl::Answer &answer, const char *reason);
 
     void matchAndFinish();
 


### PR DESCRIPTION
For example, ACLChecklist::resumeNonBlockingCheck() missed a
markFinished() call when prepNonBlocking() returned false after a
reconfiguration. Missing markFinished() calls result in the last
evaluated ACL name being unset in nonBlockingCheck() callbacks.