### PR TITLE
RESPMOD gets stuck with delay pools

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -1216,7 +1216,7 @@ HttpStateData::readReply(const CommIoCbParams &io)
             return; // wait for Client::noteMoreBodySpaceAvailable()
         }
 
-        if (virginBodyDestination && virginBodyDestination->buf().hasContent()) {
+        if (virginBodyDestination && !virginBodyDestination->buf().hasPotentialSpace()) {
             debugs(11, 5, "avoid delayRead() to give adaptation a chance to drain body pipe buffer: " << virginBodyDestination->buf().contentSize());
             return; // wait for Client::noteMoreBodySpaceAvailable()
         }


### PR DESCRIPTION
The transaction gets stuck if a delay pool individual speed is less than
~ 64K. HttpStateData::readReply() starts to wait until ModXact drains
its BodyPipe buffer but this never happens because
Icap::ModXact::virginConsume() returns early with the
"postponing consumption from" message. This does not happen if
the delay pool speed is high enough to fill the entire BodyPipe buffer,
because Icap::ModXact::virginConsume() proceeds to drain the buffer after
checking its "bp.buf().spaceSize() > 2" condition.

HttpStateData::readReply() should postpone reading only if the
BodyPipe buffer is full, instead of checking whether is not empty.