### PR TITLE
Missing error:transaction-end-before-headers in the second transaction

### DIFF
--- a/src/client_side.h
+++ b/src/client_side.h
@@ -424,12 +424,9 @@ protected:
     /// timeout to use when waiting for the next request
     virtual time_t idleTimeout() const = 0;
 
-    /// There are some unparsed request bytes.
-    /// The stream object either does not exist or already in the pipeline.
-    virtual bool pendingRequestBytes() const = 0;
-
-    /// Remove all buffered unparsed request bytes.
-    virtual void clearPendingRequestBytes() = 0;
+    /// the number of request bytes (received bytes) that we possess but
+    /// have not yet given them to the corresponding master transaction
+    virtual size_t pendingRequestBytes() const = 0;
 
     /// Perform client data lookups that depend on client src-IP.
     /// The PROXY protocol may require some data input first.
@@ -446,8 +443,6 @@ private:
     /* ::Server API */
     void terminateAll(const Error &, const LogTagsErrors &) override;
     bool shouldCloseOnEof() const override;
-
-    void checkLogging();
 
     void parseRequests();
     void clientAfterReadingRequests();
@@ -510,6 +505,8 @@ private:
     /// If set, are propagated to the current and all future master transactions
     /// on the connection.
     NotePairs::Pointer theNotes;
+    /// whether we may need logging bytes of an unparsed request
+    bool mayLogPendingRequest_ = true;
 };
 
 const char *findTrailingHTTPVersion(const char *uriAndHTTPVersion, const char *end = nullptr);

--- a/src/servers/FtpServer.h
+++ b/src/servers/FtpServer.h
@@ -102,8 +102,7 @@ protected:
     int pipelinePrefetchMax() const override;
     bool writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &call) override;
     time_t idleTimeout() const override;
-    bool pendingRequestBytes() const override { return false; } // all FTP request bytes are parsed at once
-    void clearPendingRequestBytes() override { }
+    size_t pendingRequestBytes() const override { return 0; } // all FTP request bytes are parsed at once
 
     /* BodyPipe API */
     void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -387,6 +387,17 @@ Http::One::Server::noteTakeServerConnectionControl(ServerConnectionContext serve
                    server.connection(), server.preReadServerBytes);
 }
 
+size_t
+Http::One::Server::pendingRequestBytes() const
+{
+    size_t bytes = 0;
+    if (parser_ && parser_->needsMoreData())
+        bytes += parser_->messageHeaderSize();
+    if (!inBuf.isEmpty())
+        bytes += inBuf.length();
+    return bytes;
+}
+
 ConnStateData *
 Http::NewServer(const MasterXaction::Pointer &xact)
 {

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -39,8 +39,7 @@ protected:
     int pipelinePrefetchMax() const override;
     time_t idleTimeout() const override;
     void noteTakeServerConnectionControl(ServerConnectionContext) override;
-    bool pendingRequestBytes() const override { return (parser_ && parser_->needsMoreData()) || !inBuf.isEmpty(); }
-    void clearPendingRequestBytes() override { if (parser_ && parser_->needsMoreData()) { parser_->clear(); }; inBuf.clear(); }
+    size_t pendingRequestBytes() const override;
 
     /* BodyPipe API */
     void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;


### PR DESCRIPTION
ConnStateData::checkLogging() logged the error if it noticed some bytes
in inBuf, indicating that there is an unparsed yet request. However, in
some cases, the inBuf indication is wrong because inBuf may become empty
when the partially parsed input stored in the parser itself. For
example, this happens for the second (and subsequent) incomplete
requests, when just the first request line was received.

Also fixed %>st for such incomplete requests. If the request
contained the first line and incomplete header block, %>st
showed only the header block size.


