### PR TITLE
Fix %err_code/%err_detail for some error:transaction-end-before-headers

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3960,7 +3960,10 @@ ConnStateData::checkLogging()
     http.req_sz = inBuf.length();
     // XXX: Or we died while waiting for the pinned connection to become idle.
     http.setErrorUri("error:transaction-end-before-headers");
-    http.updateError(bareError);
+    Error error(ERR_CLIENT_GONE);
+    static const auto d = MakeNamedErrorDetail("PENDING_REQUEST");
+    error.details.push_back(d);
+    http.updateError(error);
 }
 
 bool

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -427,7 +427,8 @@ protected:
     /// timeout to use when waiting for the next request
     virtual time_t idleTimeout() const = 0;
 
-    /// the current request needs more bytes to be parsed
+    /// There are some unparsed request bytes.
+    /// The stream object either does not exist or already in the pipeline.
     virtual bool pendingRequestBytes() = 0;
 
     /// Perform client data lookups that depend on client src-IP.

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -375,6 +375,9 @@ public:
     /// they need from the ACLFilledChecklist::conn() without filling/copying.
     void fillConnectionLevelDetails(ACLFilledChecklist &) const;
 
+    /// mark an stream error
+    void onStreamFailure(const char *why) { streamFailureReason_ = why; }
+
     // Exposed to be accessible inside the ClientHttpRequest constructor.
     // TODO: Remove. Make sure there is always a suitable ALE instead.
     /// a problem that occurred without a request (e.g., while parsing headers)
@@ -424,6 +427,9 @@ protected:
     /// timeout to use when waiting for the next request
     virtual time_t idleTimeout() const = 0;
 
+    /// the current request needs more bytes to be parsed
+    virtual bool pendingRequestBytes() = 0;
+
     /// Perform client data lookups that depend on client src-IP.
     /// The PROXY protocol may require some data input first.
     void whenClientIpKnown();
@@ -433,12 +439,8 @@ protected:
     /// whether preservedClientData is valid and should be kept up to date
     bool preservingClientData_ = false;
 
-    /// whether there is no (yet) enough data to parse the request
-    bool incompleteRequest() const { return !inBuf.isEmpty() || incompleteHttpRequest_; }
-
-    // no such flag for FTP: the FTP parser is not incremental
-    // HTTP parser consumed some bytes of an incomplete HTTP request
-    bool incompleteHttpRequest_ = false;
+    /// such as STREAM_UNPLANNED_COMPLETE or STREAM_FAILED
+    const char *streamFailureReason_ = nullptr;
 
     bool tunnelOnError(const err_type);
 

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -375,9 +375,6 @@ public:
     /// they need from the ACLFilledChecklist::conn() without filling/copying.
     void fillConnectionLevelDetails(ACLFilledChecklist &) const;
 
-    /// mark an stream error
-    void onStreamFailure(const char *why) { streamFailureReason_ = why; }
-
     // Exposed to be accessible inside the ClientHttpRequest constructor.
     // TODO: Remove. Make sure there is always a suitable ALE instead.
     /// a problem that occurred without a request (e.g., while parsing headers)
@@ -429,7 +426,10 @@ protected:
 
     /// There are some unparsed request bytes.
     /// The stream object either does not exist or already in the pipeline.
-    virtual bool pendingRequestBytes() = 0;
+    virtual bool pendingRequestBytes() const = 0;
+
+    /// Remove all buffered unparsed request bytes.
+    virtual void clearPendingRequestBytes() = 0;
 
     /// Perform client data lookups that depend on client src-IP.
     /// The PROXY protocol may require some data input first.
@@ -439,9 +439,6 @@ protected:
 
     /// whether preservedClientData is valid and should be kept up to date
     bool preservingClientData_ = false;
-
-    /// such as STREAM_UNPLANNED_COMPLETE or STREAM_FAILED
-    const char *streamFailureReason_ = nullptr;
 
     bool tunnelOnError(const err_type);
 
@@ -509,6 +506,8 @@ private:
     const char *stoppedSending_ = nullptr;
     /// the reason why we no longer read the request or nil
     const char *stoppedReceiving_ = nullptr;
+    /// whether quitAfterError() was called
+    bool quitAfterError_ = false;
     /// Connection annotations, clt_conn_tag and other tags are stored here.
     /// If set, are propagated to the current and all future master transactions
     /// on the connection.

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -433,6 +433,13 @@ protected:
     /// whether preservedClientData is valid and should be kept up to date
     bool preservingClientData_ = false;
 
+    /// whether there is no (yet) enough data to parse the request
+    bool incompleteRequest() const { return !inBuf.isEmpty() || incompleteHttpRequest_; }
+
+    // no such flag for FTP: the FTP parser is not incremental
+    // HTTP parser consumed some bytes of an incomplete HTTP request
+    bool incompleteHttpRequest_ = false;
+
     bool tunnelOnError(const err_type);
 
 private:

--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -81,8 +81,7 @@ typedef enum {
     ERR_REQUEST_START_TIMEOUT, // Aborts the connection instead of error page
     ERR_REQUEST_PARSE_TIMEOUT, // Aborts the connection instead of error page
     ERR_RELAY_REMOTE, // Sends server reply instead of error page
-    ERR_REQUEST_STOPPED_SENDING, // Prematurely stopped sending response to the client due to an error
-    ERR_REQUEST_STOPPED_RECEIVING, // Prematurely stopped receiving request from the client due to an error
+    ERR_STREAM_FAILURE, // No client to send the error page to
 
     /* Cache Manager GUI can install a manager index/home page */
     MGR_INDEX,

--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -81,6 +81,8 @@ typedef enum {
     ERR_REQUEST_START_TIMEOUT, // Aborts the connection instead of error page
     ERR_REQUEST_PARSE_TIMEOUT, // Aborts the connection instead of error page
     ERR_RELAY_REMOTE, // Sends server reply instead of error page
+    ERR_REQUEST_STOPPED_SENDING, // Prematurely stopped sending response to the client due to an error
+    ERR_REQUEST_STOPPED_RECEIVING, // Prematurely stopped receiving request from the client due to an error
 
     /* Cache Manager GUI can install a manager index/home page */
     MGR_INDEX,

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -538,6 +538,7 @@ Http::Stream::finished()
     /* we can't handle any more stream data - detach */
     clientStreamDetach(getTail(), http);
 
+    mayUseConnection_ = false; // may already be false
     assert(connRegistered_);
     connRegistered_ = false;
     conn->pipeline.popMe(Http::StreamPointer(this));
@@ -549,7 +550,6 @@ Http::Stream::initiateClose(const char *reason)
 {
     debugs(33, 4, clientConnection << " because " << reason);
     getConn()->stopSending(reason); // closes ASAP
-    getConn()->onStreamFailure(reason);
 }
 
 void

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -549,6 +549,7 @@ Http::Stream::initiateClose(const char *reason)
 {
     debugs(33, 4, clientConnection << " because " << reason);
     getConn()->stopSending(reason); // closes ASAP
+    getConn()->onStreamFailure(reason);
 }
 
 void

--- a/src/servers/FtpServer.h
+++ b/src/servers/FtpServer.h
@@ -102,6 +102,7 @@ protected:
     int pipelinePrefetchMax() const override;
     bool writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &call) override;
     time_t idleTimeout() const override;
+    bool pendingRequestBytes() override { return false; } // all FTP request bytes are parsed at once
 
     /* BodyPipe API */
     void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;

--- a/src/servers/FtpServer.h
+++ b/src/servers/FtpServer.h
@@ -102,7 +102,8 @@ protected:
     int pipelinePrefetchMax() const override;
     bool writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &call) override;
     time_t idleTimeout() const override;
-    bool pendingRequestBytes() override { return false; } // all FTP request bytes are parsed at once
+    bool pendingRequestBytes() const override { return false; } // all FTP request bytes are parsed at once
+    virtual void clearPendingRequestBytes() { }
 
     /* BodyPipe API */
     void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -39,6 +39,7 @@ protected:
     int pipelinePrefetchMax() const override;
     time_t idleTimeout() const override;
     void noteTakeServerConnectionControl(ServerConnectionContext) override;
+    bool pendingRequestBytes() override { return parser_->needsMoreData(); }
 
     /* BodyPipe API */
     void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -39,7 +39,7 @@ protected:
     int pipelinePrefetchMax() const override;
     time_t idleTimeout() const override;
     void noteTakeServerConnectionControl(ServerConnectionContext) override;
-    bool pendingRequestBytes() override { return parser_->needsMoreData(); }
+    bool pendingRequestBytes() override { return (parser_ && parser_->needsMoreData()) || !inBuf.isEmpty(); }
 
     /* BodyPipe API */
     void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -39,7 +39,8 @@ protected:
     int pipelinePrefetchMax() const override;
     time_t idleTimeout() const override;
     void noteTakeServerConnectionControl(ServerConnectionContext) override;
-    bool pendingRequestBytes() override { return (parser_ && parser_->needsMoreData()) || !inBuf.isEmpty(); }
+    bool pendingRequestBytes() const override { return (parser_ && parser_->needsMoreData()) || !inBuf.isEmpty(); }
+    void clearPendingRequestBytes() override { if (parser_ && parser_->needsMoreData()) { parser_->clear(); }; inBuf.clear(); }
 
     /* BodyPipe API */
     void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;


### PR DESCRIPTION
Those codes were missed when, for example, a GET request is followed
by another GET request, and client disconnects before server sends
a response (and pipelining is disabled, by default). Now the
values are:    

    %error_code=ERR_CLIENT_GONE
    %error_detail=WITH_CLIENT+PENDING_REQUEST