### PR TITLE
Close idle pooled connections to disappeared cache_peers

### DIFF
--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -60,7 +60,7 @@ CachePeers::remove(CachePeer * const peer)
     });
     Assure(pos != storage.end());
     PeerPoolMgr::Stop(peer->standby.mgr);
-    fwdPconnPool->closeToPeer(peer);
+    fwdPconnPool->closeAllTo(peer);
     storage.erase(pos);
 }
 

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -11,7 +11,9 @@
 #include "CachePeers.h"
 #include "ConfigOption.h"
 #include "configuration/Smooth.h"
+#include "FwdState.h"
 #include "neighbors.h"
+#include "pconn.h"
 #include "PeerPoolMgr.h"
 #include "PeerSelectState.h"
 #include "SquidConfig.h"
@@ -58,6 +60,7 @@ CachePeers::remove(CachePeer * const peer)
     });
     Assure(pos != storage.end());
     PeerPoolMgr::Stop(peer->standby.mgr);
+    fwdPconnPool->closeWithPeer(peer);
     storage.erase(pos);
 }
 

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -60,7 +60,7 @@ CachePeers::remove(CachePeer * const peer)
     });
     Assure(pos != storage.end());
     PeerPoolMgr::Stop(peer->standby.mgr);
-    fwdPconnPool->closeWithPeer(peer);
+    fwdPconnPool->closeToPeer(peer);
     storage.erase(pos);
 }
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4091,8 +4091,12 @@ DOC_START
 	* Changing cache_peer name from A to B means removing old cache_peer named
 	  A and adding a brand new cache_peer named B: Squid pairs old and new
 	  cache_peer directives using cache_peer name (which defaults to
-	  cache_peer hostname). To update an existing cache_peer, use its old name
-	  and, if there was no explicit name, the old hostname specs.
+	  cache_peer hostname). Note that cache_peer A removal may represent
+	  a significant overhead due to instant closing of all idle persistent
+	  connections to A. Also the removal may hurt ongoing transactions that have
+	  selected A but have not obtained a persistent connection to it yet.
+	  To update an existing cache_peer, use its old name and, if there was
+	  no explicit name, the old hostname specs.
 
 	* Changing cache_peer hostname is not yet supported.
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4091,21 +4091,21 @@ DOC_START
 	* Changing cache_peer name from A to B means removing old cache_peer named
 	  A and adding a brand new cache_peer named B: Squid pairs old and new
 	  cache_peer directives using cache_peer name (which defaults to
-	  cache_peer hostname). Note that cache_peer A removal may represent
-	  a significant overhead due to instant closing of all idle persistent
-	  connections to A. Also the removal may hurt ongoing transactions that have
-	  selected A but have not obtained a persistent connection to it yet.
-	  To update an existing cache_peer, use its old name and, if there was
-	  no explicit name, the old hostname specs.
+	  cache_peer hostname). To update an existing cache_peer, use its old name
+	  and, if there was no explicit name, the old hostname specs.
+
+	* When a cache_peer is removed, Squid closes all idle persistent HTTP(S)
+	  connections to that peer. The associated performance overheads depend on
+	  many factors. In some tests, Squid blocked for about one millisecond to
+	  close 100 idle connections.  Connections closure also slows down any
+	  ongoing transactions that have selected the being-removed cache_peer but
+	  have not obtained a connection to it yet.
 
 	* Changing cache_peer hostname is not yet supported.
 
 	* Changing many of the cache_peer options (e.g., `originserver` and
 	  `carp-key`) is not yet supported, but not diagnostic is given for some
 	  of the ignored changes. Changing TLS-related options is supported.
-
-	* Changing cache_peer options does not close any idle persistent
-	  connections to that peer (yet?).
 
 For general details about smooth reconfiguration, see documentation for
 the "reconfiguration" directive.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4094,10 +4094,10 @@ DOC_START
 	  cache_peer hostname). To update an existing cache_peer, use its old name
 	  and, if there was no explicit name, the old hostname specs.
 
-	* Removing a cache_peer closes all idle persistent HTTP(S) connections to
-	  that peer. The associated performance overheads depend on many factors.
-	  In some tests, Squid blocked for about one millisecond to close 100 idle
-	  connections.  Connections closure also slows down any ongoing
+	* Removing a cache_peer closes all idle persistent and standby connections
+	  to that peer. The associated performance overheads depend on many
+	  factors. In some tests, Squid blocked for about one millisecond to close
+	  100 idle connections.  Connections closure also slows down any ongoing
 	  transactions that have selected the being-removed cache_peer but have
 	  not obtained a connection to it yet.
 
@@ -4110,8 +4110,8 @@ DOC_START
 	  `carp-key`) is not yet supported, but not diagnostic is given for some
 	  of the ignored changes. Changing TLS-related options is supported.
 
-	* Changing cache_peer options does not close any affected idle persistent
-	  or pinned connections to that peer (yet?).
+	* Changing cache_peer options does not close any affected idle persistent,
+	  standby, or pinned connections to that peer (yet?).
 
 For general details about smooth reconfiguration, see documentation for
 the "reconfiguration" directive.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4094,18 +4094,24 @@ DOC_START
 	  cache_peer hostname). To update an existing cache_peer, use its old name
 	  and, if there was no explicit name, the old hostname specs.
 
-	* When a cache_peer is removed, Squid closes all idle persistent HTTP(S)
-	  connections to that peer. The associated performance overheads depend on
-	  many factors. In some tests, Squid blocked for about one millisecond to
-	  close 100 idle connections.  Connections closure also slows down any
-	  ongoing transactions that have selected the being-removed cache_peer but
-	  have not obtained a connection to it yet.
+	* Removing a cache_peer closes all idle persistent HTTP(S) connections to
+	  that peer. The associated performance overheads depend on many factors.
+	  In some tests, Squid blocked for about one millisecond to close 100 idle
+	  connections.  Connections closure also slows down any ongoing
+	  transactions that have selected the being-removed cache_peer but have
+	  not obtained a connection to it yet.
+
+	* Removing a cache_peer does not close idle connections pinned to that
+	  cache_peer (yet).
 
 	* Changing cache_peer hostname is not yet supported.
 
 	* Changing many of the cache_peer options (e.g., `originserver` and
 	  `carp-key`) is not yet supported, but not diagnostic is given for some
 	  of the ignored changes. Changing TLS-related options is supported.
+
+	* Changing cache_peer options does not close any affected idle persistent
+	  or pinned connections to that peer (yet?).
 
 For general details about smooth reconfiguration, see documentation for
 the "reconfiguration" directive.

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -566,10 +566,9 @@ PconnPool::closeN(int n)
 void
 PconnPool::closeAllTo(const CachePeer * const peer)
 {
-    auto hid = table;
-    hash_first(hid);
+    hash_first(table);
     debugs(48, 3, "open connections: " << count());
-    for (auto current = hash_next(hid); current; current = hash_next(hid)) {
+    for (auto current = hash_next(table); current; current = hash_next(table)) {
         // may delete current but preserves hash iterator (i.e. hid->next) that hash_next() has advanced already
         static_cast<IdleConnList *>(current)->closeAllTo(peer);
     }

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -566,8 +566,8 @@ PconnPool::closeN(int n)
 void
 PconnPool::closeAllTo(const CachePeer * const peer)
 {
-    hash_first(table);
     debugs(48, 3, "open connections: " << count());
+    hash_first(table);
     for (auto current = hash_next(table); current; current = hash_next(table)) {
         // may delete current but preserves hash iterator (i.e. table->next) that hash_next() has advanced already
         static_cast<IdleConnList *>(current)->closeAllTo(peer);

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -302,16 +302,12 @@ IdleConnList::closeAllTo(const CachePeer * const p)
         const auto i = right - 1;
         const auto conn = theList_[i];
 
-        if (!Comm::IsConnOpen(conn))
-            continue;
-
-        if (conn->getPeer() != p)
-            continue;
-
-        clearHandlers(conn);
-        /* might delete this */
-        removeAt(i);
-        conn->close();
+        if (conn->getPeer() == p) {
+            clearHandlers(conn);
+            // may delete this
+            removeAt(i);
+            conn->close();
+        }
     }
 }
 
@@ -573,9 +569,9 @@ PconnPool::closeAllTo(const CachePeer * const peer)
     auto hid = table;
     hash_first(hid);
     debugs(48, 3, "open connections: " << count());
-    for (auto walker = hash_next(hid); walker; walker = hash_next(hid)) {
-        // may delete walker
-        static_cast<IdleConnList*>(walker)->closeAllTo(peer);
+    for (auto current = hash_next(hid); current; current = hash_next(hid)) {
+        // may delete current but preserves hash iterator (i.e. hid->next) that hash_next() has advanced already
+        static_cast<IdleConnList *>(current)->closeAllTo(peer);
     }
 }
 

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -11,7 +11,6 @@
 #include "squid.h"
 #include "base/IoManip.h"
 #include "base/PackableStream.h"
-#include "base/Stopwatch.h"
 #include "CachePeer.h"
 #include "comm.h"
 #include "comm/Connection.h"
@@ -585,14 +584,10 @@ PconnPool::closeToPeer(const CachePeer * const peer)
     auto hid = table;
     hash_first(hid);
     debugs(48, 3, "open connections: " << count());
-    Stopwatch timer;
-    timer.resume();
     for (auto walker = hash_next(hid); walker; walker = hash_next(hid)) {
         // may delete walker
         static_cast<IdleConnList*>(walker)->closeAllTo(peer);
     }
-    const auto delay = std::chrono::duration_cast<std::chrono::microseconds>(timer.total());
-    debugs(48, 3, "duration: " <<  delay.count());
 }
 
 void

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -569,7 +569,7 @@ PconnPool::closeAllTo(const CachePeer * const peer)
     hash_first(table);
     debugs(48, 3, "open connections: " << count());
     for (auto current = hash_next(table); current; current = hash_next(table)) {
-        // may delete current but preserves hash iterator (i.e. hid->next) that hash_next() has advanced already
+        // may delete current but preserves hash iterator (i.e. table->next) that hash_next() has advanced already
         static_cast<IdleConnList *>(current)->closeAllTo(peer);
     }
 }

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -57,14 +57,14 @@ public:
      */
     Comm::ConnectionPointer findUseable(const Comm::ConnectionPointer &key);
 
-    /// close all direct connections (if peer is nil) or
-    /// close all connections to the given cache_peer (otherwise)
-    void closeAllTo(const CachePeer *peer);
-
     void clearHandlers(const Comm::ConnectionPointer &conn);
 
     // TODO: Upgrade to return size_t
     int count() const { return size_; }
+
+    /// close all direct connections (if the given peer is nil) or
+    /// close all connections to the given cache_peer (otherwise)
+    void closeAllTo(const CachePeer *);
 
     void closeN(size_t count);
 
@@ -143,10 +143,12 @@ public:
     void dump(std::ostream &) const;
     void unlinkList(IdleConnList *list);
     void noteUses(int uses);
+
+    /// \copydoc IdleConnList::closeAllTo()
+    void closeAllTo(const CachePeer *);
+
     /// closes any n connections, regardless of their destination
     void closeN(int n);
-    /// \copydoc IdleConnList::closeAllTo()
-    void closeAllTo(const CachePeer *peer);
     int count() const { return theCount; }
     void noteConnectionAdded() { ++theCount; }
     void noteConnectionRemoved() { assert(theCount > 0); --theCount; }

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -57,7 +57,8 @@ public:
      */
     Comm::ConnectionPointer findUseable(const Comm::ConnectionPointer &key);
 
-    /// close all connections to peer
+    /// close all direct connections (if peer is nil) or
+    /// close all connections to the given cache_peer (otherwise)
     void closeAllTo(const CachePeer *peer);
 
     void clearHandlers(const Comm::ConnectionPointer &conn);
@@ -72,7 +73,6 @@ public:
 private:
     bool isAvailable(int i) const;
     bool removeAt(size_t index);
-    void closeAt(size_t index);
     int findIndexOf(const Comm::ConnectionPointer &conn) const;
     void findAndClose(const Comm::ConnectionPointer &conn);
     static IOCB Read;
@@ -145,8 +145,8 @@ public:
     void noteUses(int uses);
     /// closes any n connections, regardless of their destination
     void closeN(int n);
-    /// closes all connections to peer
-    void closeToPeer(const CachePeer *peer);
+    /// \copydoc IdleConnList::closeAllTo()
+    void closeAllTo(const CachePeer *peer);
     int count() const { return theCount; }
     void noteConnectionAdded() { ++theCount; }
     void noteConnectionRemoved() { assert(theCount > 0); --theCount; }

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -57,6 +57,8 @@ public:
      */
     Comm::ConnectionPointer findUseable(const Comm::ConnectionPointer &key);
 
+    void closeAllWith(const CachePeer *);
+
     void clearHandlers(const Comm::ConnectionPointer &conn);
 
     // TODO: Upgrade to return size_t
@@ -69,6 +71,7 @@ public:
 private:
     bool isAvailable(int i) const;
     bool removeAt(size_t index);
+    void closeAt(size_t index);
     int findIndexOf(const Comm::ConnectionPointer &conn) const;
     void findAndClose(const Comm::ConnectionPointer &conn);
     static IOCB Read;
@@ -141,6 +144,7 @@ public:
     void noteUses(int uses);
     /// closes any n connections, regardless of their destination
     void closeN(int n);
+    void closeWithPeer(const CachePeer *);
     int count() const { return theCount; }
     void noteConnectionAdded() { ++theCount; }
     void noteConnectionRemoved() { assert(theCount > 0); --theCount; }

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -57,7 +57,8 @@ public:
      */
     Comm::ConnectionPointer findUseable(const Comm::ConnectionPointer &key);
 
-    void closeAllWith(const CachePeer *);
+    /// close all connections to peer
+    void closeAllTo(const CachePeer *peer);
 
     void clearHandlers(const Comm::ConnectionPointer &conn);
 
@@ -144,7 +145,8 @@ public:
     void noteUses(int uses);
     /// closes any n connections, regardless of their destination
     void closeN(int n);
-    void closeWithPeer(const CachePeer *);
+    /// closes all connections to peer
+    void closeToPeer(const CachePeer *peer);
     int count() const { return theCount; }
     void noteConnectionAdded() { ++theCount; }
     void noteConnectionRemoved() { assert(theCount > 0); --theCount; }


### PR DESCRIPTION
Squid now closes such idle connections after reconfiguration and similar
events leading to cache_peer directive removal performed by
`CachePeers::remove()` call. Though immediate closing of many cache_peer
idle connections may introduce some overhead, it is better to free
resources immediately instead of relying on `server_idle_pconn_timeout`.
