### PR TITLE
DelayId boolean conversion should account for cache_peer no-delay

### DIFF
--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -60,7 +60,7 @@ DelayId::operator == (DelayId const &rhs) const
 
 DelayId::operator bool() const
 {
-    return pool_ || compositeId.getRaw();
+    return (pool_ || compositeId.getRaw()) && !markedAsNoDelay;
 }
 
 /* create a delay Id for a given request */
@@ -127,7 +127,7 @@ DelayId::bytesWanted(int minimum, int maximum) const
 {
     /* unlimited */
 
-    if (! (*this) || markedAsNoDelay)
+    if (!(*this))
         return max(minimum, maximum);
 
     /* limited */
@@ -148,9 +148,6 @@ void
 DelayId::bytesIn(int qty)
 {
     if (! (*this))
-        return;
-
-    if (markedAsNoDelay)
         return;
 
     assert ((unsigned short)(pool() - 1) != 0xFFFF);

--- a/src/DelayId.h
+++ b/src/DelayId.h
@@ -31,6 +31,9 @@ public:
     DelayIdComposite::Pointer const compositePosition() const;
     void compositePosition(const DelayIdComposite::Pointer &);
     bool operator == (DelayId const &rhs) const;
+
+    /// whether we may limit reading (i.e. return zero from bytesWanted()
+    /// with a positive maximum limit)
     operator bool() const;
     int bytesWanted(int min, int max) const;
     void bytesIn (int qty);


### PR DESCRIPTION
Without this check the callers could incorrectly limit reading from a
cache_peer that has been configured to ignore delay pools. Luckily all 3
DelayId::bool() callers also checked the markedAsNoDelay flag and did
not suffer from this problem:
    
* DelayId::bytesWanted() and DelayId::bytesIn() check markedAsNoDelay
directly.
    
* Both MemObject::delayRead() callers check markedAsNoDelay indirectly
(via DelayId::bytesWanted()) and do not call this method if
markedAsNoDelay is true.