### PR TITLE
Limit Server::inBuf growth

### DIFF
--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -442,6 +442,7 @@ void Adaptation::Icap::Xaction::noteCommRead(const CommIoCbParams &io)
 
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
+    rd.size = SQUID_TCP_SO_RCVBUF - readBuf.length();
 
     switch (Comm::ReadNow(rd, readBuf)) {
     case Comm::INPROGRESS:

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -146,6 +146,8 @@ Server::doClientRead(const CommIoCbParams &io)
 
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
+    rd.size = Config.maxRequestBufferSize - inBuf.length();
+
     switch (Comm::ReadNow(rd, inBuf)) {
     case Comm::INPROGRESS:
 

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -146,6 +146,7 @@ Server::doClientRead(const CommIoCbParams &io)
 
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
+    Assure(Config.maxRequestBufferSize > inBuf.length());
     rd.size = Config.maxRequestBufferSize - inBuf.length();
 
     switch (Comm::ReadNow(rd, inBuf)) {

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -85,16 +85,25 @@ Server::maybeMakeSpaceAvailable()
         debugs(33, 4, "request buffer full: client_request_buffer_max_size=" << Config.maxRequestBufferSize);
 }
 
+bool
+Server::mayBufferMoreRequestBytes() const
+{
+    // TODO: Account for bodyPipe buffering as well.
+    if (inBuf.length() >= Config.maxRequestBufferSize) {
+        debugs(33, 4, "no: " << inBuf.length() << '-' << Config.maxRequestBufferSize << '=' << (inBuf.length() - Config.maxRequestBufferSize));
+        return false;
+    }
+    debugs(33, 7, "yes: " << Config.maxRequestBufferSize << '-' << inBuf.length() << '=' << (Config.maxRequestBufferSize - inBuf.length()));
+    return true;
+}
+
 void
 Server::readSomeData()
 {
     if (reading())
         return;
 
-    debugs(33, 4, clientConnection << ": reading request...");
-
-    // we can only read if there is more than 1 byte of space free
-    if (Config.maxRequestBufferSize - inBuf.length() < 2)
+    if (!mayBufferMoreRequestBytes())
         return;
 
     typedef CommCbMemFunT<Server, CommIoCbParams> Dialer;
@@ -125,7 +134,16 @@ Server::doClientRead(const CommIoCbParams &io)
      * Plus, it breaks our lame *HalfClosed() detection
      */
 
+    // mayBufferMoreRequestBytes() was true during readSomeData(), but variables
+    // like Config.maxRequestBufferSize may have changed since that check
+    if (!mayBufferMoreRequestBytes()) {
+        // XXX: If we avoid Comm::ReadNow(), we should not Comm::Read() again
+        // when the wait is over; resume these doClientRead() checks instead.
+        return; // wait for noteMoreBodySpaceAvailable() or a similar inBuf draining event
+    }
     maybeMakeSpaceAvailable();
+    Assure(inBuf.spaceSize());
+
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
     switch (Comm::ReadNow(rd, inBuf)) {

--- a/src/servers/Server.h
+++ b/src/servers/Server.h
@@ -121,6 +121,9 @@ protected:
     /// abort any pending transactions and prevent new ones (by closing)
     virtual void terminateAll(const Error &, const LogTagsErrors &) = 0;
 
+    /// whether client_request_buffer_max_size allows inBuf.length() increase
+    bool mayBufferMoreRequestBytes() const;
+
     void doClientRead(const CommIoCbParams &io);
     void clientWriteDone(const CommIoCbParams &io);
 


### PR DESCRIPTION
After a ReadNow() call, the buffer length must not exceed accumulation
limits (e.g.,  client_request_buffer_max_size). SBuf::reserve() alone
cannot reliably enforce those limits because it does not _decrease_ SBuf
space; various SBuf manipulations may lead to excessive SBuf space. When
filled by ReadNow(), that space exceeds the limit.

This change uses documented CommIoCbParams::size trick to limit how much
Comm::ReadNow() may read, obeying SQUID_TCP_SO_RCVBUF (server-to-Squid)
and client_request_buffer_max_size (client-to-Squid) accumulation limit.
