### PR TITLE
Fix SMP mgr:info "hits as % of" statistics

### DIFF
--- a/src/SquidMath.h
+++ b/src/SquidMath.h
@@ -23,7 +23,13 @@ namespace Math
 
 int intPercent(const int a, const int b);
 int64_t int64Percent(const int64_t a, const int64_t b);
-double doublePercent(const double, const double);
+
+/// A `part/whole` ratio expressed as a fraction of 100 with `double` precision.
+/// \returns `100*part/whole` for non-zero `whole` values
+/// \returns 0 for zero `whole` values
+/// \sa intPercent()
+double doublePercent(double part, double whole);
+
 int intAverage(const int, const int, int, const int);
 double doubleAverage(const double, const double, int, const int);
 

--- a/src/mgr/InfoAction.h
+++ b/src/mgr/InfoAction.h
@@ -46,10 +46,10 @@ public:
     EventRatio request_hit_ratio60;
     EventRatio byte_hit_ratio5;
     EventRatio byte_hit_ratio60;
-    double request_hit_mem_ratio5 = 0.0;
-    double request_hit_mem_ratio60 = 0.0;
-    double request_hit_disk_ratio5 = 0.0;
-    double request_hit_disk_ratio60 = 0.0;
+    EventRatio request_hit_mem_ratio5;
+    EventRatio request_hit_mem_ratio60;
+    EventRatio request_hit_disk_ratio5;
+    EventRatio request_hit_disk_ratio60;
 
     StoreInfoStats store; ///< disk and memory cache statistics
 

--- a/src/mgr/InfoAction.h
+++ b/src/mgr/InfoAction.h
@@ -12,6 +12,7 @@
 #define SQUID_MGR_INFO_ACTION_H
 
 #include "mgr/Action.h"
+#include "stat.h"
 #include "StoreStats.h"
 
 namespace Mgr
@@ -41,8 +42,8 @@ public:
     double avg_icp_messages = 0.0;
     double select_loops = 0.0;
     double avg_loop_time = 0.0;
-    double request_hit_ratio5 = 0.0;
-    double request_hit_ratio60 = 0.0;
+    EventRatio request_hit_ratio5;
+    EventRatio request_hit_ratio60;
     double byte_hit_ratio5 = 0.0;
     double byte_hit_ratio60 = 0.0;
     double request_hit_mem_ratio5 = 0.0;

--- a/src/mgr/InfoAction.h
+++ b/src/mgr/InfoAction.h
@@ -44,8 +44,8 @@ public:
     double avg_loop_time = 0.0;
     EventRatio request_hit_ratio5;
     EventRatio request_hit_ratio60;
-    double byte_hit_ratio5 = 0.0;
-    double byte_hit_ratio60 = 0.0;
+    EventRatio byte_hit_ratio5;
+    EventRatio byte_hit_ratio60;
     double request_hit_mem_ratio5 = 0.0;
     double request_hit_mem_ratio60 = 0.0;
     double request_hit_disk_ratio5 = 0.0;

--- a/src/snmp_agent.cc
+++ b/src/snmp_agent.cc
@@ -596,7 +596,7 @@ snmp_prfProtoFn(variable_list * Var, snint * ErrP)
             break;
 
         case PERF_MEDIAN_BHR:
-            x = statByteHitRatio(minutes);
+            x = statByteHitRatio(minutes).toPercentOr(0);
             break;
 
         case PERF_MEDIAN_HTTP_NH:

--- a/src/snmp_agent.cc
+++ b/src/snmp_agent.cc
@@ -592,11 +592,11 @@ snmp_prfProtoFn(variable_list * Var, snint * ErrP)
             break;
 
         case PERF_MEDIAN_RHR:
-            x = statRequestHitRatio(minutes).toPercentOr(0);
+            x = statRequestHitRatio(minutes).toPercent();
             break;
 
         case PERF_MEDIAN_BHR:
-            x = statByteHitRatio(minutes).toPercentOr(0);
+            x = statByteHitRatio(minutes).toPercent();
             break;
 
         case PERF_MEDIAN_HTTP_NH:

--- a/src/snmp_agent.cc
+++ b/src/snmp_agent.cc
@@ -592,7 +592,7 @@ snmp_prfProtoFn(variable_list * Var, snint * ErrP)
             break;
 
         case PERF_MEDIAN_RHR:
-            x = statRequestHitRatio(minutes);
+            x = statRequestHitRatio(minutes).toPercentOr(0);
             break;
 
         case PERF_MEDIAN_BHR:

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -121,6 +121,10 @@ CBDATA_CLASS_INIT(StatObjectsState);
 extern unsigned int mem_pool_alloc_calls;
 extern unsigned int mem_pool_free_calls;
 
+// TODO: Include last minute stats -- use statCounter instead of CountHist[0].
+/// named counter change during given past minutes
+#define CounterChange(counterName, minutes) (CountHist[0].counterName - CountHist[minutes].counterName)
+
 static void
 statUtilization(StoreEntry * e)
 {
@@ -1708,8 +1712,7 @@ EventRatio
 statRequestHitRatio(int minutes)
 {
     assert(minutes < N_COUNT_HIST);
-    return EventRatio(CountHist[0].client_http.hits - CountHist[minutes].client_http.hits,
-                      CountHist[0].client_http.requests - CountHist[minutes].client_http.requests);
+    return EventRatio(CounterChange(client_http.hits, minutes), CounterChange(client_http.requests, minutes));
 }
 
 double

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1920,6 +1920,6 @@ statGraphDump(StoreEntry * e)
 
 double EventRatio::toPercentOr(const double noEventsValue) const
 {
-    return total_ ? Math::doublePercent(primary_, total_) : noEventsValue;
+    return n_ ? Math::doublePercent(w_, n_) : noEventsValue;
 }
 

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -619,8 +619,8 @@ DumpInfo(Mgr::InfoActionData& stats, StoreEntry* sentry)
     storeAppendPrintf(sentry, "Cache information for %s:\n",APP_SHORTNAME);
 
     storeAppendPrintf(sentry, "\tHits as %% of all requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
-                      stats.request_hit_ratio5 / fct,
-                      stats.request_hit_ratio60 / fct);
+                      stats.request_hit_ratio5.toPercentOr(0),
+                      stats.request_hit_ratio60.toPercentOr(0));
 
     storeAppendPrintf(sentry, "\tHits as %% of bytes sent:\t5min: %3.1f%%, 60min: %3.1f%%\n",
                       stats.byte_hit_ratio5 / fct,
@@ -1704,14 +1704,12 @@ statCPUUsage(int minutes)
                                tvSubDsec(CountHist[minutes].timestamp, CountHist[0].timestamp));
 }
 
-double
+EventRatio
 statRequestHitRatio(int minutes)
 {
     assert(minutes < N_COUNT_HIST);
-    return Math::doublePercent(CountHist[0].client_http.hits -
-                               CountHist[minutes].client_http.hits,
-                               CountHist[0].client_http.requests -
-                               CountHist[minutes].client_http.requests);
+    return EventRatio(CountHist[0].client_http.hits - CountHist[minutes].client_http.hits,
+                      CountHist[0].client_http.requests - CountHist[minutes].client_http.requests);
 }
 
 double

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -623,20 +623,20 @@ DumpInfo(Mgr::InfoActionData& stats, StoreEntry* sentry)
     storeAppendPrintf(sentry, "Cache information for %s:\n",APP_SHORTNAME);
 
     storeAppendPrintf(sentry, "\tHits as %% of all requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
-                      stats.request_hit_ratio5.toPercentOr(0),
-                      stats.request_hit_ratio60.toPercentOr(0));
+                      stats.request_hit_ratio5.toPercent(),
+                      stats.request_hit_ratio60.toPercent());
 
     storeAppendPrintf(sentry, "\tHits as %% of bytes sent:\t5min: %3.1f%%, 60min: %3.1f%%\n",
-                      stats.byte_hit_ratio5.toPercentOr(0),
-                      stats.byte_hit_ratio60.toPercentOr(0));
+                      stats.byte_hit_ratio5.toPercent(),
+                      stats.byte_hit_ratio60.toPercent());
 
     storeAppendPrintf(sentry, "\tMemory hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
-                      stats.request_hit_mem_ratio5.toPercentOr(0),
-                      stats.request_hit_mem_ratio60.toPercentOr(0));
+                      stats.request_hit_mem_ratio5.toPercent(),
+                      stats.request_hit_mem_ratio60.toPercent());
 
     storeAppendPrintf(sentry, "\tDisk hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
-                      stats.request_hit_disk_ratio5.toPercentOr(0),
-                      stats.request_hit_disk_ratio60.toPercentOr(0));
+                      stats.request_hit_disk_ratio5.toPercent(),
+                      stats.request_hit_disk_ratio60.toPercent());
 
     storeAppendPrintf(sentry, "\tStorage Swap size:\t%.0f KB\n",
                       stats.store.swap.size / 1024);
@@ -1918,8 +1918,8 @@ statGraphDump(StoreEntry * e)
 
 /* EventRatio */
 
-double EventRatio::toPercentOr(const double noEventsValue) const
+double EventRatio::toPercent() const
 {
-    return n_ ? Math::doublePercent(w_, n_) : noEventsValue;
+    return Math::doublePercent(w_, n_);
 }
 

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -631,12 +631,12 @@ DumpInfo(Mgr::InfoActionData& stats, StoreEntry* sentry)
                       stats.byte_hit_ratio60.toPercentOr(0));
 
     storeAppendPrintf(sentry, "\tMemory hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
-                      stats.request_hit_mem_ratio5 / fct,
-                      stats.request_hit_mem_ratio60 / fct);
+                      stats.request_hit_mem_ratio5.toPercentOr(0),
+                      stats.request_hit_mem_ratio60.toPercentOr(0));
 
     storeAppendPrintf(sentry, "\tDisk hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
-                      stats.request_hit_disk_ratio5 / fct,
-                      stats.request_hit_disk_ratio60 / fct);
+                      stats.request_hit_disk_ratio5.toPercentOr(0),
+                      stats.request_hit_disk_ratio60.toPercentOr(0));
 
     storeAppendPrintf(sentry, "\tStorage Swap size:\t%.0f KB\n",
                       stats.store.swap.size / 1024);
@@ -1715,24 +1715,18 @@ statRequestHitRatio(int minutes)
     return EventRatio(CounterChange(client_http.hits, minutes), CounterChange(client_http.requests, minutes));
 }
 
-double
+EventRatio
 statRequestHitMemoryRatio(int minutes)
 {
     assert(minutes < N_COUNT_HIST);
-    return Math::doublePercent(CountHist[0].client_http.mem_hits -
-                               CountHist[minutes].client_http.mem_hits,
-                               CountHist[0].client_http.hits -
-                               CountHist[minutes].client_http.hits);
+    return EventRatio(CounterChange(client_http.mem_hits, minutes), CounterChange(client_http.hits, minutes));
 }
 
-double
+EventRatio
 statRequestHitDiskRatio(int minutes)
 {
     assert(minutes < N_COUNT_HIST);
-    return Math::doublePercent(CountHist[0].client_http.disk_hits -
-                               CountHist[minutes].client_http.disk_hits,
-                               CountHist[0].client_http.hits -
-                               CountHist[minutes].client_http.hits);
+    return EventRatio(CounterChange(client_http.disk_hits, minutes), CounterChange(client_http.hits, minutes));
 }
 
 EventRatio

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1916,3 +1916,10 @@ statGraphDump(StoreEntry * e)
 
 #endif /* STAT_GRAPHS */
 
+/* EventRatio */
+
+double EventRatio::toPercentOr(const double noEventsValue) const
+{
+    return total_ ? Math::doublePercent(primary_, total_) : noEventsValue;
+}
+

--- a/src/stat.h
+++ b/src/stat.h
@@ -38,21 +38,25 @@ public:
     /// \param w is the cumulative weight of n events
     EventRatio(const Value w, const Value n): w_(n), n_(w) {}
 
-    /// Average event weight expressed as a percentage of N. Suitable for event
-    /// probabilities (e.g., hit ratio is a probability of a hit event).
+    inline EventRatio &operator +=(const EventRatio &);
+
+    /// Average event weight expressed as a percentage of N. Handy for reporting
+    /// event probabilities (e.g., hit ratio is a probability of a hit event).
+    ///
     /// \returns 100*W/N for non-zero N
     /// \returns noEventsValue for zero N
     double toPercentOr(double noEventsValue) const;
 
-// XXX private:
+private:
     /// A total weight of n_ events. May be negative. Unused for zero n_.
     Value w_ = 0;
+
     /// A total number of events. May be zero. Never negative.
     Value n_ = 0;
 };
 
 inline EventRatio &
-operator +=(EventRatio &r1, const EventRatio &r2)
+EventRatio::operator +=(const EventRatio &r2)
 {
     // To correctly add two EventRatio objects, we give the object with a higher
     // N proportionally more weight:
@@ -62,12 +66,12 @@ operator +=(EventRatio &r1, const EventRatio &r2)
     // p1 + p2 = 1
     //
     // Basic arithmetic results in a simple "tops and bottoms" addition that
-    // correctly handles cases where one or both Ns are zeros (among others!).
-    //
+    // correctly handles cases where one or both Ns are zeros (among others!):
     // p1*(r1.w/r1.n) + p2*(r2.w/r2.n) = (r1.w + r2.w) / (r1.n + r2.n)
-    r1.w_ += r2.w_;
-    r1.n_ += r2.n_;
-    return r1;
+    w_ += r2.w_;
+    n_ += r2.n_;
+
+    return *this;
 }
 
 void statInit(void);

--- a/src/stat.h
+++ b/src/stat.h
@@ -63,8 +63,8 @@ void pconnHistCount(int, int);
 int stat5minClientRequests(void);
 double stat5minCPUUsage(void);
 EventRatio statRequestHitRatio(int minutes);
-double statRequestHitMemoryRatio(int minutes);
-double statRequestHitDiskRatio(int minutes);
+EventRatio statRequestHitMemoryRatio(int minutes);
+EventRatio statRequestHitDiskRatio(int minutes);
 EventRatio statByteHitRatio(int minutes);
 
 class StatCounters;

--- a/src/stat.h
+++ b/src/stat.h
@@ -11,50 +11,67 @@
 #ifndef SQUID_STAT_H_
 #define SQUID_STAT_H_
 
-// TODO: Rephrase to support negative tops (and bottoms?) as in byte hit ratios.
-/// Maintains totals for events that are divided into two mutually exclusive
-/// categories (e.g., cache hits/misses or busy/idle time). One of the two
-/// categories is treated as "primary" for the purposes of computing event
-/// ratios (e.g., hit ratio or busy time percentage). Each event is associated
-/// with an integer "value" or "weight".
+// Maintains an "average event weight" statistics with support for aggregating
+// W/N statistics received from multiple sources (e.g., SMP kids). Each source
+// supplies the total number of events (N) and the total weight of those N
+// events (W). The notion of "event" and "weight" is user-defined. For example:
+// * Mean response time: N is the number of transactions, and W is the sum of
+//   those transaction response times.
+// * [Document] hit ratio: N is the number of client requests, and W is the
+//   number of cache hits across those N requests.
+// * Byte hit ratio: N is the number of response bytes sent to the client, and W
+//   is the difference between N and the number of bytes received from servers.
+//   That difference may be negative due to, say, client aborts and supplemental
+//   transactions that receive bytes from servers but send nothing to clients.
 class EventRatio
 {
 public:
+    /// Underlying type for storing N and (possibly negative) W values. Does not
+    /// overflow when recording stats from long-running busy Squid instances and
+    /// when aggregating stats from multiple SMP kids. TODO: Use int64_t?
     using Value = double;
 
     /// no events have been observed (e.g., hit ratio after zero requests)
     EventRatio() = default;
 
-    /// \param primary is the cumulative weight of events in primary category
-    /// \param total is the cumulative weight of events in all categories
-    EventRatio(const Value primary, const Value total): primary_(primary), total_(total) {}
+    /// \param n is the total number of events
+    /// \param w is the cumulative weight of n events
+    EventRatio(const Value w, const Value n): w_(n), n_(w) {}
 
     // TODO: Check whether this can be removed.
     /// whether any events have been observed, allowing this ratio to be
     /// accurately represented by a single non-negative number
-    explicit operator bool() const { return bool(total_); }
+    explicit operator bool() const { return bool(n_); }
 
-    /// represents primary value as a percentage of the total
-    /// \returns 100*primary/total for non-zero totals
-    /// \returns noEventsValue for zero totals
+    /// Average event weight expressed as a percentage of N. Suitable for event
+    /// probabilities (e.g., hit ratio is a probability of a hit event).
+    /// \returns 100*W/N for non-zero N
+    /// \returns noEventsValue for zero N
     double toPercentOr(double noEventsValue) const;
 
 // XXX private:
-    Value primary_ = 0;
-    Value total_ = 0;
+    /// A total weight of n_ events. May be negative. Unused for zero n_.
+    Value w_ = 0;
+    /// A total number of events. May be zero. Never negative.
+    Value n_ = 0;
 };
 
 inline EventRatio &
 operator +=(EventRatio &r1, const EventRatio &r2)
 {
-    // "Tops and bottoms" addition. The usual fractions addition does not work
-    // for event ratios. For example, if both workers received only hits, then
-    // an SMP Squid instance document hit ratio is 100% rather than 200% that
-    // adding n/n and m/m fractions would have yielded. Similarly, dividing
-    // the usual fractions sum by the number of fractions yields wrong ratios:
-    // (1000/1000 + 1/10)/2 = 55% compared to ~99% actual instance hit ratio.
-    r1.primary_ += r2.primary_;
-    r1.total_ += r2.total_;
+    // To correctly add two EventRatio objects, we give the object with a higher
+    // N proportionally more weight:
+    //
+    // p1 = r1.n/(r1.n+r2.n) -- r1's proportional contribution coefficient
+    // p2 = r2.n/(r2.n+r2.n) -- r2's proportional contribution coefficient
+    // p1 + p2 = 1
+    //
+    // Basic arithmetic results in a simple "tops and bottoms" addition that
+    // correctly handles cases where one or both Ns are zeros (among others!).
+    //
+    // p1*(r1.w/r1.n) + p2*(r2.w/r2.n) = (r1.w + r2.w) / (r1.n + r2.n)
+    r1.w_ += r2.w_;
+    r1.n_ += r2.n_;
     return r1;
 }
 

--- a/src/stat.h
+++ b/src/stat.h
@@ -34,9 +34,10 @@ public:
     /// accurately represented by a single non-negative number
     explicit operator bool() const { return bool(total_); }
 
+    /// represents primary value as a percentage of the total
     /// \returns 100*primary/total for non-zero totals
     /// \returns noEventsValue for zero totals
-    double toPercentOr(double noEventsValue) const { return total_ ? (100.0*primary_)/total_ : noEventsValue; }
+    double toPercentOr(double noEventsValue) const;
 
 // XXX private:
     Value primary_ = 0;

--- a/src/stat.h
+++ b/src/stat.h
@@ -11,6 +11,7 @@
 #ifndef SQUID_STAT_H_
 #define SQUID_STAT_H_
 
+// TODO: Rephrase to support negative tops (and bottoms?) as in byte hit ratios.
 /// Maintains totals for events that are divided into two mutually exclusive
 /// categories (e.g., cache hits/misses or busy/idle time). One of the two
 /// categories is treated as "primary" for the purposes of computing event
@@ -19,24 +20,27 @@
 class EventRatio
 {
 public:
+    using Value = double;
+
     /// no events have been observed (e.g., hit ratio after zero requests)
     EventRatio() = default;
 
     /// \param primary is the cumulative weight of events in primary category
     /// \param total is the cumulative weight of events in all categories
-    EventRatio(uint64_t primary, uint64_t total): primary_(primary), total_(total) {}
+    EventRatio(const Value primary, const Value total): primary_(primary), total_(total) {}
 
+    // TODO: Check whether this can be removed.
     /// whether any events have been observed, allowing this ratio to be
     /// accurately represented by a single non-negative number
-    explicit operator bool() const { return total_ != 0; }
+    explicit operator bool() const { return bool(total_); }
 
     /// \returns 100*primary/total for non-zero totals
     /// \returns noEventsValue for zero totals
     double toPercentOr(double noEventsValue) const { return total_ ? (100.0*primary_)/total_ : noEventsValue; }
 
 // XXX private:
-    uint64_t primary_ = 0;
-    uint64_t total_ = 0;
+    Value primary_ = 0;
+    Value total_ = 0;
 };
 
 inline EventRatio &
@@ -61,7 +65,7 @@ double stat5minCPUUsage(void);
 EventRatio statRequestHitRatio(int minutes);
 double statRequestHitMemoryRatio(int minutes);
 double statRequestHitDiskRatio(int minutes);
-double statByteHitRatio(int minutes);
+EventRatio statByteHitRatio(int minutes);
 
 class StatCounters;
 StatCounters *snmpStatGet(int);

--- a/src/stat.h
+++ b/src/stat.h
@@ -11,12 +11,54 @@
 #ifndef SQUID_STAT_H_
 #define SQUID_STAT_H_
 
+/// Maintains totals for events that are divided into two mutually exclusive
+/// categories (e.g., cache hits/misses or busy/idle time). One of the two
+/// categories is treated as "primary" for the purposes of computing event
+/// ratios (e.g., hit ratio or busy time percentage). Each event is associated
+/// with an integer "value" or "weight".
+class EventRatio
+{
+public:
+    /// no events have been observed (e.g., hit ratio after zero requests)
+    EventRatio() = default;
+
+    /// \param primary is the cumulative weight of events in primary category
+    /// \param total is the cumulative weight of events in all categories
+    EventRatio(uint64_t primary, uint64_t total): primary_(primary), total_(total) {}
+
+    /// whether any events have been observed, allowing this ratio to be
+    /// accurately represented by a single non-negative number
+    explicit operator bool() const { return total_ != 0; }
+
+    /// \returns 100*primary/total for non-zero totals
+    /// \returns noEventsValue for zero totals
+    double toPercentOr(double noEventsValue) const { return total_ ? (100.0*primary_)/total_ : noEventsValue; }
+
+// XXX private:
+    uint64_t primary_ = 0;
+    uint64_t total_ = 0;
+};
+
+inline EventRatio &
+operator +=(EventRatio &r1, const EventRatio &r2)
+{
+    // "Tops and bottoms" addition. The usual fractions addition does not work
+    // for event ratios. For example, if both workers received only hits, then
+    // an SMP Squid instance document hit ratio is 100% rather than 200% that
+    // adding n/n and m/m fractions would have yielded. Similarly, dividing
+    // the usual fractions sum by the number of fractions yields wrong ratios:
+    // (1000/1000 + 1/10)/2 = 55% compared to ~99% actual instance hit ratio.
+    r1.primary_ += r2.primary_;
+    r1.total_ += r2.total_;
+    return r1;
+}
+
 void statInit(void);
 double median_svc_get(int, int);
 void pconnHistCount(int, int);
 int stat5minClientRequests(void);
 double stat5minCPUUsage(void);
-double statRequestHitRatio(int minutes);
+EventRatio statRequestHitRatio(int minutes);
 double statRequestHitMemoryRatio(int minutes);
 double statRequestHitDiskRatio(int minutes);
 double statByteHitRatio(int minutes);

--- a/src/stat.h
+++ b/src/stat.h
@@ -38,11 +38,6 @@ public:
     /// \param w is the cumulative weight of n events
     EventRatio(const Value w, const Value n): w_(n), n_(w) {}
 
-    // TODO: Check whether this can be removed.
-    /// whether any events have been observed, allowing this ratio to be
-    /// accurately represented by a single non-negative number
-    explicit operator bool() const { return bool(n_); }
-
     /// Average event weight expressed as a percentage of N. Suitable for event
     /// probabilities (e.g., hit ratio is a probability of a hit event).
     /// \returns 100*W/N for non-zero N

--- a/src/stat.h
+++ b/src/stat.h
@@ -42,10 +42,8 @@ public:
 
     /// Average event weight expressed as a percentage of N. Handy for reporting
     /// event probabilities (e.g., hit ratio is a probability of a hit event).
-    ///
-    /// \returns 100*W/N for non-zero N
-    /// \returns noEventsValue for zero N
-    double toPercentOr(double noEventsValue) const;
+    /// \returns Math::doublePercent(W, N), including cases where N is zero.
+    double toPercent() const;
 
 private:
     /// A total weight of n_ events. May be negative. Unused for zero n_.

--- a/src/stat.h
+++ b/src/stat.h
@@ -34,9 +34,9 @@ public:
     /// no events have been observed (e.g., hit ratio after zero requests)
     EventRatio() = default;
 
+    /// \param w is the cumulative weight of events
     /// \param n is the total number of events
-    /// \param w is the cumulative weight of n events
-    EventRatio(const Value w, const Value n): w_(n), n_(w) {}
+    EventRatio(const Value w, const Value n): w_(w), n_(n) {}
 
     inline EventRatio &operator +=(const EventRatio &);
 


### PR DESCRIPTION
The following SMP `mgr:info` stats were fixed:

* `Hits as % of all requests`
* `Hits as % of bytes sent`
* `Memory hits as % of hit requests`
* `Disk hits as % of hit requests`

SMP Squid incorrectly aggregated cache hit statistics, reporting
arithmetic mean across individual percentages computed by workers and
diskers. For example, after receiving one request that happened to be a
hit, a Squid instance with two workers and one disker may report 33% hit
ratio ((100% + 0% + 0%) / 3) instead of reporting 100% actual hit ratio.

Converting stats extracting code from returning computed percentages to
returning actual hits/requests ratios allows stats aggregation code to
compute correct aggregated ratios and removes "divide by the number of
reports" correction hacks from stats reporting code (i.e. DumpInfo()).

When nothing was sent to clients but some bytes were received from
servers, "Hits as % of bytes sent" were reported as `-0.0%`. They are
now reported without the minus sign (just like all other
impossible-to-compute percentages in this context): `0.0%`.

TODO: SNMP code has not been fixed, and its cacheRequestHitRatio.*
objects still suffer from the same problem. Solution candidates include:

1. Send EventRatio objects as SNMP objects; compute at the last mile.
2. Serialize an EventRatio object into two integer variables, smuggle
   those two integer variables to aggregation code, and then reconstruct
   EventRatio objects and compute the correct ratio at the last mile.
3. Use hit and request counters to compute the ratio at the last mile
   (statCounter.client_http.hits and statCounter.client_http.requests).

TODO: A few other stats are affected by SMP aggregation problems,
especially in environments with uneven kids load and kid restarts.

### Alternative solutions

The following alternative fix was considered: Instead of representing
various A/B ratios using a dedicated C++ class that knows how to add
them up correctly, we could send raw A and B integers, aggregate these
integer values as usual/independently, and then compute A/B ratio (using
aggregated values) to show the admin. In many cases, A and/or B
measurements are already collected!

That alternative was rejected (for now): Some of the ratios are based on
more than two numbers (e.g., statByteHitRatio() uses cd.kbytes_recv,
client_http.kbytes_out, and server.all.kbytes_in). We would have to add
those fields to InfoActionData, once for 5- and once for 60-minute
aggregates. That is a lot of fields duplication!

If we go down that path, then we may want to replace most InfoActionData
"computed" fields with their raw sources like statCounter, CountHist[0],
and CountHist[60] instead. That is a much bigger change! It would be
tempting to take one more step then, moving these large raw stats into
shared memory to fix aggregation of median response times and other
complex stats while keeping IPC/UDS message sizes small!

We may come back to these alternatives. The ultimate question here is
probably whether complex stats calculation algorithms belong to the
stats generation/production code or stats rendering/sending code. Since
there are many ways to render the same underlying data, the "rendering
code" answer may be the right one.