### PR TITLE
Limit logformat 'current time' %codes to the record formatting time

### DIFF
--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -246,6 +246,14 @@ public:
     /// see ConnStateData::proxyProtocolHeader_
     ProxyProtocol::HeaderPointer proxyProtocolHeader;
 
+    /// the time of the latest accessLogLogTo() call
+    /// use this value as 'current time' while calculating relevant logformat codes
+    MessageTimer::Time formattingTime;
+
+    /// the time of the latest accessLogLogTo() call
+    /// pass this value to Stopwatch::totalAsOf() while calculating relevant logformat codes
+    Stopwatch::Clock::time_point stopwatchFormattingTime;
+
 #if ICAP_CLIENT
     /** \brief This subclass holds log info for ICAP part of request
      *  TODO: Inner class declarations should be moved outside

--- a/src/base/Stopwatch.cc
+++ b/src/base/Stopwatch.cc
@@ -19,11 +19,11 @@ Stopwatch::Stopwatch():
 }
 
 Stopwatch::Clock::duration
-Stopwatch::total() const
+Stopwatch::totalAsOf(const Clock::time_point time) const
 {
     auto result = subtotal_;
     if (running())
-        result += Clock::now() - runStart_;
+        result += time - runStart_;
     return result;
 }
 

--- a/src/base/Stopwatch.h
+++ b/src/base/Stopwatch.h
@@ -43,8 +43,8 @@ public:
     bool ran() const { return resumes_ > 0; }
 
     /// the sum of all measurement period durations (or zero)
-    /// includes the current measurement period, if any
-    Clock::duration total() const;
+    /// includes the current measurement period, if any, up to time
+    Clock::duration totalAsOf(Clock::time_point time) const;
 
     /// (re)starts or continues the current measurement period; each resume()
     /// call must be paired with a dedicated future pause() call

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -421,8 +421,6 @@ ClientHttpRequest::logRequest()
 
     al->cache.highOffset = out.offset;
 
-    tvSub(al->cache.trTime, al->cache.start_time, current_time);
-
     if (request)
         prepareLogWithRequestDetails(request, al);
 

--- a/src/log/FormatHttpdCombined.cc
+++ b/src/log/FormatHttpdCombined.cc
@@ -46,11 +46,13 @@ Log::Format::HttpdCombined(const AccessLogEntry::Pointer &al, Logfile * logfile)
 
     const SBuf method(al->getLogMethod());
 
+    const auto secondsSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(al->formattingTime.time_since_epoch()).count();
+
     logfilePrintf(logfile, "%s %s %s [%s] \"" SQUIDSBUFPH " " SQUIDSBUFPH " %s/%d.%d\" %d %" PRId64 " \"%s\" \"%s\" %s:%s%s",
                   clientip,
                   user_ident ? user_ident : dash_str,
                   user_auth ? user_auth : dash_str,
-                  Time::FormatHttpd(squid_curtime),
+                  Time::FormatHttpd(secondsSinceEpoch),
                   SQUIDSBUFPRINT(method),
                   SQUIDSBUFPRINT(al->url),
                   AnyP::ProtocolType_str[al->http.version.protocol],

--- a/src/log/FormatHttpdCommon.cc
+++ b/src/log/FormatHttpdCommon.cc
@@ -33,11 +33,13 @@ Log::Format::HttpdCommon(const AccessLogEntry::Pointer &al, Logfile * logfile)
 
     const SBuf method(al->getLogMethod());
 
+    const auto secondsSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(al->formattingTime.time_since_epoch()).count();
+
     logfilePrintf(logfile, "%s %s %s [%s] \"" SQUIDSBUFPH " " SQUIDSBUFPH " %s/%d.%d\" %d %" PRId64 " %s:%s%s",
                   clientip,
                   user_ident ? user_ident : dash_str,
                   user_auth ? user_auth : dash_str,
-                  Time::FormatHttpd(squid_curtime),
+                  Time::FormatHttpd(secondsSinceEpoch),
                   SQUIDSBUFPRINT(method),
                   SQUIDSBUFPRINT(al->url),
                   AnyP::ProtocolType_str[al->http.version.protocol],

--- a/src/log/FormatSquidIcap.cc
+++ b/src/log/FormatSquidIcap.cc
@@ -46,9 +46,14 @@ Log::Format::SquidIcap(const AccessLogEntry::Pointer &al, Logfile * logfile)
     if (user && !*user)
         safe_free(user);
 
+    using namespace std::chrono_literals;
+    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(al->formattingTime.time_since_epoch()).count();
+    const auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(al->formattingTime.time_since_epoch());
+    const auto ms = (totalMs % std::chrono::milliseconds(1s)).count();
+
     logfilePrintf(logfile, "%9ld.%03d %6ld %s %s/%03d %" PRId64 " %s %s %s -/%s -\n",
-                  (long int) current_time.tv_sec,
-                  (int) current_time.tv_usec / 1000,
+                  seconds,
+                  static_cast<int>(ms),
                   tvToMsec(al->icap.trTime),
                   client,
                   al->icap.outcome,

--- a/src/log/FormatSquidNative.cc
+++ b/src/log/FormatSquidNative.cc
@@ -49,9 +49,14 @@ Log::Format::SquidNative(const AccessLogEntry::Pointer &al, Logfile * logfile)
 
     const SBuf method(al->getLogMethod());
 
+    using namespace std::chrono_literals;
+    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(al->formattingTime.time_since_epoch()).count();
+    const auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(al->formattingTime.time_since_epoch());
+    const auto ms = (totalMs % std::chrono::milliseconds(1s)).count();
+
     logfilePrintf(logfile, "%9ld.%03d %6ld %s %s/%03d %" PRId64 " " SQUIDSBUFPH " " SQUIDSBUFPH " %s %s%s/%s %s%s",
-                  (long int) current_time.tv_sec,
-                  (int) current_time.tv_usec / 1000,
+                  seconds,
+                  static_cast<int>(ms),
                   tvToMsec(al->cache.trTime),
                   clientip,
                   al->cache.code.c_str(),

--- a/src/log/FormatSquidReferer.cc
+++ b/src/log/FormatSquidReferer.cc
@@ -29,9 +29,14 @@ Log::Format::SquidReferer(const AccessLogEntry::Pointer &al, Logfile *logfile)
 
     const SBuf url = !al->url.isEmpty() ? al->url : ::Format::Dash;
 
+    using namespace std::chrono_literals;
+    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(al->formattingTime.time_since_epoch()).count();
+    const auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(al->formattingTime.time_since_epoch());
+    const auto ms = (totalMs % std::chrono::milliseconds(1s)).count();
+
     logfilePrintf(logfile, "%9ld.%03d %s %s " SQUIDSBUFPH "\n",
-                  (long int) current_time.tv_sec,
-                  (int) current_time.tv_usec / 1000,
+                  seconds,
+                  static_cast<int>(ms),
                   clientip,
                   referer,
                   SQUIDSBUFPRINT(url));

--- a/src/log/FormatSquidUseragent.cc
+++ b/src/log/FormatSquidUseragent.cc
@@ -28,9 +28,11 @@ Log::Format::SquidUserAgent(const AccessLogEntry::Pointer &al, Logfile * logfile
     char clientip[MAX_IPSTRLEN];
     al->getLogClientIp(clientip, MAX_IPSTRLEN);
 
+    const auto secondsSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(al->formattingTime.time_since_epoch()).count();
+
     logfilePrintf(logfile, "%s [%s] \"%s\"\n",
                   clientip,
-                  Time::FormatHttpd(squid_curtime),
+                  Time::FormatHttpd(secondsSinceEpoch),
                   agent);
 }
 


### PR DESCRIPTION
All fields of a single access log record should use the same notion of
"current time" to reduce absurd combinations like %<tt that exceeds %tr
or two different %<tt values. The same idea applies to other contexts
where logformat %codes are expanded and to same-transaction records sent
to multiple access_log destinations.