### PR TITLE
Fix CachePeer.cc:101 "!tcp_up" assertion after cache_peer death

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -282,10 +282,8 @@ getFirstUpParent(PeerSelector *ps)
     assert(ps);
     HttpRequest *request = ps->request;
 
-    CachePeer *p = nullptr;
-
     for (const auto &peer: CurrentCachePeers()) {
-        p = peer.get();
+        const auto p = peer.get();
 
         if (!neighborUp(p))
             continue;
@@ -297,7 +295,6 @@ getFirstUpParent(PeerSelector *ps)
             continue;
 
         debugs(15, 3, "returning " << *p);
-
         return p;
     }
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -296,11 +296,13 @@ getFirstUpParent(PeerSelector *ps)
         if (!peerHTTPOkay(p, ps))
             continue;
 
-        break;
+        debugs(15, 3, "returning " << *p);
+
+        return p;
     }
 
-    debugs(15, 3, "returning " << RawPointer(p).orNil());
-    return p;
+    debugs(15, 3, "none found");
+    return nullptr;
 }
 
 CachePeer *


### PR DESCRIPTION
getFirstUpParent() could return a down (or otherwise disqualified)
cache_peer. Broken by 2023 commit 2e24d0b.

Refactored function structure to improve code quality, partially
addressing "use our return/reporting style" TODO in getDefaultParent().