### PR TITLE
Break reference cycle between CachePeer and PeerPoolMgr

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -55,9 +55,6 @@ CachePeer::~CachePeer()
 
     delete standby.pool;
 
-    // the mgr job will notice that its owner is gone and stop
-    PeerPoolMgr::Checkpoint(standby.mgr, "peer gone");
-
     xfree(domain);
 }
 

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -57,7 +57,7 @@ CachePeers::remove(CachePeer * const peer)
         return storePeer.get() == peer;
     });
     Assure(pos != storage.end());
-    PeerPoolMgr::Cancel(peer->standby.mgr);
+    PeerPoolMgr::Stop(peer->standby.mgr);
     storage.erase(pos);
 }
 

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -26,14 +26,6 @@ CachePeers::~CachePeers()
         remove(storage.front().get());
 }
 
-/// make notifications that the CachePeer is about to be removed
-void
-CachePeers::notifyPeerGone(const CachePeer &peer) const
-{
-    // the mgr job will notice that its owner is gone and stop
-    PeerPoolMgr::Checkpoint(peer.standby.mgr, "peer gone");
-}
-
 CachePeer &
 CachePeers::nextPeerToPing(const size_t pollIndex)
 {
@@ -65,7 +57,7 @@ CachePeers::remove(CachePeer * const peer)
         return storePeer.get() == peer;
     });
     Assure(pos != storage.end());
-    notifyPeerGone(*peer);
+    PeerPoolMgr::Cancel(peer->standby.mgr);
     storage.erase(pos);
 }
 

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -22,9 +22,8 @@
 
 CachePeers::~CachePeers()
 {
-    std::for_each(storage.begin(), storage.end(), [&](const auto &peer) {
-        notifyPeerGone(*peer.get());
-    });
+    while (!storage.empty())
+        remove(storage.front().get());
 }
 
 /// make notifications that the CachePeer is about to be removed

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -45,8 +45,6 @@ public:
     CachePeer &nextPeerToPing(size_t iteration);
 
 private:
-    void notifyPeerGone(const CachePeer &) const;
-
     /// cache_peers in configuration/parsing order
     Storage storage;
 

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -28,9 +28,6 @@ public:
     /// stores a configured cache_peer, becoming responsible for its lifetime
     void absorb(std::unique_ptr<CachePeer> &&);
 
-    /// deletes a previously add()ed CachePeer object
-    void remove(CachePeer *);
-
     /// the number of currently stored (i.e. added and not removed) cache_peers
     auto size() const { return storage.size(); }
 
@@ -38,6 +35,10 @@ public:
     using const_iterator = Storage::const_iterator;
     auto begin() const { return storage.cbegin(); }
     auto end() const { return storage.cend(); }
+
+    /// deletes a previously add()ed CachePeer object
+    /// \returns const_iterator following the removed element or end()
+    const_iterator remove(const_iterator pos);
 
     /// A CachePeer to query next when scanning all peer caches in hope to fetch
     /// a remote cache hit. \sa neighborsUdpPing()

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -17,7 +17,7 @@
 #include <vector>
 
 /// cache_peer configuration storage
-class CachePeers
+class CachePeers final
 {
 public:
     ~CachePeers();

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -28,6 +28,9 @@ public:
     /// stores a configured cache_peer, becoming responsible for its lifetime
     void absorb(std::unique_ptr<CachePeer> &&);
 
+    /// deletes a previously add()ed CachePeer object
+    void remove(CachePeer *);
+
     /// the number of currently stored (i.e. added and not removed) cache_peers
     auto size() const { return storage.size(); }
 
@@ -35,10 +38,6 @@ public:
     using const_iterator = Storage::const_iterator;
     auto begin() const { return storage.cbegin(); }
     auto end() const { return storage.cend(); }
-
-    /// deletes a previously add()ed CachePeer object
-    /// \returns const_iterator following the removed element or end()
-    const_iterator remove(const_iterator pos);
 
     /// A CachePeer to query next when scanning all peer caches in hope to fetch
     /// a remote cache hit. \sa neighborsUdpPing()

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -20,6 +20,8 @@
 class CachePeers
 {
 public:
+    ~CachePeers();
+
     /// owns stored CachePeer objects
     using Storage = std::vector< std::unique_ptr<CachePeer>, PoolingAllocator< std::unique_ptr<CachePeer> > >;
 
@@ -43,6 +45,8 @@ public:
     CachePeer &nextPeerToPing(size_t iteration);
 
 private:
+    void notifyPeerGone(const CachePeer &) const;
+
     /// cache_peers in configuration/parsing order
     Storage storage;
 

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -251,15 +251,15 @@ PeerPoolMgr::Checkpoint(const Pointer &mgr, const char *reason)
 }
 
 void
-PeerPoolMgr::Cancel(const Pointer &mgr)
+PeerPoolMgr::Stop(const Pointer &mgr)
 {
-    if (!mgr.valid()) {
+    if (!mgr) {
         debugs(48, 5, "no mgr");
         return;
     }
 
     CallService(mgr->codeContext, [&] {
-        CallJobHere(48, 5, mgr, AsyncJob, handleStopRequest);
+        CallJobHere(48, 5, mgr, PeerPoolMgr, handleStopRequest);
     });
 }
 

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -251,6 +251,19 @@ PeerPoolMgr::Checkpoint(const Pointer &mgr, const char *reason)
 }
 
 void
+PeerPoolMgr::Cancel(const Pointer &mgr)
+{
+    if (!mgr.valid()) {
+        debugs(48, 5, "no mgr");
+        return;
+    }
+
+    CallService(mgr->codeContext, [&] {
+        CallJobHere(48, 5, mgr, AsyncJob, handleStopRequest);
+    });
+}
+
+void
 PeerPoolMgr::StartManagingIfNeeded(CachePeer &peer)
 {
     if (!peer.standby.mgr && peer.standby.limit) {

--- a/src/PeerPoolMgr.h
+++ b/src/PeerPoolMgr.h
@@ -36,6 +36,9 @@ public:
     /// new mgr jobs.
     static void Checkpoint(const Pointer &mgr, const char *reason);
 
+    /// terminates the existing mgr job (if any)
+    static void Cancel(const Pointer &mgr);
+
     /// Brings peer->standby.mgr in sync with peer->standby.limit configuration,
     /// calling either StartManagingIfNeeded() or Checkpoint().
     static void SyncConfig(CachePeer &);

--- a/src/PeerPoolMgr.h
+++ b/src/PeerPoolMgr.h
@@ -36,12 +36,12 @@ public:
     /// new mgr jobs.
     static void Checkpoint(const Pointer &mgr, const char *reason);
 
-    /// terminates the existing mgr job (if any)
-    static void Cancel(const Pointer &mgr);
-
     /// Brings peer->standby.mgr in sync with peer->standby.limit configuration,
     /// calling either StartManagingIfNeeded() or Checkpoint().
     static void SyncConfig(CachePeer &);
+
+    /// terminates the existing mgr job (if any)
+    static void Stop(const Pointer &mgr);
 
     explicit PeerPoolMgr(CachePeer *aPeer);
     ~PeerPoolMgr() override;


### PR DESCRIPTION
This change helps transition CachePeer storage from disappearing weak to
RefCount pointers that are required for smooth reconfiguration but would
otherwise form a circular reference: `peer->standby.mgr->peer`.
