### PR TITLE
Do not treat 2-byte buffer space specially

### DIFF
--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -438,7 +438,7 @@ void Adaptation::Icap::ModXact::virginConsume()
     // Why > 2? HttpState does not use the last bytes in the buffer
     // because Client::delayRead() is arguably broken. See
     // HttpStateData::maybeReadVirginBody for more details.
-    if (wantToPostpone && bp.buf().spaceSize() > 2) {
+    if (wantToPostpone && bp.buf().hasPotentialSpace) {
         // Postponing may increase memory footprint and slow the HTTP side
         // down. Not postponing may increase the number of ICAP errors
         // if the ICAP service fails. We may also use "potential" space to

--- a/src/http.cc
+++ b/src/http.cc
@@ -1698,12 +1698,6 @@ HttpStateData::maybeMakeSpaceAvailable(const size_t maxReadSize)
 {
     // how much we want to read
     const size_t read_size = calcBufferSpaceToReserve(inBuf.spaceSize(), maxReadSize);
-
-    if (read_size < 2) {
-        debugs(11, 7, "will not read up to " << read_size << " into buffer (" << inBuf.length() << "/" << inBuf.spaceSize() << ") from " << serverConnection);
-        return 0;
-    }
-
     // we may need to grow the buffer
     inBuf.reserveSpace(read_size);
     debugs(11, 7, "may read up to " << read_size << " bytes info buffer (" << inBuf.length() << "/" << inBuf.spaceSize() << ") from " << serverConnection);


### PR DESCRIPTION
HttpStateData::maybeMakeSpaceAvailable() did not allow to read if the
buffer space was less than 2 bytes. This behavior was added in 2005
2afaba0 commit in order to compensate for delayAwareRead() inability to
read 1 byte.  Then, in 2007 478cfe9 commit the similar 2-byte limitation
was added into Icap::ModXact::virginConsume() so that both ICAP and
http.cc sharing the body pipe were consistent. Now we can remove
this special treatment for 2-byte buffers, since  in 2012 4dc2b07
commit the underlying delayAwareRead() flaw was fixed.
