### PR TITLE
Do not mark successful FTP PUT entries with ENTRY_BAD_LENGTH

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -2272,6 +2272,7 @@ ftpWriteTransferDone(Ftp::Gateway * ftpState)
     }
 
     ftpState->entry->timestampsSet();   /* XXX Is this needed? */
+    ftpState->markParsedVirginReplyAsWhole("ftpWriteTransferDone code 226 or 250");
     ftpSendReply(ftpState);
 }
 


### PR DESCRIPTION
ba3fe8d commit introduced a mechanism allowing to mark complete
responses and treating all other responses as truncated. It missed
one case when the FTP server responds with 226 or 250 code after
completing the upload transfer. The bug affects HTTP PUT requests
using FTP URI scheme.