### PR TITLE
CI failure after removing CONTRIBUTOR entry

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -29,6 +29,8 @@ env:
   # empty except for pull_request events
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
+  GH_TOKEN: ${{ github.token }}
+
   # Full clones of Squid repository branches (depth=19000+) waste resources,
   # while excessively shallow clones break tests that check for past commits
   # (e.g., to skip a particular test until a known bug is fixed) or generate

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -707,11 +707,13 @@ run_ checkMakeNamedErrorDetails || exit 1
 # considered vetted:
 #
 # * authored (in "git log --author" sense) by squidadm,
-# * matching (in "git log --grep" sense) $vettedCommitPhraseRegex set below.
+# * matching (in "git log --grep" sense) $vettedPhraseRegex set below.
 #
 # A human authoring an official GitHub pull request containing a new
 # CONTRIBUTORS version (that they want to be used as a new vetting point)
-# should add a phrase matching $vettedCommitPhraseRegex to the PR description.
+# should add a phrase matching $vettedPhraseRegex to the PR description.
+# Adding a phrase matching $vettedPhraseRegex renders the entire PR branch
+# vetted, i.e., CONTRIBUTORS for such PR branch is not updated.
 #
 # [1] As defined by the --update-contributors-since script parameter.
 collectAuthors ()
@@ -721,13 +723,25 @@ collectAuthors ()
         return 0 # successfully did nothing, as requested
     fi
 
-    vettedCommitPhraseRegex='[Rr]eference point for automated CONTRIBUTORS updates'
+    vettedPhraseRegex='[Rr]eference point for automated CONTRIBUTORS updates'
+
+    vettedByPr=false
+    if test -n "${PULL_REQUEST_NUMBER}"
+    then
+        vettedByPr=`gh pr view $PULL_REQUEST_NUMBER --json body --jq ".body | test(\"${vettedPhraseRegex}\")"`
+    fi
+
+    if test "x$vettedByPr" = xtrue
+    then
+        echo 'successfully vetted by the PR description'
+        return 0
+    fi
 
     since="$UpdateContributorsSince"
     if test "x$UpdateContributorsSince" = xauto
     then
         # find the last CONTRIBUTORS commit vetted by a human
-        humanSha=`git log -n1 --format='%H' --grep="$vettedCommitPhraseRegex" CONTRIBUTORS`
+        humanSha=`git log -n1 --format='%H' --grep="$vettedPhraseRegex" CONTRIBUTORS`
         # find the last CONTRIBUTORS commit attributed to this script
         botSha=`git log -n1 --format='%H' --author=squidadm CONTRIBUTORS`
         if test "x$humanSha" = x && test "x$botSha" = x
@@ -765,7 +779,7 @@ collectAuthors ()
     # add collected new (co-)authors, if any, to CONTRIBUTORS
     ./scripts/update-contributors.pl --quiet < authors.tmp > CONTRIBUTORS.new || return
     updateIfChanged CONTRIBUTORS CONTRIBUTORS.new  \
-        "A human PR description should match: $vettedCommitPhraseRegex" || return
+        "A human PR description should match: $vettedPhraseRegex" || return
 
     rm -f authors.tmp
     return 0


### PR DESCRIPTION
source-maintenance.sh recognizes a magic phrase in the commit message
and treats that commit as authoritative for CONTRIBUTORS file. However
when dealing with PRs, the merge commit that is built has a
GitHub-generated commit message which obviously lacks the magic
phrase.
    
The problem happens when, for example, a user creates a PR and wants to
change their CONTRIBUTORS entry (e.g., from U@foo to U@bar). In this
case GitHub actions start source-maintenance.sh for the merge commit
which adds the old U@foo to CONTRIBUTORS (because the U@foo is the merge
commit author). The build is aborted due to the "modified sources"
error. To avoid this problem, a PR author now can mark the
entire PR as authoritative for CONTRIBUTORS by adding the magic phrase
to the PR description.
