### PR TITLE
Simplify Ipc::Strand::handleRegistrationResponse()

### DIFF
--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -119,15 +119,8 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 void
 Ipc::Strand::handleRegistrationResponse(const StrandMessage &msg)
 {
-    // handle registration response from the coordinator; it could be stale
-    if (msg.strand.kidId == KidIdentifier && msg.strand.pid == getpid()) {
-        debugs(54, 6, "kid" << KidIdentifier << " registered");
-        clearTimeout(); // we are done
-    } else {
-        // could be an ACK to the registration message of our dead predecessor
-        debugs(54, 6, "kid" << KidIdentifier << " is not yet registered");
-        // keep listening, with a timeout
-    }
+    debugs(54, 6, "kid" << KidIdentifier << " registered");
+    clearTimeout(); // we are done
 }
 
 void Ipc::Strand::handleCacheMgrRequest(const Mgr::Request& request)


### PR DESCRIPTION
The method's check for stale responses became unnecessary after
4c21861 commit that added Mine() guarantee that the message is fresh.