### PR TITLE
Use shared pointer to store FwdServer::_peer

### DIFF
--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -53,7 +53,7 @@ class FwdServer
     MEMPROXY_CLASS(FwdServer);
 
 public:
-    FwdServer(CachePeer *p, hier_code c) :
+    FwdServer(const KeptCachePeer &p, const hier_code c):
         cachePeer(p),
         code(c),
         next(nullptr)

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -80,11 +80,11 @@ static const char *DirectStr[] = {
 class PeerSelectionDumper
 {
 public:
-    PeerSelectionDumper(const PeerSelector * const aSelector, const CachePeer * const aPeer, const hier_code aCode):
+    PeerSelectionDumper(const PeerSelector * const aSelector, const KeptCachePeer &aPeer, const hier_code aCode):
         selector(aSelector), peer(aPeer), code(aCode) {}
 
     const PeerSelector * const selector; ///< selection parameters
-    const CachePeer * const peer; ///< successful selection info
+    const KeptCachePeer peer; ///< successful selection info
     const hier_code code; ///< selection algorithm
 };
 
@@ -1129,7 +1129,7 @@ PeerSelector::addSelection(CachePeer *peer, const hier_code code)
                                (code == PINNED) : (server->_peer == peer);
         if (duplicate) {
             debugs(44, 3, "skipping " << PeerSelectionDumper(this, peer, code) <<
-                   "; have " << PeerSelectionDumper(this, server->_peer.getRaw(), server->code));
+                   "; have " << PeerSelectionDumper(this, server->_peer, server->code));
             return;
         }
         serversTail = &server->next;

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -31,9 +31,9 @@
 #include "ip/tools.h"
 #include "ipcache.h"
 #include "neighbors.h"
-#include "peering.h"
 #include "peer_sourcehash.h"
 #include "peer_userhash.h"
+#include "peering.h"
 #include "PeerSelectState.h"
 #include "SquidConfig.h"
 #include "Store.h"
@@ -452,7 +452,7 @@ PeerSelector::resolveSelected()
     // convert the list of FwdServer destinations into destinations IP addresses
     if (fs && wantsMoreDestinations()) {
         // send the next one off for DNS lookup.
-        const char *host = fs->_peer ? fs->_peer->host : request->url.host();
+        const auto host = fs->_peer ? fs->_peer->host : request->url.host();
         debugs(44, 2, "Find IP destination for: " << url() << "' via " << host);
         Dns::nbgethostbyname(host, this);
         return;

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -516,7 +516,7 @@ PeerSelector::noteIp(const Ip::Address &ip)
     if (!wantsMoreDestinations())
         return;
 
-    const auto peer = servers->_peer.getRaw();
+    const auto peer = servers->_peer;
 
     // for TPROXY spoofing, we must skip unusable addresses
     if (request->flags.spoofClientIp && !(peer && peer->options.no_tproxy) ) {

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -61,6 +61,7 @@ public:
 
     /// the selected cache_peer destination or nil for an origin server
     KeptCachePeer cachePeer;
+
     hier_code code;
     FwdServer *next;
 };


### PR DESCRIPTION
This data member stores an intermediate peer selection result.
The transaction that initiated the selection must be able to use the
selected cache_peer even if it has been just reconfigured away because
the transaction cannot restart the whole peer selection algorithm
from scratch.

Also made PeerSelectionDumper::peer a shared pointer.