### PR TITLE
New approach for cache_peers smooth reconfiguration

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -137,9 +137,6 @@ CachePeer::update(Configuration::SmoothReconfiguration &sr, const CachePeer &fre
     // preserve `tcp_up` state
     // preserve `reprobe` state
 
-    stale = fresh.stale;
-    Assure(!stale); // update() should be given fresh configurations
-
     // `addresses` changes are handled by peerDNSConfigure() triggered by peerDnsRefreshStart()
     // `n_addresses` changes are handled by peerDNSConfigure() triggered by peerDnsRefreshStart()
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -184,10 +184,6 @@ public:
     /// whether to do another TCP probe after current TCP probes
     bool reprobe = false;
 
-    /// whether the last reconfiguration attempt expects to check our settings
-    /// but has not done so
-    bool stale = false;
-
     Ip::Address addresses[10];
     int n_addresses = 0;
     int rr_count = 0;

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -33,6 +33,10 @@ public:
     /// deletes a previously add()ed CachePeer object
     void remove(CachePeer *);
 
+    /// removes from the storage and returns a CachePeer
+    /// with the given name (if any) or nil
+    KeptCachePeer take(const char *name);
+
     /// the number of currently stored (i.e. added and not removed) cache_peers
     auto size() const { return storage.size(); }
 

--- a/src/configuration/Smooth.cc
+++ b/src/configuration/Smooth.cc
@@ -8,14 +8,20 @@
 
 #include "squid.h"
 #include "cache_cf.h"
+#include "CachePeers.h"
 #include "configuration/Preprocessor.h"
 #include "configuration/Smooth.h"
 #include "debug/Stream.h"
 
 Configuration::SmoothReconfiguration::SmoothReconfiguration(const PreprocessedCfg &aConfig):
-    freshConfig(aConfig)
+    freshConfig(aConfig), oldPeers(nullptr)
 {
     Assure(freshConfig.allowSmoothReconfiguration);
+}
+
+Configuration::SmoothReconfiguration::~SmoothReconfiguration()
+{
+    delete oldPeers;
 }
 
 void

--- a/src/configuration/Smooth.h
+++ b/src/configuration/Smooth.h
@@ -11,6 +11,7 @@
 
 #include "base/AsyncCallList.h"
 #include "configuration/forward.h"
+#include "peering.h"
 
 namespace Configuration {
 
@@ -29,6 +30,7 @@ class SmoothReconfiguration
 {
 public:
     explicit SmoothReconfiguration(const PreprocessedCfg &);
+    ~SmoothReconfiguration();
 
     /// performs all smooth reconfiguration steps
     void run();
@@ -44,6 +46,8 @@ public:
 
     /// configuration we are tasked with interpreting and applying
     const PreprocessedCfg &freshConfig;
+
+    CachePeers *oldPeers;
 
 protected:
     /// Component-specific reconfiguration steps to run before we reconfigure()
@@ -84,6 +88,7 @@ Configuration::SmoothReconfiguration::asyncCall(const int debugSection, const in
     if (!plan_.slowlyFindByName(callName))
         plan_.add(::asyncCall(debugSection, debugLevel, callName, dialer));
 }
+
 
 #endif /* SQUID_SRC_CONFIGURATION_SMOOTH_H */
 


### PR DESCRIPTION
This addresses an XXX by removing the CachePeer::stale flag.  The new
approach uses a temporary CachePeers object for keeping the old
cache_peers and should either forget them (upon successful smooth
reconfiguration) or (TODO) bring them back on a failure.