### PR TITLE
Optimize AppendTokens() by adding Tokenizer::prefixUntil()

### DIFF
--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -339,10 +339,9 @@ static void
 AppendTokens(NotePairs::Entries &entries, const SBuf &key, const SBuf &val, const CharacterSet &delimiters)
 {
     Parser::Tokenizer tok(val);
-    const auto tokenCharacters = delimiters.complement("non-delimiters");
     do {
         SBuf token;
-        (void)tok.prefix(token, tokenCharacters);
+        (void)tok.prefixUntil(token, delimiters);
         entries.push_back(new NotePairs::Entry(key, token)); // token may be empty
     } while (tok.skipOne(delimiters));
 }

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -76,12 +76,12 @@ Parser::Tokenizer::token(SBuf &returnedToken, const CharacterSet &delimiters)
 }
 
 bool
-Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, const SearchAlgorithm searchAlgorithm, const CharacterSet &charSet)
+Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, const SearchAlgorithm searchAlgorithm, const CharacterSet &chars)
 {
     const auto str = buf_.substr(0, limit);
-    auto prefixLen = (searchAlgorithm == findFirstOf) ? str.findFirstOf(charSet) : str.findFirstNotOf(charSet);
+    auto prefixLen = (searchAlgorithm == findFirstOf) ? str.findFirstOf(chars) : str.findFirstNotOf(chars);
     if (prefixLen == 0) {
-        debugs(24, 8, "empty needle with set=" << charSet.name);
+        debugs(24, 8, "empty needle with set=" << chars.name);
         return false;
     }
     if (prefixLen == SBuf::npos && !str.length()) {

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -78,13 +78,13 @@ Parser::Tokenizer::token(SBuf &returnedToken, const CharacterSet &delimiters)
 bool
 Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, const SearchAlgorithm searchAlgorithm, const CharacterSet &chars)
 {
-    const auto str = buf_.substr(0, limit);
-    auto prefixLen = (searchAlgorithm == findFirstOf) ? str.findFirstOf(chars) : str.findFirstNotOf(chars);
+    const auto limitedBuf = buf_.substr(0, limit);
+    auto prefixLen = (searchAlgorithm == findFirstOf) ? limitedBuf.findFirstOf(chars) : limitedBuf.findFirstNotOf(chars);
     if (prefixLen == 0) {
         debugs(24, 8, "empty needle with set " << chars.name);
         return false;
     }
-    if (prefixLen == SBuf::npos && !str.length()) {
+    if (prefixLen == SBuf::npos && !limitedBuf.length()) {
         debugs(24, 8, "empty haystack with limit " << limit);
         return false;
     }

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -76,10 +76,10 @@ Parser::Tokenizer::token(SBuf &returnedToken, const CharacterSet &delimiters)
 }
 
 bool
-Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, const SearchMethod searchMethod, const CharacterSet &charSet)
+Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, const SearchAlgorithm searchAlgorithm, const CharacterSet &charSet)
 {
     const auto str = buf_.substr(0, limit);
-    auto prefixLen = (str.*searchMethod)(charSet, 0);
+    auto prefixLen = (searchAlgorithm == findFirstOf) ? str.findFirstOf(charSet) : str.findFirstNotOf(charSet);
     if (prefixLen == 0) {
         debugs(24, 8, "empty needle with set=" << charSet.name);
         return false;
@@ -100,7 +100,7 @@ Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, con
 bool
 Parser::Tokenizer::prefix(SBuf &returnedToken, const CharacterSet &tokenChars, const SBuf::size_type limit)
 {
-    return prefix_(returnedToken, limit, &SBuf::findFirstNotOf, tokenChars);
+    return prefix_(returnedToken, limit, findFirstNotOf, tokenChars);
 }
 
 SBuf
@@ -111,7 +111,7 @@ Parser::Tokenizer::prefix(const char *description, const CharacterSet &tokenChar
 
     SBuf result;
 
-    if (!prefix_(result, limit, &SBuf::findFirstNotOf, tokenChars))
+    if (!prefix_(result, limit, findFirstNotOf, tokenChars))
         throw TexcHere(ToSBuf("cannot parse ", description));
 
     if (atEnd())
@@ -123,7 +123,7 @@ Parser::Tokenizer::prefix(const char *description, const CharacterSet &tokenChar
 bool
 Parser::Tokenizer::prefixUntil(SBuf &returnedToken, const CharacterSet &delimiters, SBuf::size_type limit)
 {
-    return prefix_(returnedToken, limit, &SBuf::findFirstOf, delimiters);
+    return prefix_(returnedToken, limit, findFirstOf, delimiters);
 }
 
 bool

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -81,14 +81,14 @@ Parser::Tokenizer::prefix_(SBuf &returnedToken, const CharacterSet &charSet, con
     const auto str = buf_.substr(0,limit);
     auto prefixLen = (csType == csDelimiter) ? str.findFirstOf(charSet) : str.findFirstNotOf(charSet);
     if (prefixLen == 0) {
-        debugs(24, 8, "no prefix for set " << charSet.name);
+        debugs(24, 8, "empty needle with set=" << charSet.name);
         return false;
     }
-    if (prefixLen == SBuf::npos && (atEnd() || limit == 0)) {
-        debugs(24, 8, "insufficient input or zero limit while looking for prefix");
+    if (prefixLen == SBuf::npos && !str.length()) {
+        debugs(24, 8, "empty haystack with limit=" << limit);
         return false;
     }
-    if (prefixLen == SBuf::npos && limit > 0) {
+    if (prefixLen == SBuf::npos) {
         debugs(24, 8, "whole haystack matched");
         prefixLen = limit;
     }

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -76,7 +76,7 @@ Parser::Tokenizer::token(SBuf &returnedToken, const CharacterSet &delimiters)
 }
 
 bool
-Parser::Tokenizer::prefix(SBuf &returnedToken, const CharacterSet &charSet, const SBuf::size_type limit, const CharacterSetType csType)
+Parser::Tokenizer::prefix_(SBuf &returnedToken, const CharacterSet &charSet, const SBuf::size_type limit, const CharacterSetType csType)
 {
     const auto str = buf_.substr(0,limit);
     auto prefixLen = (csType == csDelimiter) ? str.findFirstOf(charSet) : str.findFirstNotOf(charSet);
@@ -100,7 +100,7 @@ Parser::Tokenizer::prefix(SBuf &returnedToken, const CharacterSet &charSet, cons
 bool
 Parser::Tokenizer::prefix(SBuf &returnedToken, const CharacterSet &tokenChars, const SBuf::size_type limit)
 {
-    return prefix(returnedToken, tokenChars, limit, csToken);
+    return prefix_(returnedToken, tokenChars, limit, csToken);
 }
 
 SBuf
@@ -111,7 +111,7 @@ Parser::Tokenizer::prefix(const char *description, const CharacterSet &tokenChar
 
     SBuf result;
 
-    if (!prefix(result, tokenChars, limit, csToken))
+    if (!prefix_(result, tokenChars, limit, csToken))
         throw TexcHere(ToSBuf("cannot parse ", description));
 
     if (atEnd())
@@ -123,7 +123,7 @@ Parser::Tokenizer::prefix(const char *description, const CharacterSet &tokenChar
 bool
 Parser::Tokenizer::prefixUntil(SBuf &returnedToken, const CharacterSet &delimiters, SBuf::size_type limit)
 {
-    return prefix(returnedToken, delimiters, limit, csDelimiter);
+    return prefix_(returnedToken, delimiters, limit, csDelimiter);
 }
 
 bool

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -81,11 +81,11 @@ Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, con
     const auto str = buf_.substr(0, limit);
     auto prefixLen = (searchAlgorithm == findFirstOf) ? str.findFirstOf(chars) : str.findFirstNotOf(chars);
     if (prefixLen == 0) {
-        debugs(24, 8, "empty needle with set=" << chars.name);
+        debugs(24, 8, "empty needle with set " << chars.name);
         return false;
     }
     if (prefixLen == SBuf::npos && !str.length()) {
-        debugs(24, 8, "empty haystack with limit=" << limit);
+        debugs(24, 8, "empty haystack with limit " << limit);
         return false;
     }
     if (prefixLen == SBuf::npos) {

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -76,10 +76,10 @@ Parser::Tokenizer::token(SBuf &returnedToken, const CharacterSet &delimiters)
 }
 
 bool
-Parser::Tokenizer::prefix_(SBuf &returnedToken, const CharacterSet &charSet, const SBuf::size_type limit, const CharacterSetType csType)
+Parser::Tokenizer::prefix_(SBuf &returnedToken, const SBuf::size_type limit, const SearchMethod searchMethod, const CharacterSet &charSet)
 {
-    const auto str = buf_.substr(0,limit);
-    auto prefixLen = (csType == csDelimiter) ? str.findFirstOf(charSet) : str.findFirstNotOf(charSet);
+    const auto str = buf_.substr(0, limit);
+    auto prefixLen = (str.*searchMethod)(charSet, 0);
     if (prefixLen == 0) {
         debugs(24, 8, "empty needle with set=" << charSet.name);
         return false;
@@ -100,7 +100,7 @@ Parser::Tokenizer::prefix_(SBuf &returnedToken, const CharacterSet &charSet, con
 bool
 Parser::Tokenizer::prefix(SBuf &returnedToken, const CharacterSet &tokenChars, const SBuf::size_type limit)
 {
-    return prefix_(returnedToken, tokenChars, limit, csToken);
+    return prefix_(returnedToken, limit, &SBuf::findFirstNotOf, tokenChars);
 }
 
 SBuf
@@ -111,7 +111,7 @@ Parser::Tokenizer::prefix(const char *description, const CharacterSet &tokenChar
 
     SBuf result;
 
-    if (!prefix_(result, tokenChars, limit, csToken))
+    if (!prefix_(result, limit, &SBuf::findFirstNotOf, tokenChars))
         throw TexcHere(ToSBuf("cannot parse ", description));
 
     if (atEnd())
@@ -123,7 +123,7 @@ Parser::Tokenizer::prefix(const char *description, const CharacterSet &tokenChar
 bool
 Parser::Tokenizer::prefixUntil(SBuf &returnedToken, const CharacterSet &delimiters, SBuf::size_type limit)
 {
-    return prefix_(returnedToken, delimiters, limit, csDelimiter);
+    return prefix_(returnedToken, limit, &SBuf::findFirstOf, delimiters);
 }
 
 bool

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -180,6 +180,7 @@ protected:
     /// \param searchAlgorithm specifies how to scan buf_ prefix using the given CharacterSet
     /// \param chars searchAlgorithm parameter -- permitted token or delimiter characters
     bool prefix_(SBuf &returnedToken, SBuf::size_type limit, SearchAlgorithm searchAlgorithm, const CharacterSet &chars);
+
     SBuf consume(const SBuf::size_type n);
     SBuf::size_type success(const SBuf::size_type n);
     SBuf consumeTrailing(const SBuf::size_type n);

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -174,11 +174,11 @@ public:
     int64_t udec64(const char *description, SBuf::size_type limit = SBuf::npos);
 
 protected:
-    enum CharacterSetType { csDelimiter, csToken };
+    using SearchMethod = decltype(&SBuf::findFirstOf);
 
     /// Code shared by prefix() and prefixUntil() methods.
-    /// \param csType determines whether the passed CharacterSet specifies delimiters or allowed token symbols
-    bool prefix_(SBuf &returnedToken, const CharacterSet &, SBuf::size_type limit, CharacterSetType csType);
+    /// \param searchMethod specifies how to scan buf_ prefix using the given CharacterSet
+    bool prefix_(SBuf &returnedToken, SBuf::size_type limit, SearchMethod searchMethod, const CharacterSet &);
     SBuf consume(const SBuf::size_type n);
     SBuf::size_type success(const SBuf::size_type n);
     SBuf consumeTrailing(const SBuf::size_type n);

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -174,11 +174,13 @@ public:
     int64_t udec64(const char *description, SBuf::size_type limit = SBuf::npos);
 
 protected:
-    using SearchMethod = decltype(&SBuf::findFirstOf);
+    /// SBuf searches supported by prefix_()
+    using SearchAlgorithm = enum { findFirstOf, findFirstNotOf };
 
     /// Code shared by prefix() and prefixUntil() methods.
-    /// \param searchMethod specifies how to scan buf_ prefix using the given CharacterSet
-    bool prefix_(SBuf &returnedToken, SBuf::size_type limit, SearchMethod searchMethod, const CharacterSet &);
+    /// \param searchAlgorithm specifies how to scan buf_ prefix using the given CharacterSet
+    /// \param chars searchAlgorithm parameter -- permitted token or delimiter characters
+    bool prefix_(SBuf &returnedToken, SBuf::size_type limit, SearchAlgorithm searchAlgorithm, const CharacterSet &chars);
     SBuf consume(const SBuf::size_type n);
     SBuf::size_type success(const SBuf::size_type n);
     SBuf consumeTrailing(const SBuf::size_type n);

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -70,14 +70,13 @@ public:
      */
     bool prefix(SBuf &returnedToken, const CharacterSet &tokenChars, SBuf::size_type limit = SBuf::npos);
 
-    /** Extracts all sequential non-delimiter characters up to an optional length limit.
-     *
-     *  Note that Tokenizer cannot tell whether the prefix will
-     *  continue when/if more input data becomes available later.
-     *
-     * \retval true one or more characters were found, the sequence (string) is placed in returnedToken
-     * \retval false no characters from the permitted set were found
-     */
+    /// Extracts all sequential non-delimiter characters up to an optional
+    /// length limit. Any subsequent characters are left intact. If no delimiter
+    /// characters were found, and the length limit has not been reached, then
+    /// the prefix may continue when/if more input data becomes available later!
+    ///
+    /// \retval true if one or more permitted characters were found
+    /// \param returnedToken is used to store permitted characters found
     bool prefixUntil(SBuf &returnedToken, const CharacterSet &delimiters, SBuf::size_type limit = SBuf::npos);
 
     /** Extracts all sequential permitted characters up to an optional length limit.

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -70,6 +70,16 @@ public:
      */
     bool prefix(SBuf &returnedToken, const CharacterSet &tokenChars, SBuf::size_type limit = SBuf::npos);
 
+    /** Extracts all sequential non-delimiter characters up to an optional length limit.
+     *
+     *  Note that Tokenizer cannot tell whether the prefix will
+     *  continue when/if more input data becomes available later.
+     *
+     * \retval true one or more characters were found, the sequence (string) is placed in returnedToken
+     * \retval false no characters from the permitted set were found
+     */
+    bool prefixUntil(SBuf &returnedToken, const CharacterSet &delimiters, SBuf::size_type limit = SBuf::npos);
+
     /** Extracts all sequential permitted characters up to an optional length limit.
      * Operates on the trailing end of the buffer.
      *
@@ -164,6 +174,11 @@ public:
     int64_t udec64(const char *description, SBuf::size_type limit = SBuf::npos);
 
 protected:
+    enum CharacterSetType { csDelimiter, csToken };
+
+    /// prefix() implementation
+    /// \param csType determines whether the passed CharacterSet specifies delimiters or allowed token symbols
+    bool prefix(SBuf &returnedToken, const CharacterSet &, SBuf::size_type limit, CharacterSetType csType);
     SBuf consume(const SBuf::size_type n);
     SBuf::size_type success(const SBuf::size_type n);
     SBuf consumeTrailing(const SBuf::size_type n);

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -176,9 +176,9 @@ public:
 protected:
     enum CharacterSetType { csDelimiter, csToken };
 
-    /// prefix() implementation
+    /// Code shared by prefix() and prefixUntil() methods.
     /// \param csType determines whether the passed CharacterSet specifies delimiters or allowed token symbols
-    bool prefix(SBuf &returnedToken, const CharacterSet &, SBuf::size_type limit, CharacterSetType csType);
+    bool prefix_(SBuf &returnedToken, const CharacterSet &, SBuf::size_type limit, CharacterSetType csType);
     SBuf consume(const SBuf::size_type n);
     SBuf::size_type success(const SBuf::size_type n);
     SBuf consumeTrailing(const SBuf::size_type n);


### PR DESCRIPTION
Also simplified complex "empty haystack" and "empty needle" conditions
after naming buf_.substr() return value. Those conditions are mutually
exclusive (in npos cases) but earlier code did not relay that fact well.

No functionality changes expected outside of level-8 debugging messages.
