### PR TITLE
Fix cache_peer standby pool destruction

### DIFF
--- a/include/hash.h
+++ b/include/hash.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_INCLUDE_HASH_H
 #define SQUID_INCLUDE_HASH_H
 
-typedef void HASHFREE(void *);
 typedef int HASHCMP(const void *, const void *);
 typedef unsigned int HASHHASH(const void *, unsigned int);
 
@@ -19,6 +18,8 @@ public:
     void *key;
     hash_link *next;
 };
+
+typedef void HASHFREE(hash_link *);
 
 class hash_table {
 public:

--- a/include/hash.h
+++ b/include/hash.h
@@ -19,7 +19,7 @@ public:
     hash_link *next;
 };
 
-typedef void HASHFREE(hash_link *);
+using HASHFREE = void (hash_link *);
 
 class hash_table {
 public:

--- a/src/auth/digest/file/text_backend.cc
+++ b/src/auth/digest/file/text_backend.cc
@@ -51,9 +51,9 @@ typedef struct _user_data {
 } user_data;
 
 static void
-my_free(void *p)
+my_free(hash_link *p)
 {
-    user_data *u = static_cast<user_data*>(p);
+    auto u = reinterpret_cast<user_data*>(p);
     xfree(u->hash.key);
     xfree(u->passwd);
     xfree(u);

--- a/src/auth/digest/file/text_backend.cc
+++ b/src/auth/digest/file/text_backend.cc
@@ -51,9 +51,9 @@ typedef struct _user_data {
 } user_data;
 
 static void
-my_free(hash_link *p)
+my_free(hash_link *const p)
 {
-    auto u = reinterpret_cast<user_data*>(p);
+    const auto u = reinterpret_cast<user_data*>(p);
     xfree(u->hash.key);
     xfree(u->passwd);
     xfree(u);

--- a/src/auth/digest/file/text_backend.cc
+++ b/src/auth/digest/file/text_backend.cc
@@ -51,7 +51,7 @@ typedef struct _user_data {
 } user_data;
 
 static void
-my_free(hash_link *const p)
+my_free(hash_link * const p)
 {
     const auto u = reinterpret_cast<user_data*>(p);
     xfree(u->hash.key);

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -404,7 +404,7 @@ PconnPool::PconnPool(const char *aDescr, const CbcPointer<PeerPoolMgr> &aMgr):
 }
 
 static void
-DeleteIdleConnList(void *hashItem)
+DeleteIdleConnList(hash_link *hashItem)
 {
     delete static_cast<IdleConnList*>(hashItem);
 }

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -404,7 +404,7 @@ PconnPool::PconnPool(const char *aDescr, const CbcPointer<PeerPoolMgr> &aMgr):
 }
 
 static void
-DeleteIdleConnList(hash_link *hashItem)
+DeleteIdleConnList(hash_link * const hashItem)
 {
     delete static_cast<IdleConnList*>(hashItem);
 }


### PR DESCRIPTION
Squid is likely to crash (e.g., from segmentation fault/SIGSEGV) when
reconfiguring a cache_peer that has standby=N connection pool enabled.

In pconn.cc:

* When storing an idle connection list, a hash_join() call implicitly
  casts an IdleConnList pointer to a hash_link pointer, changing the
  pointer value because IdleConnList's hash_link parent class starts
  after IdleConnList’s vtable.

* When deleting a stored idle connection list, DeleteIdleConnList()
  attempts to restore the original IdleConnList pointer value, but its
  reverse cast (via static_cast) from `void*` preserves the stored
  hash_link pointer value instead (because the compiler only sees
  `void*` and cannot tell that we are casting a hash_link pointer).

Broken since 2016 commit a27fcaed (with red flags missed in followup
commit af834148).

The fix changes hash cleanup callback argument type to prevent similar
future bugs.

The only other HASHFREE user -- src/auth/digest/file/text_backend.cc --
happened to work because its POD types do not deal with virtual tables.
Other hash_join() callers "manually" destroy individual hashed items
after calling hash_remove_link(); they do not call hashFreeItems().