### PR TITLE
Fix %err_code/%err_detail for some error:transaction-end-before-headers

### DIFF
--- a/src/client_side.h
+++ b/src/client_side.h
@@ -441,6 +441,7 @@ private:
     bool shouldCloseOnEof() const override;
 
     void checkLogging();
+    void checkLeftovers();
 
     void parseRequests();
     void clientAfterReadingRequests();

--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -81,6 +81,7 @@ typedef enum {
     ERR_REQUEST_START_TIMEOUT, // Aborts the connection instead of error page
     ERR_REQUEST_PARSE_TIMEOUT, // Aborts the connection instead of error page
     ERR_RELAY_REMOTE, // Sends server reply instead of error page
+    ERR_STREAM_FAILURE, // No client to send the error page to
 
     /* Cache Manager GUI can install a manager index/home page */
     MGR_INDEX,


### PR DESCRIPTION
These format codes were empty in some situations for the second (and
subsequent) pipeline transactions if something went wrong with the
previous transaction (e.g., client connection was aborted, server
send an incomplete response body, etc.). Now a new ERR_STREAM_FAILURE
error code marks all these cases.