### PR TITLE
Do not duplicate received Surrogate-Capability in sent requests

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -1954,7 +1954,8 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
 #else
         snprintf(bbuf, BBUF_SZ, "%s=\"Surrogate/1.0\"", Config.Accel.surrogate_id);
 #endif
-        strListAdd(&strSurrogate, bbuf, ',');
+        if (strSurrogate.find(bbuf) == String::npos)
+            strListAdd(&strSurrogate, bbuf, ',');
         hdr_out->putStr(Http::HdrType::SURROGATE_CAPABILITY, strSurrogate.termedBuf());
     }
 
@@ -2300,10 +2301,12 @@ copyOneHeaderFromClientsideRequestToUpstreamRequest(const HttpHeaderEntry *e, co
             hdr_out->addEntry(e->clone());
         break;
 
+    case Http::HdrType::SURROGATE_CAPABILITY:
+
     case Http::HdrType::X_FORWARDED_FOR:
 
     case Http::HdrType::CACHE_CONTROL:
-        /** \par X-Forwarded-For:, Cache-Control:
+        /** \par X-Forwarded-For:, Cache-Control:, Surrogate-Capability:
          * handled specially by Squid, so leave off for now.
          * append these after the loop if needed */
         break;

--- a/src/http.cc
+++ b/src/http.cc
@@ -1954,8 +1954,8 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
 #else
         snprintf(bbuf, BBUF_SZ, "%s=\"Surrogate/1.0\"", Config.Accel.surrogate_id);
 #endif
-        if (strSurrogate.find(bbuf) == String::npos)
-            strListAdd(&strSurrogate, bbuf, ',');
+        strListAdd(&strSurrogate, bbuf, ',');
+        hdr_out->delById(Http::HdrType::SURROGATE_CAPABILITY);
         hdr_out->putStr(Http::HdrType::SURROGATE_CAPABILITY, strSurrogate.termedBuf());
     }
 
@@ -2301,12 +2301,10 @@ copyOneHeaderFromClientsideRequestToUpstreamRequest(const HttpHeaderEntry *e, co
             hdr_out->addEntry(e->clone());
         break;
 
-    case Http::HdrType::SURROGATE_CAPABILITY:
-
     case Http::HdrType::X_FORWARDED_FOR:
 
     case Http::HdrType::CACHE_CONTROL:
-        /** \par X-Forwarded-For:, Cache-Control:, Surrogate-Capability:
+        /** \par X-Forwarded-For:, Cache-Control:
          * handled specially by Squid, so leave off for now.
          * append these after the loop if needed */
         break;


### PR DESCRIPTION
When computing Surrogate-Capability header while forwarding an
accelerated request, Squid duplicated old (i.e. received) header entries
(if any). For example, this outgoing request shows an extra hop1 entry:

    GET / HTTP/1.1
    ...
    Surrogate-Capability: hop1="Surrogate/1.0"
    Surrogate-Capability: hop1="Surrogate/1.0", hop2="Surrogate/1.0"
