### PR TITLE
Use shared pointers to store configured CachePeer objects

### DIFF
--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -12,6 +12,7 @@
 #include "acl/forward.h"
 #include "base/CbcPointer.h"
 #include "base/forward.h"
+#include "base/RefCount.h"
 #include "configuration/forward.h"
 #include "enums.h"
 #include "http/StatusCode.h"
@@ -26,11 +27,13 @@ class PconnPool;
 class PeerDigest;
 class PeerPoolMgr;
 
-class CachePeer
+class CachePeer : public RefCountable
 {
     CBDATA_CLASS(CachePeer);
 
 public:
+    using Pointer = RefCount<CachePeer>;
+
     explicit CachePeer(const SBuf &address);
     ~CachePeer();
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -27,7 +27,7 @@ class PconnPool;
 class PeerDigest;
 class PeerPoolMgr;
 
-class CachePeer : public RefCountable
+class CachePeer: public RefCountable
 {
     CBDATA_CLASS(CachePeer);
 

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -44,10 +44,10 @@ CachePeers::nextPeerToPing(const size_t pollIndex)
 }
 
 void
-CachePeers::absorb(std::unique_ptr<CachePeer> &&peer)
+CachePeers::add(const KeptCachePeer &peer)
 {
-    const auto &added = storage.emplace_back(std::move(peer));
-    added->index = size();
+    storage.push_back(peer);
+    storage.back()->index = size();
 }
 
 void
@@ -72,12 +72,12 @@ CurrentCachePeers()
 }
 
 void
-AbsorbConfigured(std::unique_ptr<CachePeer> &&peer)
+AddConfigured(const KeptCachePeer &peer)
 {
     if (!Config.peers)
         Config.peers = new CachePeers;
 
-    Config.peers->absorb(std::move(peer));
+    Config.peers->add(peer);
 
     peerClearRRStart();
 }

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -23,7 +23,7 @@
 CachePeers::~CachePeers()
 {
     while (!storage.empty())
-        remove(storage.front().get());
+        remove(storage.front().getRaw());
 }
 
 CachePeer &
@@ -54,7 +54,7 @@ void
 CachePeers::remove(CachePeer * const peer)
 {
     const auto pos = std::find_if(storage.begin(), storage.end(), [&](const auto &storePeer) {
-        return storePeer.get() == peer;
+        return storePeer.getRaw() == peer;
     });
     Assure(pos != storage.end());
     PeerPoolMgr::Stop(peer->standby.mgr);
@@ -136,7 +136,7 @@ Configuration::Component<CachePeers*>::FinishSmoothReconfiguration(SmoothReconfi
 
     for (const auto &p: CurrentCachePeers()) {
         if (p->stale)
-            peersToRemove.push_back(p.get());
+            peersToRemove.push_back(p.getRaw());
     }
 
     while (peersToRemove.size()) {

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -12,6 +12,7 @@
 #include "base/forward.h"
 #include "CachePeer.h"
 #include "mem/PoolingAllocator.h"
+#include "peering.h"
 
 #include <memory>
 #include <vector>
@@ -23,10 +24,11 @@ public:
     ~CachePeers();
 
     /// owns stored CachePeer objects
-    using Storage = std::vector< std::unique_ptr<CachePeer>, PoolingAllocator< std::unique_ptr<CachePeer> > >;
+    using Storage = std::vector<KeptCachePeer, PoolingAllocator<KeptCachePeer> >;
 
-    /// stores a configured cache_peer, becoming responsible for its lifetime
-    void absorb(std::unique_ptr<CachePeer> &&);
+    /// stores a configured cache_peer
+    /// \sa remove()
+    void add(const KeptCachePeer &);
 
     /// deletes a previously add()ed CachePeer object
     void remove(CachePeer *);
@@ -60,14 +62,14 @@ const CachePeers &CurrentCachePeers();
 /// Adds a given configured peer to CurrentCachePeers() collection.
 /// \prec findCachePeerByName() is false for the given peer
 /// \sa DeleteConfigured()
-void AbsorbConfigured(std::unique_ptr<CachePeer> &&);
+void AddConfigured(const KeptCachePeer &);
 
 /// destroys the given peer after removing it from the set of configured peers
 void DeleteConfigured(CachePeer *);
 
 /// Weak pointers to zero or more Config.peers.
 /// Users must specify the selection algorithm and the order of entries.
-using SelectedCachePeers = std::vector< CbcPointer<CachePeer>, PoolingAllocator< CbcPointer<CachePeer> > >;
+using SelectedCachePeers = std::vector<DisappearingCachePeer, PoolingAllocator<DisappearingCachePeer> >;
 
 /// Temporary, local storage of raw pointers to zero or more Config.peers.
 using RawCachePeers = std::vector<CachePeer *, PoolingAllocator<CachePeer*> >;

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -69,7 +69,7 @@ void DeleteConfigured(CachePeer *);
 
 /// Weak pointers to zero or more Config.peers.
 /// Users must specify the selection algorithm and the order of entries.
-using SelectedCachePeers = std::vector<DisappearingCachePeer, PoolingAllocator<DisappearingCachePeer> >;
+using SelectedCachePeers = std::vector< CbcPointer<CachePeer>, PoolingAllocator< CbcPointer<CachePeer> > >;
 
 /// Temporary, local storage of raw pointers to zero or more Config.peers.
 using RawCachePeers = std::vector<CachePeer *, PoolingAllocator<CachePeer*> >;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -425,6 +425,7 @@ squid_SOURCES = \
 	peer_sourcehash.h \
 	peer_userhash.cc \
 	peer_userhash.h \
+	peering.h \
 	protos.h \
 	redirect.cc \
 	redirect.h \

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -298,7 +298,7 @@ void
 PeerPoolMgrsRr::syncConfig()
 {
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
         // On reconfigure, Squid deletes the old config (and old peers in it),
         // so should always be dealing with a brand new configuration.
         assert(!p->standby.mgr);

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -88,9 +88,6 @@ public:
 
     C * getRaw() const { return const_cast<C *>(p_); }
 
-    // XXX: diff reducer, remove
-    C * get() const { return getRaw(); }
-
     bool operator == (const RefCount& p) const {
         return p.p_ == p_;
     }

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -88,6 +88,9 @@ public:
 
     C * getRaw() const { return const_cast<C *>(p_); }
 
+    // XXX: diff reducer, remove
+    C * get() const { return getRaw(); }
+
     bool operator == (const RefCount& p) const {
         return p.p_ == p_;
     }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1789,7 +1789,7 @@ dump_peer(StoreEntry * entry, const char *name, const CachePeers *peers)
     LOCAL_ARRAY(char, xname, 128);
 
     for (const auto &peer: *peers) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
         storeAppendPrintf(entry, "%s %s %s %d %d name=%s",
                           name,
                           p->host,
@@ -2073,7 +2073,7 @@ ParseCachePeer(ConfigParser &parser)
 
 #if USE_CACHE_DIGESTS
     if (!p->options.no_digest)
-        p->digest = new PeerDigest(*p.get());
+        p->digest = new PeerDigest(*p.getRaw());
 #endif
 
     if (p->secure.encryptTransport)

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1867,7 +1867,7 @@ ParseCachePeer(ConfigParser &parser)
 {
     const auto address = parser.token("cache_peer TCP listening address");
 
-    auto p = std::make_unique<CachePeer>(address);
+    const auto p = KeptCachePeer::Make(address);
 
     p->type = parseNeighborType("cache_peer type parameter", parser);
 
@@ -2105,7 +2105,7 @@ parse_peer(CachePeers **peers)
     if (findCachePeerByName(p->name))
         throw TextException("cache_peer specified twice", Here());
 
-    AbsorbConfigured(std::move(p));
+    AddConfigured(p);
 }
 
 static void
@@ -2134,7 +2134,7 @@ Configuration::Component<CachePeers*>::Reconfigure(SmoothReconfiguration &sr, Ca
         PeerPoolMgr::StartManagingIfNeeded(*newPeer);
         peerSelectAdd(sr, *newPeer);
         sr.asyncCall(3, 5, "neighbors_init", NullaryFunDialer(&neighbors_init));
-        AbsorbConfigured(std::move(newPeer));
+        AddConfigured(newPeer);
     }
 }
 

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -67,7 +67,7 @@ carpInit(void)
 
     RawCachePeers rawCarpPeers;
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
 
         if (!p->options.carp)
             continue;

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -1220,7 +1220,7 @@ static CachePeer *
 findUsableParentAtHostname(PeerSelector *ps, const char * const hostname, const HttpRequest &request)
 {
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
         // Both fields should be lowercase, but no code ensures that invariant.
         // TODO: net_db_peer should point to CachePeer instead of its hostname!
         if (strcasecmp(p->host, hostname) != 0)

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -33,6 +33,7 @@
 #include "mgr/Registration.h"
 #include "mime_header.h"
 #include "neighbors.h"
+#include "peering.h"
 #include "PeerSelectState.h"
 #include "sbuf/SBuf.h"
 #include "SquidConfig.h"
@@ -76,7 +77,7 @@ public:
         e->unlock("netdbExchangeDone");
     }
 
-    CbcPointer<CachePeer> p;
+    DisappearingCachePeer p;
     StoreEntry *e = nullptr;
     store_client *sc = nullptr;
     HttpRequestPointer r;

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -104,7 +104,7 @@ whichPeer(const Ip::Address &from)
     for (const auto &p: CurrentCachePeers()) {
         for (j = 0; j < p->n_addresses; ++j) {
             if (from == p->addresses[j] && from.port() == p->icp.port) {
-                return p.get();
+                return p.getRaw();
             }
         }
     }
@@ -269,7 +269,7 @@ neighborsCount(PeerSelector *ps)
     int count = 0;
 
     for (const auto &p: CurrentCachePeers())
-        if (peerWouldBePinged(p.get(), ps))
+        if (peerWouldBePinged(p.getRaw(), ps))
             ++count;
 
     debugs(15, 3, "neighborsCount: " << count);
@@ -284,7 +284,7 @@ getFirstUpParent(PeerSelector *ps)
     HttpRequest *request = ps->request;
 
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
 
         if (!neighborUp(p))
             continue;
@@ -312,7 +312,7 @@ getRoundRobinParent(PeerSelector *ps)
     CachePeer *q = nullptr;
 
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
         if (!p->options.roundrobin)
             continue;
 
@@ -355,7 +355,7 @@ getWeightedRoundRobinParent(PeerSelector *ps)
     int weighted_rtt;
 
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
 
         if (!p->options.weighted_roundrobin)
             continue;
@@ -377,7 +377,7 @@ getWeightedRoundRobinParent(PeerSelector *ps)
             if (!p->options.weighted_roundrobin)
                 continue;
 
-            if (neighborType(p.get(), request->url) != PEER_PARENT)
+            if (neighborType(p.getRaw(), request->url) != PEER_PARENT)
                 continue;
 
             p->rr_count = 0;
@@ -471,7 +471,7 @@ getDefaultParent(PeerSelector *ps)
     HttpRequest *request = ps->request;
 
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
 
         if (neighborType(p, request->url) != PEER_PARENT)
             continue;
@@ -527,7 +527,7 @@ neighbors_init(void)
                 debugs(15, DBG_IMPORTANT, "WARNING: Peer looks like this host." <<
                        Debug::Extra << "Ignoring cache_peer " << *thisPeer);
 
-                peersToRemove.push_back(thisPeer.get());
+                peersToRemove.push_back(thisPeer.getRaw());
                 break; // avoid warning about (and removing) the same CachePeer twice
             }
         }
@@ -1054,7 +1054,7 @@ findCachePeerByName(const char * const name)
 {
     for (const auto &p: CurrentCachePeers()) {
         if (!strcasecmp(name, p->name))
-            return p.get();
+            return p.getRaw();
     }
     return nullptr;
 }
@@ -1182,7 +1182,7 @@ peerDnsRefreshStart()
     const auto savedContext = CodeContext::Current();
     for (const auto &p: CurrentCachePeers()) {
         CodeContext::Reset(p->probeCodeContext);
-        ipcache_nbgethostbyname(p->host, peerDNSConfigure, p.get());
+        ipcache_nbgethostbyname(p->host, peerDNSConfigure, p.getRaw());
     }
     CodeContext::Reset(savedContext);
 
@@ -1518,7 +1518,7 @@ dump_peers(StoreEntry *sentry, CachePeers *peers)
     }
 
     for (const auto &peer: *peers) {
-        const auto e = peer.get();
+        const auto e = peer.getRaw();
         assert(e->host != nullptr);
         storeAppendPrintf(sentry, "\n%-11.11s: %s\n",
                           neighborTypeStr(e),
@@ -1692,7 +1692,7 @@ neighborsHtcpClear(StoreEntry * e, HttpRequest * req, const HttpRequestMethod &m
             continue;
         }
         debugs(15, 3, "neighborsHtcpClear: sending CLR to " << p->in_addr.toUrl(buf, 128));
-        htcpClear(e, req, method, p.get(), reason);
+        htcpClear(e, req, method, p.getRaw(), reason);
     }
 }
 

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -860,7 +860,7 @@ PeerSelector::selectAllParents()
     /* Add all alive parents */
 
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.get();
+        const auto p = peer.getRaw();
         /* XXX: neighbors.c lacks a public interface for enumerating
          * parents to a request so we have to dig some here..
          */

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -58,7 +58,7 @@ peerSourceHashInit(void)
 
     RawCachePeers rawSourceHashPeers;
     for (const auto &p: CurrentCachePeers()) {
-        const auto peer = p.get();
+        const auto peer = p.getRaw();
 
         if (!p->options.sourcehash)
             continue;

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -65,7 +65,7 @@ peerUserHashInit(void)
 
     RawCachePeers rawUserHashPeers;
     for (const auto &p: CurrentCachePeers()) {
-        const auto peer = p.get();
+        const auto peer = p.getRaw();
 
         if (!p->options.userhash)
             continue;

--- a/src/peering.h
+++ b/src/peering.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_PEERING_H
+#define SQUID_SRC_PEERING_H
+
+#include "base/forward.h"
+
+class CachePeer;
+
+using DisappearingCachePeer = CbcPointer<CachePeer>;
+using KeptCachePeer = RefCount<CachePeer>;
+
+#endif /* SQUID_SRC_PEERING_H */
+

--- a/src/peering.h
+++ b/src/peering.h
@@ -12,6 +12,7 @@
 #include "base/forward.h"
 
 class CachePeer;
+class CachePeers;
 
 using DisappearingCachePeer = CbcPointer<CachePeer>;
 using KeptCachePeer = RefCount<CachePeer>;

--- a/src/snmp_agent.cc
+++ b/src/snmp_agent.cc
@@ -198,7 +198,7 @@ snmp_meshPtblFn(variable_list * Var, snint * ErrP)
     for (const auto &peer: CurrentCachePeers()) {
         if (peer->index == index) {
             laddr = peer->in_addr ;
-            p = peer.get();
+            p = peer.getRaw();
             break;
         }
     }


### PR DESCRIPTION
A transaction should continue to use the already selected CachePeer
object across/despite reconfiguration(s). Thus, CachePeer object X
lifetime should be extended to all X-using transactions. Thus, CachePeer
class has to support shared/RefCount pointers.

Several changes are required to fully transition CachePeer users to
shared pointers. This first change converts the primary configuration
storage. We start here because that storage is already controlling
CachePeer objects lifetime. This change preserves that invariant and
should have no effect on Squid functionality (other than some minor
debugging changes).

During this transition (and likely beyond it!), some CachePeer users
will naturally continue to use weak pointers to store CachePeer objects
and use cbdata protections to handle those objects disappearance. This
change names that weak pointer type DisappearingCachePeer and renames
one explicit `CbcPointer<CachePeer>` user that we expect to continue to
use a weak pointer -- netdbExchangeState::p.

For now, we preserve other weak pointer users (both CbcPointer-based and
raw) because we want to use DisappearingCachePeer name as a marker of
_finalized_ pointer type decision _and_ to avoid an explosion of noisy
but trivial code changes converting raw pointers to CbcPointer. We will
followup with dedicated commits converting the remaining stored
CachePeer pointers to either KeptCachePeer or DisappearingCachePeer.
