### PR TITLE
Fix Ipc::UdsSender memory leaks

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1152,9 +1152,6 @@ comm_init(void)
 {
     assert(fd_table);
 
-    // make sure the IO pending callback table exists
-    Comm::CallbackTableInit();
-
     /* XXX account fd_table */
     /* Keep a few file descriptors free so that we don't run out of FD's
      * after accepting a client but before it opens a socket or a file.
@@ -1172,8 +1169,6 @@ comm_exit(void)
 {
     delete TheHalfClosed;
     TheHalfClosed = nullptr;
-
-    Comm::CallbackTableDestruct();
 }
 
 #if USE_DELAY_POOLS

--- a/src/comm/IoCallback.cc
+++ b/src/comm/IoCallback.cc
@@ -33,10 +33,12 @@ Comm::CallbackTableInit()
 void
 Comm::CallbackTableDestruct()
 {
-    // release any Comm::Connections being held.
+    // release resources being held
     for (int pos = 0; pos < Squid_MaxFD; ++pos) {
         iocb_table[pos].readcb.conn = nullptr;
         iocb_table[pos].writecb.conn = nullptr;
+        iocb_table[pos].readcb.callback = nullptr;
+        iocb_table[pos].writecb.callback = nullptr;
     }
     safe_free(iocb_table);
 }

--- a/src/comm/IoCallback.cc
+++ b/src/comm/IoCallback.cc
@@ -33,6 +33,7 @@ Comm::CbEntry &
 Comm::ioCallbacks(const int fd)
 {
     static const auto table = CallbackTableInit();
+    assert(fd < Squid_MaxFD);
     return table[fd];
 }
 

--- a/src/comm/IoCallback.cc
+++ b/src/comm/IoCallback.cc
@@ -16,23 +16,32 @@
 #include "fde.h"
 #include "globals.h"
 
-static Comm::CbEntry *
-CallbackTableInit()
+namespace Comm
+{
+
+// XXX: Add API to react to Squid_MaxFD changes.
+/// Creates a new callback table using the current value of Squid_MaxFD.
+/// \sa fde::Init()
+static CbEntry *
+MakeCallbackTable()
 {
     // XXX: convert this to a std::map<> ?
-    const auto iocb_table = static_cast<Comm::CbEntry*>(xcalloc(Squid_MaxFD, sizeof(Comm::CbEntry)));
+    // XXX: Stop bypassing CbEntry-associated constructors! Refactor to use new() instead.
+    const auto iocb_table = static_cast<CbEntry*>(xcalloc(Squid_MaxFD, sizeof(CbEntry)));
     for (int pos = 0; pos < Squid_MaxFD; ++pos) {
         iocb_table[pos].fd = pos;
-        iocb_table[pos].readcb.type = Comm::IOCB_READ;
-        iocb_table[pos].writecb.type = Comm::IOCB_WRITE;
+        iocb_table[pos].readcb.type = IOCB_READ;
+        iocb_table[pos].writecb.type = IOCB_WRITE;
     }
     return iocb_table;
+}
+
 }
 
 Comm::CbEntry &
 Comm::ioCallbacks(const int fd)
 {
-    static const auto table = CallbackTableInit();
+    static const auto table = MakeCallbackTable();
     assert(fd < Squid_MaxFD);
     return table[fd];
 }

--- a/src/comm/IoCallback.h
+++ b/src/comm/IoCallback.h
@@ -72,8 +72,8 @@ public:
 /// Callbacks which might be scheduled in future are stored in fd_table.
 CbEntry &ioCallbacks(int fd);
 
-#define COMMIO_FD_READCB(fd)    (&(Comm::ioCallbacks(fd).readcb))
-#define COMMIO_FD_WRITECB(fd)   (&(Comm::ioCallbacks(fd).writecb))
+#define COMMIO_FD_READCB(fd) (&(Comm::ioCallbacks(fd).readcb))
+#define COMMIO_FD_WRITECB(fd) (&(Comm::ioCallbacks(fd).writecb))
 
 } // namespace Comm
 

--- a/src/comm/IoCallback.h
+++ b/src/comm/IoCallback.h
@@ -58,7 +58,7 @@ private:
     void reset();
 };
 
-/// Entry nodes for the IO callback table: iocb_table
+/// Entry nodes for the IO callback table.
 /// Keyed off the FD which the event applies to.
 class CbEntry
 {
@@ -70,13 +70,10 @@ public:
 
 /// Table of scheduled IO events which have yet to be processed ??
 /// Callbacks which might be scheduled in future are stored in fd_table.
-extern CbEntry *iocb_table;
+CbEntry &ioCallbacks(int fd);
 
-void CallbackTableInit();
-void CallbackTableDestruct();
-
-#define COMMIO_FD_READCB(fd)    (&Comm::iocb_table[(fd)].readcb)
-#define COMMIO_FD_WRITECB(fd)   (&Comm::iocb_table[(fd)].writecb)
+#define COMMIO_FD_READCB(fd)    (&(Comm::ioCallbacks(fd).readcb))
+#define COMMIO_FD_WRITECB(fd)   (&(Comm::ioCallbacks(fd).writecb))
 
 } // namespace Comm
 

--- a/src/comm/Write.cc
+++ b/src/comm/Write.cc
@@ -49,7 +49,7 @@ Comm::Write(const Comm::ConnectionPointer &conn, const char *buf, int size, Asyn
 
 /** Write to FD.
  * This function is used by the lowest level of IO loop which only has access to FD numbers.
- * We have to use the comm iocb_table to map FD numbers to waiting data and Comm::Connections.
+ * We have to use the comm Comm::ioCallbacks() to map FD numbers to waiting data and Comm::Connections.
  * Once the write has been concluded we schedule the waiting call with success/fail results.
  */
 void

--- a/src/comm/Write.cc
+++ b/src/comm/Write.cc
@@ -49,7 +49,7 @@ Comm::Write(const Comm::ConnectionPointer &conn, const char *buf, int size, Asyn
 
 /** Write to FD.
  * This function is used by the lowest level of IO loop which only has access to FD numbers.
- * We have to use the comm Comm::ioCallbacks() to map FD numbers to waiting data and Comm::Connections.
+ * We have to use the Comm::ioCallbacks() to map FD numbers to waiting data and Comm::Connections.
  * Once the write has been concluded we schedule the waiting call with success/fail results.
  */
 void

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -49,9 +49,6 @@ Comm::ConnOpener::ConnOpener(const Comm::ConnectionPointer &, const AsyncCall::P
     void Comm::IoCallback::selectOrQueueWrite() STUB
     void Comm::IoCallback::cancel(const char *) STUB
     void Comm::IoCallback::finish(Comm::Flag, int) STUB
-    Comm::CbEntry *Comm::iocb_table = nullptr;
-void Comm::CallbackTableInit() STUB
-void Comm::CallbackTableDestruct() STUB
 
 #include "comm/Loops.h"
 void Comm::SelectLoopInit(void) STUB


### PR DESCRIPTION
During shutdown, iocb_table global was deleted, but the corresponding
cleanup code ignored some IoCallback members, triggering misleading
memory leak reports from Valgrind.

This change uses NoNewGlobals design to address the above problem, but
this code needs a lot more refactoring to address other old problems
associated with Comm initialization.

    {
       UdsSender-write
       Memcheck:Leak
       ...
       fun:_ZN3Ipc9UdsSender5writeEv
       fun:_ZN3Ipc9UdsSender5startEv
       fun:_ZN14NullaryMemFunTI8AsyncJobE6doDialEv
    }
