### PR TITLE
Allocate fast-checking ACLFilledChecklists on stack

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -798,11 +798,10 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
         const bool proxyProtocolPort = port ? port->flags.proxySurrogate : false;
         if (flags.interceptTproxy && !proxyProtocolPort) {
             if (Config.accessList.spoof_client_ip) {
-                const auto checklist = new ACLFilledChecklist(Config.accessList.spoof_client_ip, this);
-                checklist->al = al;
-                checklist->syncAle(this, nullptr);
-                flags.spoofClientIp = checklist->fastCheck().allowed();
-                delete checklist;
+                ACLFilledChecklist checklist(Config.accessList.spoof_client_ip, this);
+                checklist.al = al;
+                checklist.syncAle(this, nullptr);
+                flags.spoofClientIp = checklist.fastCheck().allowed();
             } else
                 flags.spoofClientIp = true;
         } else

--- a/src/adaptation/icap/Launcher.cc
+++ b/src/adaptation/icap/Launcher.cc
@@ -140,12 +140,9 @@ bool Adaptation::Icap::Launcher::canRepeat(Adaptation::Icap::XactAbortInfo &info
     if (info.icapReply->sline.status() == Http::scNone) // failed to parse the reply; I/O err
         return true;
 
-    const auto cl = new ACLFilledChecklist(TheConfig.repeat, info.icapRequest);
-    cl->updateReply(info.icapReply);
-
-    bool result = cl->fastCheck().allowed();
-    delete cl;
-    return result;
+    ACLFilledChecklist cl(TheConfig.repeat, info.icapRequest);
+    cl.updateReply(info.icapReply);
+    return cl.fastCheck().allowed();
 }
 
 /* ICAPXactAbortInfo */

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -844,9 +844,10 @@ clientReplyContext::blockedHit() const
         return false; // internal content "hits" cannot be blocked
 
     {
-        std::unique_ptr<ACLFilledChecklist> chl(clientAclChecklistCreate(Config.accessList.sendHit, http));
-        chl->updateReply(&http->storeEntry()->mem().freshestReply());
-        return !chl->fastCheck().allowed(); // when in doubt, block
+        ACLFilledChecklist chl(Config.accessList.sendHit, nullptr);
+        clientAclChecklistFill(chl, http);
+        chl.updateReply(&http->storeEntry()->mem().freshestReply());
+        return !chl.fastCheck().allowed(); // when in doubt, block
     }
 }
 

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -290,9 +290,10 @@ Http::Stream::sendStartOfMessage(HttpReply *rep, StoreIOBuffer bodyData)
 #if USE_DELAY_POOLS
     for (const auto &pool: MessageDelayPools::Instance()->pools) {
         if (pool->access) {
-            std::unique_ptr<ACLFilledChecklist> chl(clientAclChecklistCreate(pool->access, http));
-            chl->updateReply(rep);
-            const auto answer = chl->fastCheck();
+            ACLFilledChecklist chl(pool->access, nullptr);
+            clientAclChecklistFill(chl, http);
+            chl.updateReply(rep);
+            const auto answer = chl.fastCheck();
             if (answer.allowed()) {
                 writeQuotaHandler = pool->createBucket();
                 fd_table[clientConnection->fd].writeQuotaHandler = writeQuotaHandler;


### PR DESCRIPTION
There is no need for dynamic allocation overhead in these cases.