### PR TITLE
Bug 5056: assertion failed: Read.cc:61: Comm::IsConnOpen(conn)

### DIFF
--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -897,6 +897,16 @@ tunnelDelayedServerRead(void *data)
 void
 TunnelStateData::copyRead(Connection &from, IOCB *completion)
 {
+    // TODO: remove code duplication, creating a helper method
+    if (!Comm::IsConnOpen(from.conn)) {
+        const auto clientGone = from.conn == client.conn;
+	    debugs(26, 1, (clientGone ? "Client" : "Server") << " gone away. Shutting down "
+                    << (clientGone ? "server" : "client") << " connection.");
+	    const auto toConn = clientGone ? server.conn : client.conn;
+	    toConn->close();
+	    return;
+    }
+
     assert(from.len == 0);
     // If only the minimum permitted read size is going to be attempted
     // then we schedule an event to try again in a few I/O cycles.


### PR DESCRIPTION
    FATAL: assertion failed: Read.cc:61: "Comm::IsConnOpen(conn)"

comm_read() was called on a closed connection because it was initiated
by tunnelDelayedServerRead() event triggered after the connection
closure.