### PR TITLE
Convert weak PeerDigest::peer cbdata pointer to a reference

### DIFF
--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -76,14 +76,14 @@ class PeerDigest
     CBDATA_CLASS(PeerDigest);
 
 public:
-    PeerDigest(CachePeer *);
+    PeerDigest(const CachePeer &);
     ~PeerDigest();
 
     /// reacts to digest transfer completion
     /// \prec DigestFetchState stats were finalized (by calling peerDigestFetchSetStats())
     void noteFetchFinished(const DigestFetchState &, const char *outcomeDescription, bool sawError);
 
-    CbcPointer<CachePeer> peer; ///< pointer back to peer structure, argh
+    const CachePeer &peer; ///< the associated cache_peer
     CacheDigest *cd = nullptr;            /**< actual digest structure */
     const SBuf host; ///< copy of peer->host
     const char *req_result = nullptr;     /**< text status of the last request */

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -76,7 +76,7 @@ class PeerDigest
     CBDATA_CLASS(PeerDigest);
 
 public:
-    PeerDigest(const CachePeer &);
+    explicit PeerDigest(const CachePeer &);
     ~PeerDigest();
 
     /// reacts to digest transfer completion

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2073,7 +2073,7 @@ ParseCachePeer(ConfigParser &parser)
 
 #if USE_CACHE_DIGESTS
     if (!p->options.no_digest)
-        p->digest = new PeerDigest(p.get());
+        p->digest = new PeerDigest(*p.get());
 #endif
 
     if (p->secure.encryptTransport)


### PR DESCRIPTION
This improvement became possible after 2024 commit f036532 that confined
PeerDigest lifetime to the associated CachePeer lifetime. Using a
reference instead of a pointer clarifies lifetime guarantees _and_
avoids creating a reference counting loop during the expected migration
from disappearing/weak cbdata pointers to reference-counted CachePeers.
