### PR TITLE
Do not require an HTTP request in annotate_client

### DIFF
--- a/src/acl/AnnotateClient.cc
+++ b/src/acl/AnnotateClient.cc
@@ -26,6 +26,7 @@ Acl::AnnotateClientCheck::match(ACLChecklist * const ch)
             tdata->annotate(request->notes(), &delimiters.value, checklist->al);
         return 1;
     }
+    debugs(28, 7, "fails: client has gone");
     return 0;
 }
 

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -20,7 +20,6 @@ class AnnotateClientCheck: public Acl::AnnotationCheck
 public:
     /* Acl::Node API */
     int match(ACLChecklist *) override;
-    bool requiresRequest() const override { return true; }
 };
 
 } // namespace Acl

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1401,7 +1401,7 @@ ENDIF
 
 	acl aclname annotate_transaction [-m[=delimiters]] key=value ...
 	acl aclname annotate_transaction [-m[=delimiters]] key+=value ...
-	  # Always matches. [fast]
+	  # Matches transactions containing an HTTP request. [fast]
 	  # Used for its side effect: This ACL immediately adds a
 	  # key=value annotation to the current master transaction.
 	  # The added annotation can then be tested using note ACL and


### PR DESCRIPTION
This ACL needs just the current client-to-Squid connection for
storing the configured annotation: there can be no parsed HTTP request
at that time. If the request is available, it is optionally added to the
current transaction annotation.

Also fixed annotate_transaction documentation to reflect the
fact that in cannot be used in the context without the (parsed)
HTTP request.