### PR TITLE
annotate_client did not annotate error:* transactions

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -773,10 +773,18 @@ UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs const &he
 void
 HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntryPointer &al)
 {
+    if (clientConnectionManager == aMgr)
+        return;
+
     clientConnectionManager = aMgr;
 
     if (!clientConnectionManager.valid())
         return;
+
+    // TODO: We fill request notes here until we find a way to verify whether
+    // no ACL checking is performed before ClientHttpRequest::doCallouts().
+    if (clientConnectionManager->hasNotes())
+        notes()->appendNewOnly(clientConnectionManager->notes().getRaw());
 
     AnyP::PortCfgPointer port = clientConnectionManager->port;
     if (port) {

--- a/src/acl/AnnotateClient.cc
+++ b/src/acl/AnnotateClient.cc
@@ -30,9 +30,6 @@ Acl::AnnotateClientCheck::match(ACLChecklist * const ch)
     if (const auto &request = checklist->request) {
         tdata->annotate(request->notes(), &delimiters.value, checklist->al);
         annotated = true;
-    } else if (conn && !conn->pipeline.empty()) {
-        debugs(28, DBG_IMPORTANT, "ERROR: Squid BUG: " << name << " ACL is used in context with " <<
-               "an unexpectedly nil ACLFilledChecklist::request. Did not annotate the current transaction.");
     }
 
     if (!annotated) {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1578,8 +1578,6 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
     // this entire function to remove them from the FTP code path. Connection
     // setup and body_pipe preparation blobs are needed for FTP.
 
-    request->manager(conn, http->al);
-
     request->flags.accelerated = http->flags.accel;
     request->flags.sslBumped=conn->switchedToHttps();
     // TODO: decouple http->flags.accel from request->flags.sslBumped

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1612,10 +1612,6 @@ void
 ClientHttpRequest::initRequest(HttpRequest *aRequest)
 {
     assignRequest(aRequest);
-    if (const auto csd = getConn()) {
-        if (!csd->notes()->empty())
-            request->notes()->appendNewOnly(csd->notes().getRaw());
-    }
     // al is created in the constructor
     assert(al);
     if (!al->request) {

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -756,6 +756,7 @@ Ftp::Server::parseOneRequest()
     http->req_sz = tok.parsedSize();
     http->uri = newUri;
     http->initRequest(request);
+    request->manager(this, http->al);
 
     Http::Stream *const result =
         new Http::Stream(clientConnection, http);

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -59,7 +59,7 @@ private:
     /// Return false if parsing is failed, true otherwise.
     bool buildHttpRequest(Http::StreamPointer &context);
 
-    void setReplyError(Http::StreamPointer &context, HttpRequest::Pointer &request, err_type requestError, Http::StatusCode errStatusCode, const char *requestErrorBytes);
+    void setReplyError(Http::StreamPointer &context, err_type requestError, Http::StatusCode errStatusCode, const char *requestErrorBytes);
 
     Http1::RequestParserPointer parser_;
     HttpRequestMethod method_; ///< parsed HTTP method


### PR DESCRIPTION
cc71dd7 introduced an admin-level BUG requirement that a non-empty
message pipeline means an existing HttpRequest object. That requirement
was incorrect because when the pipeline receives the HttpStream object
(returned by ConnStateData::parseOneRequest()), the corresponding
HttpRequest is not created yet (an may be not created at all, depending
on further checks). Now, instead of demanding HttpRequest
presence in annotate_client, we annotate requests if/when they get
created (and imported into ClientHttpRequest) by copying the existing
connection annotation. That copying already worked for successfully
parsed and fake HttpRequests, but was missing for error-uri requests
(such as "error:invalid-request").

Also fill these 'error:*' HttpRequests with connection-level
information. For example, access_log takes this information from
the request, and fails to match some ACLs, such as 'src'.
