### PR TITLE
 Fix memory leaks when parsing FTP EPLF directory listing

### DIFF
--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -45,6 +45,8 @@ libcompatsquid_la_SOURCES = \
 	memrchr.cc \
 	memrchr.h \
 	mswindows.cc \
+	netdb.cc \
+	netdb.h \
 	os/aix.h \
 	os/android.h \
 	os/dragonfly.h \
@@ -63,8 +65,12 @@ libcompatsquid_la_SOURCES = \
 	os/sunos.h \
 	osdetect.h \
 	pipe.h \
+	select.cc \
+	select.h \
 	shm.cc \
 	shm.h \
+	socket.cc \
+	socket.h \
 	statvfs.cc \
 	statvfs.h \
 	stdio.h \
@@ -72,9 +78,13 @@ libcompatsquid_la_SOURCES = \
 	strtoll.h \
 	tempnam.h \
 	types.h \
+	unistd.cc \
+	unistd.h \
 	valgrind.h \
 	win32_maperror.cc \
 	win32_maperror.h \
+	wserrno.cc \
+	wserrno.h \
 	xalloc.cc \
 	xalloc.h \
 	xis.h \

--- a/compat/mswindows.cc
+++ b/compat/mswindows.cc
@@ -11,6 +11,8 @@
 
 #include "squid.h"
 
+#include "compat/unistd.h"
+
 // The following code section is part of an EXPERIMENTAL native Windows NT/2000 Squid port.
 // Compiles only on MS Visual C++
 // CygWin appears not to need any of these
@@ -156,10 +158,9 @@ WIN32_ftruncate(int fd, off_t size)
 int
 WIN32_truncate(const char *pathname, off_t length)
 {
-    int fd;
     int res = -1;
 
-    fd = open(pathname, O_RDWR);
+    const auto fd = xopen(pathname, O_RDWR);
 
     if (fd == -1)
         errno = EBADF;

--- a/compat/netdb.cc
+++ b/compat/netdb.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
+
+#include "compat/netdb.h"
+#include "compat/wserrno.h"
+
+struct hostent *
+xgethostbyname(const char * const name)
+{
+    const auto result = gethostbyname(name);
+    if (!result)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+struct servent *
+xgetservbyname(const char * const name, const char * const proto)
+{
+    const auto result = getservbyname(name, proto);
+    if (!result)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+#endif /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */

--- a/compat/netdb.h
+++ b/compat/netdb.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_COMPAT_NETDB_H
+#define SQUID_COMPAT_NETDB_H
+
+#if HAVE_NETDB_H
+#include <netdb.h>
+#endif
+
+/// POSIX gethostbyname(3) equivalent
+struct hostent * xgethostbyname(const char * name);
+
+/// POSIX getservbyname(3) equivalent
+struct servent * xgetservbyname(const char * name, const char * proto);
+
+#if !(_SQUID_WINDOWS_ || _SQUID_MINGW_)
+
+inline struct hostent *
+xgethostbyname(const char *name)
+{
+    return gethostbyname(name);
+}
+
+inline struct servent *
+xgetservbyname(const char *name, const char *proto)
+{
+    return getservbyname(name, proto);
+}
+
+#endif /* !(_SQUID_WINDOWS_ || _SQUID_MINGW_) */
+#endif /* SQUID_COMPAT_NETDB_H */

--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -280,10 +280,6 @@ struct timezone {
 
 #include <io.h>
 
-#ifndef _PATH_DEVNULL
-#define _PATH_DEVNULL "NUL"
-#endif
-
 #ifndef EISCONN
 #define EISCONN WSAEISCONN
 #endif
@@ -392,68 +388,9 @@ SQUIDCEXTERN THREADLOCAL int ws32_result;
 
 #if defined(__cplusplus)
 
-inline int
-close(int fd)
-{
-    char l_so_type[sizeof(int)];
-    int l_so_type_siz = sizeof(l_so_type);
-    SOCKET sock = _get_osfhandle(fd);
-
-    if (::getsockopt(sock, SOL_SOCKET, SO_TYPE, l_so_type, &l_so_type_siz) == 0) {
-        int result = 0;
-        if (closesocket(sock) == SOCKET_ERROR) {
-            errno = WSAGetLastError();
-            result = 1;
-        }
-        _free_osfhnd(fd);
-        _osfile(fd) = 0;
-        return result;
-    } else
-        return _close(fd);
-}
-
 #if defined(_MSC_VER) /* Microsoft C Compiler ONLY */
 
-#ifndef _S_IREAD
-#define _S_IREAD 0x0100
 #endif
-
-#ifndef _S_IWRITE
-#define _S_IWRITE 0x0080
-#endif
-
-inline int
-open(const char *filename, int oflag, int pmode = 0)
-{
-    return _open(filename, oflag, pmode & (_S_IREAD | _S_IWRITE));
-}
-#endif
-
-inline int
-read(int fd, void * buf, size_t siz)
-{
-    char l_so_type[sizeof(int)];
-    int l_so_type_siz = sizeof(l_so_type);
-    SOCKET sock = _get_osfhandle(fd);
-
-    if (::getsockopt(sock, SOL_SOCKET, SO_TYPE, l_so_type, &l_so_type_siz) == 0)
-        return ::recv(sock, (char FAR *) buf, (int)siz, 0);
-    else
-        return _read(fd, buf, (unsigned int)siz);
-}
-
-inline int
-write(int fd, const void * buf, size_t siz)
-{
-    char l_so_type[sizeof(int)];
-    int l_so_type_siz = sizeof(l_so_type);
-    SOCKET sock = _get_osfhandle(fd);
-
-    if (::getsockopt(sock, SOL_SOCKET, SO_TYPE, l_so_type, &l_so_type_siz) == 0)
-        return ::send(sock, (char FAR *) buf, siz, 0);
-    else
-        return _write(fd, buf, siz);
-}
 
 // stdlib <functional> definitions are required before std API redefinitions.
 #include <functional>
@@ -475,107 +412,6 @@ namespace Squid
  * - map the FD value used by Squid to the socket handes used by Windows.
  */
 
-inline int
-accept(int s, struct sockaddr * a, socklen_t * l)
-{
-    SOCKET result;
-    if ((result = ::accept(_get_osfhandle(s), a, l)) == INVALID_SOCKET) {
-        if (WSAEMFILE == (errno = WSAGetLastError()))
-            errno = EMFILE;
-        return -1;
-    } else
-        return _open_osfhandle(result, 0);
-}
-#define accept(s,a,l) Squid::accept(s,a,reinterpret_cast<socklen_t*>(l))
-
-inline int
-bind(int s, const struct sockaddr * n, socklen_t l)
-{
-    if (::bind(_get_osfhandle(s),n,l) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return 0;
-}
-#define bind(s,n,l) Squid::bind(s,n,l)
-
-inline int
-connect(int s, const struct sockaddr * n, socklen_t l)
-{
-    if (::connect(_get_osfhandle(s),n,l) == SOCKET_ERROR) {
-        if (WSAEMFILE == (errno = WSAGetLastError()))
-            errno = EMFILE;
-        return -1;
-    } else
-        return 0;
-}
-#define connect(s,n,l) Squid::connect(s,n,l)
-
-inline struct hostent *
-gethostbyname(const char *n) {
-    HOSTENT FAR * result;
-    if ((result = ::gethostbyname(n)) == NULL)
-        errno = WSAGetLastError();
-    return result;
-}
-#define gethostbyname(n) Squid::gethostbyname(n)
-
-inline SERVENT FAR *
-getservbyname(const char * n, const char * p)
-{
-    SERVENT FAR * result;
-    if ((result = ::getservbyname(n, p)) == NULL)
-        errno = WSAGetLastError();
-    return result;
-}
-#define getservbyname(n,p) Squid::getservbyname(n,p)
-
-inline HOSTENT FAR *
-gethostbyaddr(const void * a, size_t l, int t)
-{
-    HOSTENT FAR * result;
-    if ((result = ::gethostbyaddr((const char*)a, l, t)) == NULL)
-        errno = WSAGetLastError();
-    return result;
-}
-#define gethostbyaddr(a,l,t) Squid::gethostbyaddr(a,l,t)
-
-inline int
-getsockname(int s, struct sockaddr * n, socklen_t * l)
-{
-    int i=*l;
-    if (::getsockname(_get_osfhandle(s), n, &i) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return 0;
-}
-#define getsockname(s,a,l) Squid::getsockname(s,a,reinterpret_cast<socklen_t*>(l))
-
-inline int
-gethostname(char * n, size_t l)
-{
-    if ((::gethostname(n, l)) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return 0;
-}
-#define gethostname(n,l) Squid::gethostname(n,l)
-
-inline int
-getsockopt(int s, int l, int o, void * v, socklen_t * n)
-{
-    Sleep(1);
-    if ((::getsockopt(_get_osfhandle(s), l, o,(char *) v, n)) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return 0;
-}
-#define getsockopt(s,l,o,v,n) Squid::getsockopt(s,l,o,v,n)
-
-/* Simple ioctl() emulation */
 inline int
 ioctl(int s, int c, void * a)
 {
@@ -599,94 +435,6 @@ ioctlsocket(int s, long c, u_long FAR * a)
 #define ioctlsocket(s,c,a) Squid::ioctlsocket(s,c,a)
 
 inline int
-listen(int s, int b)
-{
-    if (::listen(_get_osfhandle(s), b) == SOCKET_ERROR) {
-        if (WSAEMFILE == (errno = WSAGetLastError()))
-            errno = EMFILE;
-        return -1;
-    } else
-        return 0;
-}
-#define listen(s,b) Squid::listen(s,b)
-
-inline ssize_t
-recv(int s, void * b, size_t l, int f)
-{
-    ssize_t result;
-    if ((result = ::recv(_get_osfhandle(s), (char *)b, l, f)) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return result;
-}
-#define recv(s,b,l,f) Squid::recv(s,b,l,f)
-
-inline ssize_t
-recvfrom(int s, void * b, size_t l, int f, struct sockaddr * fr, socklen_t * fl)
-{
-    ssize_t result;
-    int ifl=*fl;
-    if ((result = ::recvfrom(_get_osfhandle(s), (char *)b, l, f, fr, &ifl)) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return result;
-}
-#define recvfrom(s,b,l,f,r,n) Squid::recvfrom(s,b,l,f,r,reinterpret_cast<socklen_t*>(n))
-
-inline int
-select(int n, fd_set * r, fd_set * w, fd_set * e, struct timeval * t)
-{
-    int result;
-    if ((result = ::select(n,r,w,e,t)) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return result;
-}
-#define select(n,r,w,e,t) Squid::select(n,r,w,e,t)
-
-inline ssize_t
-send(int s, const char * b, size_t l, int f)
-{
-    ssize_t result;
-    if ((result = ::send(_get_osfhandle(s), b, l, f)) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return result;
-}
-#define send(s,b,l,f) Squid::send(s,reinterpret_cast<const char*>(b),l,f)
-
-inline ssize_t
-sendto(int s, const void * b, size_t l, int f, const struct sockaddr * t, socklen_t tl)
-{
-    ssize_t result;
-    if ((result = ::sendto(_get_osfhandle(s), (char *)b, l, f, t, tl)) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return result;
-}
-#define sendto(a,b,l,f,t,n) Squid::sendto(a,b,l,f,t,n)
-
-inline int
-setsockopt(SOCKET s, int l, int o, const void * v, socklen_t n)
-{
-    SOCKET socket;
-
-    socket = ((s == INVALID_SOCKET) ? s : (SOCKET)_get_osfhandle((int)s));
-
-    if (::setsockopt(socket, l, o, (const char *)v, n) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return 0;
-}
-#define setsockopt(s,l,o,v,n) Squid::setsockopt(s,l,o,v,n)
-
-inline int
 shutdown(int s, int h)
 {
     if (::shutdown(_get_osfhandle(s),h) == SOCKET_ERROR) {
@@ -696,30 +444,6 @@ shutdown(int s, int h)
         return 0;
 }
 #define shutdown(s,h) Squid::shutdown(s,h)
-
-inline int
-socket(int f, int t, int p)
-{
-    SOCKET result;
-    if ((result = ::socket(f, t, p)) == INVALID_SOCKET) {
-        if (WSAEMFILE == (errno = WSAGetLastError()))
-            errno = EMFILE;
-        return -1;
-    } else
-        return _open_osfhandle(result, 0);
-}
-#define socket(f,t,p) Squid::socket(f,t,p)
-
-inline int
-WSAAsyncSelect(int s, HWND h, unsigned int w, long e)
-{
-    if (::WSAAsyncSelect(_get_osfhandle(s), h, w, e) == SOCKET_ERROR) {
-        errno = WSAGetLastError();
-        return -1;
-    } else
-        return 0;
-}
-#define WSAAsyncSelect(s,h,w,e) Squid::WSAAsyncSelect(s,h,w,e)
 
 #undef WSADuplicateSocket
 inline int
@@ -758,28 +482,6 @@ WSASocket(int a, int t, int p, LPWSAPROTOCOL_INFO i, GROUP g, DWORD f)
 } /* namespace Squid */
 
 #else /* #ifdef __cplusplus */
-#define connect(s,n,l) \
-    (SOCKET_ERROR == connect(_get_osfhandle(s),n,l) ? \
-    (WSAEMFILE == (errno = WSAGetLastError()) ? errno = EMFILE : -1, -1) : 0)
-#define gethostbyname(n) \
-    (NULL == ((HOSTENT FAR*)(ws32_result = (int)gethostbyname(n))) ? \
-    (errno = WSAGetLastError()), (HOSTENT FAR*)NULL : (HOSTENT FAR*)ws32_result)
-#define gethostname(n,l) \
-    (SOCKET_ERROR == gethostname(n,l) ? \
-    (errno = WSAGetLastError()), -1 : 0)
-#define recv(s,b,l,f) \
-    (SOCKET_ERROR == (ws32_result = recv(_get_osfhandle(s),b,l,f)) ? \
-    (errno = WSAGetLastError()), -1 : ws32_result)
-#define sendto(s,b,l,f,t,tl) \
-    (SOCKET_ERROR == (ws32_result = sendto(_get_osfhandle(s),b,l,f,t,tl)) ? \
-    (errno = WSAGetLastError()), -1 : ws32_result)
-#define select(n,r,w,e,t) \
-    (SOCKET_ERROR == (ws32_result = select(n,r,w,e,t)) ? \
-    (errno = WSAGetLastError()), -1 : ws32_result)
-#define socket(f,t,p) \
-    (INVALID_SOCKET == ((SOCKET)(ws32_result = (int)socket(f,t,p))) ? \
-    ((WSAEMFILE == (errno = WSAGetLastError()) ? errno = EMFILE : -1), -1) : \
-    (SOCKET)_open_osfhandle(ws32_result,0))
 #define write      _write /* Needed in util.c */
 #define open       _open /* Needed in win32lib.c */
 #endif /* #ifdef __cplusplus */

--- a/compat/select.cc
+++ b/compat/select.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "compat/select.h"
+#include "compat/wserrno.h"
+
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
+
+int
+xselect(int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, struct timeval * timeout)
+{
+    const auto result = select(nfds, readfds, writefds, exceptfds, timeout);
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+#endif /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */

--- a/compat/select.h
+++ b/compat/select.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_COMPAT_SELECT_H
+#define SQUID_COMPAT_SELECT_H
+
+#if HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+
+/// POSIX select(2) equivalent
+int xselect(int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, struct timeval * timeout);
+
+#if !(_SQUID_WINDOWS_ || _SQUID_MINGW_)
+
+inline int
+xselect(int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, struct timeval * timeout)
+{
+    return select(nfds, readfds, writefds, exceptfds, timeout);
+}
+
+#endif /* !(_SQUID_WINDOWS_ || _SQUID_MINGW_) */
+
+#endif /* SQUID_COMPAT_SELECT_H */

--- a/compat/socket.cc
+++ b/compat/socket.cc
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "compat/socket.h"
+#include "compat/wserrno.h"
+
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
+#include <unordered_map>
+
+int
+xaccept(int socketFd, struct sockaddr *sa, socklen_t *saLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    int al = 0;
+    int *alp = nullptr;
+    if (saLength) {
+        assert(*saLength <= INT_MAX);
+        al = static_cast<int>(*saLength);
+        alp = &al;
+    }
+    const auto result = accept(handle, sa, alp);
+    if (result == INVALID_SOCKET) {
+        SetErrnoFromWsaError();
+        return SOCKET_ERROR;
+    }
+    const auto rv = _open_osfhandle(result, 0);
+    if (rv == -1)
+        errno = EBADF;
+    if (saLength)
+        *saLength = static_cast<socklen_t>(al);
+    return rv;
+}
+
+int
+xbind(int socketFd, const struct sockaddr *sa, socklen_t saLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    assert(saLength <= INT_MAX);
+    const auto result = bind(handle, sa, static_cast<int>(saLength));
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+int
+xconnect(int socketFd, const struct sockaddr *sa, socklen_t saLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    assert(saLength <= INT_MAX);
+    const auto result = connect(handle, sa, static_cast<int>(saLength));
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+int
+xgetsockname(int socketFd, struct sockaddr * sa, socklen_t * saLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    int al = 0;
+    int *alp = nullptr;
+    if (saLength) {
+        assert(*saLength <= INT_MAX);
+        al = static_cast<int>(*saLength);
+        alp = &al;
+    }
+    const auto result = getsockname(handle, sa, alp);
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    if (saLength)
+        *saLength = static_cast<socklen_t>(al);
+    return result;
+}
+
+int
+xgetsockopt(int socketFd, int level, int optionName, void * optionValue, socklen_t * optionLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    int ol = 0;
+    int *olp = nullptr;
+    if (optionLength) {
+        assert(*optionLength <= INT_MAX);
+        ol = static_cast<int>(*optionLength);
+        olp = &ol;
+    }
+    const auto result = getsockopt(handle, level, optionName, static_cast<char *>(optionValue), olp);
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    if (optionLength)
+        *optionLength = static_cast<socklen_t>(ol);
+    return result;
+}
+
+int
+xlisten(int socketFd, int backlog)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    const auto result = listen(handle, backlog);
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+ssize_t
+xrecv(int socketFd, void * buf, size_t bufLength, int flags)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    assert(bufLength <= INT_MAX);
+    const auto result = recv(handle, static_cast<char *>(buf), static_cast<int>(bufLength), flags);
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+ssize_t
+xrecvfrom(int socketFd, void * buf, size_t bufLength, int flags, struct sockaddr * from, socklen_t * fromLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    assert(bufLength <= INT_MAX);
+    int fl = 0;
+    int *flp = nullptr;
+    if (fromLength) {
+        assert(*fromLength <= INT_MAX);
+        fl = static_cast<int>(*fromLength);
+        flp = &fl;
+    }
+    const auto result = recvfrom(handle, static_cast<char *>(buf), static_cast<int>(bufLength), flags, from, flp);
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    if (fromLength)
+        *fromLength = static_cast<socklen_t>(fl);
+    return result;
+}
+
+ssize_t
+xsend(int socketFd, const void * buf, size_t bufLength, int flags)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    assert(bufLength <= INT_MAX);
+    const auto result = send(handle, static_cast<const char *>(buf), static_cast<int>(bufLength), flags);
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+ssize_t
+xsendto(int socketFd, const void * buf, size_t bufLength, int flags, const struct sockaddr * to, socklen_t toLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    assert(bufLength <= INT_MAX);
+    assert(toLength <= INT_MAX);
+    const auto result = sendto(handle, static_cast<const char *>(buf), static_cast<int>(bufLength), flags, to, static_cast<int>(toLength));
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+int
+xsetsockopt(int socketFd, int level, int option, const void *value, socklen_t valueLength)
+{
+    const auto handle = _get_osfhandle(socketFd);
+    if (!isValidSocketHandle(handle)) {
+        // errno is already set by _get_osfhandle()
+        return SOCKET_ERROR;
+    }
+    assert(option <= INT_MAX);
+    const auto result = setsockopt(handle, level, option, static_cast<const char *>(value), static_cast<int>(valueLength));
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+int
+xsocket(int domain, int type, int protocol)
+{
+    const auto result = socket(domain, type, protocol);
+    if (result == INVALID_SOCKET) {
+        SetErrnoFromWsaError();
+        return SOCKET_ERROR;
+    }
+    const auto rv = _open_osfhandle(result, 0);
+    if (rv == -1)
+        errno = EBADF;
+    return rv;
+}
+
+#endif /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */

--- a/compat/socket.h
+++ b/compat/socket.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_COMPAT_SOCKET_H
+#define SQUID_COMPAT_SOCKET_H
+
+#if HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+
+/// POSIX accept(2) equivalent
+int xaccept(int socketFd, struct sockaddr *sa, socklen_t *saLength);
+
+/// POSIX bind(2) equivalent
+int xbind(int socketFd, const struct sockaddr *sa, socklen_t saLength);
+
+/// POSIX connect(2) equivalent
+int xconnect(int socketFd, const struct sockaddr *sa, socklen_t saLength);
+
+/// POSIX getsockopt(2) equivalent
+int xgetsockopt(int socketFd, int level, int optionName, void * optionValue, socklen_t * optionLength);
+
+/// POSIX getsockname(2) equivalent
+int xgetsockname(int socketFd, struct sockaddr * sa, socklen_t * saLength);
+
+/// POSIX listen(2) equivalent
+int xlisten(int socketFd, int backlog);
+
+/// POSIX recv(2) equivalent
+ssize_t xrecv(int socketFd, void * buf, size_t bufLength, int flags);
+
+/// POSIX recvfrom(2) equivalent
+ssize_t xrecvfrom(int socketFd, void * buf, size_t bufLength, int flags, struct sockaddr * from, socklen_t * fromLength);
+
+/// POSIX send(2) equivalent
+ssize_t xsend(int socketFd, const void * buf, size_t bufLength, int flags);
+
+/// POSIX sendto(2) equivalent
+ssize_t xsendto(int socketFd, const void * buf, size_t bufLength, int flags, const struct sockaddr * to, socklen_t toLength);
+
+/// POSIX setsockopt(2) equivalent
+int xsetsockopt(int socketFd, int level, int option, const void * value, socklen_t valueLength);
+
+/// POSIX socket(2) equivalent
+int xsocket(int domain, int type, int protocol);
+
+// Solaris and possibly others lack MSG_NOSIGNAL optimization
+// TODO: move this into compat/? Use a dedicated compat file to avoid dragging
+// sys/socket.h into the rest of Squid??
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+#if !(_SQUID_WINDOWS_ || _SQUID_MINGW_)
+
+inline int
+xaccept(int socketFd, struct sockaddr *sa, socklen_t *saLength)
+{
+    return accept(socketFd, sa, saLength);
+}
+
+inline int
+xbind(int socketFd, const struct sockaddr *sa, socklen_t saLength)
+{
+    return bind(socketFd, sa, saLength);
+}
+
+inline int
+xconnect(int socketFd, const struct sockaddr *sa, socklen_t saLength)
+{
+    return connect(socketFd, sa, saLength);
+}
+
+inline int
+xgetsockname(int socketFd, struct sockaddr * sa, socklen_t * saLength)
+{
+    return getsockname(socketFd, sa, saLength);
+}
+
+inline int
+xlisten(int socketFd, int backlog)
+{
+    return listen(socketFd, backlog);
+}
+
+inline int
+xgetsockopt(int socketFd, int level, int optionName, void * optionValue, socklen_t * optionLength)
+{
+    return getsockopt(socketFd, level, optionName, optionValue, optionLength);
+}
+
+inline ssize_t
+xrecv(int socketFd, void * buf, size_t bufLength, int flags)
+{
+    return recv(socketFd, buf, bufLength, flags);
+}
+
+inline ssize_t
+xrecvfrom(int socketFd, void * buf, size_t bufLength, int flags, struct sockaddr * from, socklen_t * fromLength)
+{
+    return recvfrom(socketFd, buf, bufLength, flags, from, fromLength);
+}
+
+inline ssize_t
+xsend(int socketFd, const void * buf, size_t bufLength, int flags)
+{
+    return send(socketFd, buf, bufLength, flags);
+}
+
+inline ssize_t
+xsendto(int socketFd, const void * buf, size_t bufLength, int flags, const struct sockaddr * to, socklen_t l)
+{
+    return sendto(socketFd, buf, bufLength, flags, to, l);
+}
+
+inline int
+xsetsockopt(int socketFd, int level, int option, const void *value, socklen_t valueLength)
+{
+    return setsockopt(socketFd, level, option, value, valueLength);
+}
+
+inline int
+xsocket(int domain, int type, int protocol)
+{
+    return socket(domain, type, protocol);
+}
+
+#else
+
+static_assert(SOCKET_ERROR == -1);
+
+inline bool
+isValidSocketHandle(intptr_t handle)
+{
+    return handle != intptr_t(INVALID_HANDLE_VALUE);
+}
+
+#endif /* !(_SQUID_WINDOWS_ || _SQUID_MINGW_) */
+
+#endif /* SQUID_COMPAT_SOCKET_H */

--- a/compat/unistd.cc
+++ b/compat/unistd.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
+
+#include "compat/socket.h"
+#include "compat/unistd.h"
+#include "compat/wserrno.h"
+
+// 2025 MinGW and pre-2022 MSVC do not define these
+#ifndef _S_IREAD
+#define _S_IREAD 0x0100
+#endif
+
+#ifndef _S_IWRITE
+#define _S_IWRITE 0x0080
+#endif
+
+/// returns true if handle is a valid socket. Preserves errno.
+static bool
+isSocket(intptr_t handle)
+{
+    if (!isValidSocketHandle(handle)) {
+        // isValidSocketHandle does not touch errno
+        return false;
+    }
+
+    int value = 0;
+    int valueSize = sizeof(value);
+    const auto savedErrno = errno;
+    // use Windows API directly
+    const auto result = (getsockopt(handle, SOL_SOCKET, SO_TYPE, reinterpret_cast<char *>(&value), &valueSize) == 0);
+    errno = savedErrno;
+    return result;
+}
+
+int
+xclose(int fd)
+{
+    const auto sock = _get_osfhandle(fd);
+    if (sock == intptr_t(INVALID_HANDLE_VALUE)) {
+        // errno is already set by _get_osfhandle()
+        return -1;
+    }
+
+    if (isSocket(sock)) {
+        const auto result = closesocket(sock);
+        if (result == SOCKET_ERROR)
+            SetErrnoFromWsaError();
+        return result;
+    } else {
+        const auto result = _close(fd);
+        if (result)
+            SetErrnoFromWsaError();
+        return result;
+    }
+}
+
+int
+xgethostname(char *name, size_t nameLength)
+{
+    assert(nameLength <= INT_MAX);
+    const auto result = gethostname(name, static_cast<int>(nameLength));
+    if (result == SOCKET_ERROR)
+        SetErrnoFromWsaError();
+    return result;
+}
+
+int
+xopen(const char *filename, int oflag, int pmode)
+{
+    return _open(filename, oflag, pmode & (_S_IREAD | _S_IWRITE));
+}
+
+int
+xread(int fd, void * buf, size_t bufSize)
+{
+    const auto sock = _get_osfhandle(fd);
+    if (sock == intptr_t(INVALID_HANDLE_VALUE)) {
+        // errno is already set by _get_osfhandle()
+        return -1;
+    }
+
+    assert(bufSize <= UINT_MAX);
+    if (isSocket(sock))
+        return xrecv(sock, buf, bufSize, 0);
+    else
+        return _read(fd, buf, static_cast<unsigned int>(bufSize));
+}
+
+int
+xwrite(int fd, const void * buf, size_t bufSize)
+{
+    const auto sock = _get_osfhandle(fd);
+    if (sock == intptr_t(INVALID_HANDLE_VALUE)) {
+        // errno is already set by _get_osfhandle()
+        return -1;
+    }
+
+    assert(bufSize <= UINT_MAX);
+    if (isSocket(sock))
+        return xsend(sock, buf, bufSize, 0);
+    else
+        return _write(fd, buf, static_cast<unsigned int>(bufSize));
+}
+
+#endif /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */

--- a/compat/unistd.h
+++ b/compat/unistd.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_COMPAT_UNISTD_H
+#define SQUID_COMPAT_UNISTD_H
+
+#if HAVE_PATHS_H
+#include <paths.h>
+#endif
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+/// POSIX close(2) equivalent
+int xclose(int fd);
+
+/// POSIX gethostname(2) equivalent
+int xgethostname(char *name, size_t nameLength);
+
+/// POSIX open(2) equivalent
+int xopen(const char *filename, int oflag, int pmode = 0);
+
+/// POSIX read(2) equivalent
+int xread(int fd, void * buf, size_t bufSize);
+
+/// POSIX write(2) equivalent
+int xwrite(int fd, const void * buf, size_t bufSize);
+
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
+
+#if !defined(_PATH_DEVNULL)
+#define _PATH_DEVNULL "NUL"
+#endif
+
+#else /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */
+
+inline int
+xclose(int fd)
+{
+    return close(fd);
+}
+
+inline int
+xgethostname(char *name, size_t nameLength)
+{
+    return gethostname(name, nameLength);
+}
+
+inline int
+xopen(const char *filename, int oflag, int pmode)
+{
+    return open(filename, oflag, pmode);
+}
+
+inline int
+xread(int fd, void * buf, size_t bufSize)
+{
+    return read(fd, buf, bufSize);
+}
+
+inline int
+xwrite(int fd, const void * buf, size_t bufSize)
+{
+    return write(fd, buf, bufSize);
+}
+
+#endif /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */
+#endif /* SQUID_COMPAT_UNISTD_H */

--- a/compat/wserrno.cc
+++ b/compat/wserrno.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "compat/wserrno.h"
+
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
+
+#include <unordered_map>
+
+void
+SetErrnoFromWsaError()
+{
+    // POSIX codes which socket API users may care about
+    static const auto *CodeMap = new std::unordered_map<int, int> {
+        { WSAECONNABORTED, ECONNABORTED },
+        { WSAEINPROGRESS, EINPROGRESS },
+        { WSAEAFNOSUPPORT, EAFNOSUPPORT },
+        { WSAEINVAL, EINVAL },
+        { WSAEISCONN, EISCONN },
+        { WSAEWOULDBLOCK, EWOULDBLOCK },
+        // no Windows error code maps to EAGAIN
+        { WSAEALREADY, EALREADY },
+        { WSAEINTR, EINTR },
+        // no Windows error code maps to ERESTART
+        { WSAEMFILE, EMFILE },
+        // no Windows error code maps to ENFILE
+        { WSAECONNRESET, ECONNRESET }
+    };
+
+    const auto wsa = WSAGetLastError();
+    const auto itr = CodeMap->find(wsa);
+    if (itr != CodeMap->cend())
+        errno = itr->second;
+    else
+        errno = wsa;
+}
+
+#endif /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */

--- a/compat/wserrno.h
+++ b/compat/wserrno.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_COMPAT_WSERRNO_H
+#define SQUID_COMPAT_WSERRNO_H
+
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
+
+/**
+ * Squid socket code is written to handle POSIX errno codes.
+ * Set errno to the relevant POSIX or WSA code.
+ */
+void SetErrnoFromWsaError();
+
+#endif /* _SQUID_WINDOWS_ || _SQUID_MINGW_ */
+
+#endif /* SQUID_COMPAT_WSERRNO_H */

--- a/src/DiskIO/DiskDaemon/DiskdIOStrategy.cc
+++ b/src/DiskIO/DiskDaemon/DiskdIOStrategy.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "comm.h"
 #include "comm/Loops.h"
+#include "compat/select.h"
 #include "ConfigOption.h"
 #include "diomsg.h"
 #include "DiskdFile.h"
@@ -409,7 +410,7 @@ DiskdIOStrategy::SEND(diomsg *M, int mtype, int id, size_t size, off_t offset, s
     struct timeval delay = {0, 1};
 
     while (away > magic2) {
-        select(0, nullptr, nullptr, nullptr, &delay);
+        xselect(0, nullptr, nullptr, nullptr, &delay);
         Store::Root().callback();
 
         if (delay.tv_usec < 1000000)

--- a/src/DiskIO/DiskDaemon/diskd.cc
+++ b/src/DiskIO/DiskDaemon/diskd.cc
@@ -9,6 +9,8 @@
 /* DEBUG: section --    External DISKD process implementation. */
 
 #include "squid.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "DiskIO/DiskDaemon/diomsg.h"
 #include "hash.h"
 
@@ -53,12 +55,11 @@ static int DebugLevel = 0;
 static int
 do_open(diomsg * r, int, const char *buf)
 {
-    int fd;
     file_state *fs;
     /*
      * note r->offset holds open() flags
      */
-    fd = open(buf, r->offset, 0600);
+    const auto fd = xopen(buf, r->offset, 0600);
 
     if (fd < 0) {
         DEBUG(1) {
@@ -111,13 +112,12 @@ do_close(diomsg * r, int)
                 fs);
     }
     xfree(fs);
-    return close(fd);
+    return xclose(fd);
 }
 
 static int
 do_read(diomsg * r, int, char *buf)
 {
-    int x;
     int readlen = r->size;
     file_state *fs;
     fs = (file_state *) hash_lookup(hash, &r->id);
@@ -145,7 +145,7 @@ do_read(diomsg * r, int, char *buf)
         }
     }
 
-    x = read(fs->fd, buf, readlen);
+    const auto x = xread(fs->fd, buf, readlen);
     DEBUG(2) {
         fprintf(stderr, "%d READ %d,%d,%" PRId64 " ret %d\n", (int) mypid,
                 fs->fd, readlen, (int64_t)r->offset, x);
@@ -168,7 +168,6 @@ static int
 do_write(diomsg * r, int, const char *buf)
 {
     int wrtlen = r->size;
-    int x;
     file_state *fs;
     fs = (file_state *) hash_lookup(hash, &r->id);
 
@@ -195,7 +194,7 @@ do_write(diomsg * r, int, const char *buf)
         fprintf(stderr, "%d WRITE %d,%d,%" PRId64 "\n", (int) mypid,
                 fs->fd, wrtlen, (int64_t)r->offset);
     }
-    x = write(fs->fd, buf, wrtlen);
+    const auto x = xwrite(fs->fd, buf, wrtlen);
 
     if (x < 0) {
         DEBUG(1) {
@@ -370,7 +369,7 @@ main(int argc, char *argv[])
 
         if (rlen < 0) {
             if (EINTR == errno) {
-                if (read(0, rbuf, 512) <= 0) {
+                if (xread(0, rbuf, 512) <= 0) {
                     if (EWOULDBLOCK == errno)
                         (void) 0;
                     else if (EAGAIN == errno)

--- a/src/DiskIO/DiskThreads/CommIO.cc
+++ b/src/DiskIO/DiskThreads/CommIO.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "comm/Loops.h"
 #include "compat/pipe.h"
+#include "compat/unistd.h"
 #include "DiskIO/DiskThreads/CommIO.h"
 #include "fd.h"
 #include "globals.h"
@@ -40,8 +41,8 @@ CommIO::NotifyIOClose()
 {
     /* Close done pipe signal */
     FlushPipe();
-    close(DoneFD);
-    close(DoneReadFD);
+    xclose(DoneFD);
+    xclose(DoneReadFD);
     fd_close(DoneFD);
     fd_close(DoneReadFD);
     Initialized = false;

--- a/src/DiskIO/DiskThreads/aiops.cc
+++ b/src/DiskIO/DiskThreads/aiops.cc
@@ -13,6 +13,8 @@
 #endif
 
 #include "squid.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "DiskIO/DiskThreads/CommIO.h"
 #include "DiskThreads.h"
 #include "SquidConfig.h"
@@ -578,7 +580,7 @@ squidaio_cleanup_request(squidaio_request_t * requestp)
     case _AIO_OP_OPEN:
         if (cancelled && requestp->ret >= 0)
             /* The open() was cancelled but completed */
-            close(requestp->ret);
+            xclose(requestp->ret);
 
         squidaio_xstrfree(requestp->path);
 
@@ -587,7 +589,7 @@ squidaio_cleanup_request(squidaio_request_t * requestp)
     case _AIO_OP_CLOSE:
         if (cancelled && requestp->ret < 0)
             /* The close() was cancelled and never got executed */
-            close(requestp->fd);
+            xclose(requestp->fd);
 
         break;
 
@@ -701,7 +703,7 @@ static void
 squidaio_do_read(squidaio_request_t * requestp)
 {
     if (lseek(requestp->fd, requestp->offset, requestp->whence) >= 0)
-        requestp->ret = read(requestp->fd, requestp->bufferp, requestp->buflen);
+        requestp->ret = xread(requestp->fd, requestp->bufferp, requestp->buflen);
     else
         requestp->ret = -1;
     requestp->err = errno;
@@ -740,7 +742,7 @@ squidaio_write(int fd, char *bufp, size_t bufs, off_t offset, int whence, squida
 static void
 squidaio_do_write(squidaio_request_t * requestp)
 {
-    requestp->ret = write(requestp->fd, requestp->bufferp, requestp->buflen);
+    requestp->ret = xwrite(requestp->fd, requestp->bufferp, requestp->buflen);
     requestp->err = errno;
 }
 
@@ -769,7 +771,7 @@ squidaio_close(int fd, squidaio_result_t * resultp)
 static void
 squidaio_do_close(squidaio_request_t * requestp)
 {
-    requestp->ret = close(requestp->fd);
+    requestp->ret = xclose(requestp->fd);
     requestp->err = errno;
 }
 

--- a/src/DiskIO/DiskThreads/aiops_win32.cc
+++ b/src/DiskIO/DiskThreads/aiops_win32.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 43    Windows AIOPS */
 
 #include "squid.h"
+#include "compat/unistd.h"
 #include "compat/win32_maperror.h"
 #include "DiskIO/DiskThreads/CommIO.h"
 #include "DiskThreads.h"
@@ -653,7 +654,7 @@ squidaio_cleanup_request(squidaio_request_t * requestp)
     case _AIO_OP_OPEN:
         if (cancelled && requestp->ret >= 0)
             /* The open() was cancelled but completed */
-            close(requestp->ret);
+            xclose(requestp->ret);
 
         squidaio_xstrfree(requestp->path);
 
@@ -662,7 +663,7 @@ squidaio_cleanup_request(squidaio_request_t * requestp)
     case _AIO_OP_CLOSE:
         if (cancelled && requestp->ret < 0)
             /* The close() was cancelled and never got executed */
-            close(requestp->fd);
+            xclose(requestp->fd);
 
         break;
 
@@ -853,9 +854,9 @@ squidaio_close(int fd, squidaio_result_t * resultp)
 static void
 squidaio_do_close(squidaio_request_t * requestp)
 {
-    if ((requestp->ret = close(requestp->fd)) < 0) {
+    if ((requestp->ret = xclose(requestp->fd)) < 0) {
         debugs(43, DBG_CRITICAL, "squidaio_do_close: FD " << requestp->fd << ", errno " << errno);
-        close(requestp->fd);
+        xclose(requestp->fd);
     }
 
     requestp->err = errno;

--- a/src/adaptation/icap/ServiceRep.cc
+++ b/src/adaptation/icap/ServiceRep.cc
@@ -17,6 +17,7 @@
 #include "adaptation/icap/ServiceRep.h"
 #include "base/TextException.h"
 #include "comm/Connection.h"
+#include "compat/netdb.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "fde.h"
@@ -66,9 +67,9 @@ Adaptation::Icap::ServiceRep::finalize()
     if (!have_port) {
         struct servent *serv;
         if (cfg().protocol.caseCmp("icaps") == 0)
-            serv = getservbyname("icaps", "tcp");
+            serv = xgetservbyname("icaps", "tcp");
         else
-            serv = getservbyname("icap", "tcp");
+            serv = xgetservbyname("icap", "tcp");
 
         if (serv) {
             writeableCfg().port = htons(serv->s_port);

--- a/src/auth/basic/RADIUS/basic_radius_auth.cc
+++ b/src/auth/basic/RADIUS/basic_radius_auth.cc
@@ -57,6 +57,10 @@
 #include "auth/basic/RADIUS/radius-util.h"
 #include "auth/basic/RADIUS/radius.h"
 #include "base/Random.h"
+#include "compat/netdb.h"
+#include "compat/select.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "helper/protocol_defines.h"
 #include "md5.h"
 
@@ -64,26 +68,14 @@
 #include <cerrno>
 #include <cstring>
 #include <ctime>
-#if HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
 #if HAVE_NETINET_IN_H
 #include <netinet/in.h>
-#endif
-#if HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #if HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
 #if _SQUID_WINDOWS_
 #include <io.h>
-#endif
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#if HAVE_NETDB_H
-#include <netdb.h>
 #endif
 #if HAVE_PWD_H
 #include <pwd.h>
@@ -417,7 +409,7 @@ authenticate(int socket_fd, const char *username, const char *passwd)
          *    Send the request we've built.
          */
         gettimeofday(&sent, nullptr);
-        if (send(socket_fd, (char *) auth, total_length, 0) < 0) {
+        if (xsend(socket_fd, auth, total_length, 0) < 0) {
             int xerrno = errno;
             // EAGAIN is expected at high traffic, just retry
             // TODO: block/sleep a few ms to let the apparently full buffer drain ?
@@ -437,11 +429,11 @@ authenticate(int socket_fd, const char *username, const char *passwd)
             }
             FD_ZERO(&readfds);
             FD_SET(socket_fd, &readfds);
-            if (select(socket_fd + 1, &readfds, nullptr, nullptr, &tv) == 0)  /* Select timeout */
+            if (xselect(socket_fd + 1, &readfds, nullptr, nullptr, &tv) == 0)  /* Select timeout */
                 break;
             salen = sizeof(saremote);
-            len = recvfrom(socket_fd, recv_buffer, sizeof(i_recv_buffer),
-                           0, (struct sockaddr *) &saremote, &salen);
+            len = xrecvfrom(socket_fd, recv_buffer, sizeof(i_recv_buffer),
+                            0, (struct sockaddr *) &saremote, &salen);
 
             if (len < 0)
                 continue;
@@ -468,7 +460,6 @@ main(int argc, char **argv)
 {
     struct sockaddr_in salocal;
     struct sockaddr_in saremote;
-    struct servent *svp;
     unsigned short svc_port;
     char username[MAXPWNAM];
     char passwd[MAXPASS];
@@ -536,7 +527,7 @@ main(int argc, char **argv)
     /*
      *    Open a connection to the server.
      */
-    svp = getservbyname(svc_name, "udp");
+    const auto svp = xgetservbyname(svc_name, "udp");
     if (svp != nullptr)
         svc_port = ntohs((unsigned short) svp->s_port);
     else
@@ -549,7 +540,7 @@ main(int argc, char **argv)
         fprintf(stderr, "FATAL: %s: Couldn't find host %s\n", argv[0], server);
         exit(EXIT_FAILURE);
     }
-    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    sockfd = xsocket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0) {
         perror("socket");
         exit(EXIT_FAILURE);
@@ -559,12 +550,12 @@ main(int argc, char **argv)
     saremote.sin_addr.s_addr = htonl(auth_ipaddr);
     saremote.sin_port = htons(svc_port);
 
-    if (connect(sockfd, (struct sockaddr *) &saremote, sizeof(saremote)) < 0) {
+    if (xconnect(sockfd, (struct sockaddr *) &saremote, sizeof(saremote)) < 0) {
         perror("connect");
         exit(EXIT_FAILURE);
     }
     salen = sizeof(salocal);
-    if (getsockname(sockfd, (struct sockaddr *) &salocal, &salen) < 0) {
+    if (xgetsockname(sockfd, (struct sockaddr *) &salocal, &salen) < 0) {
         perror("getsockname");
         exit(EXIT_FAILURE);
     }
@@ -612,7 +603,7 @@ main(int argc, char **argv)
 
         authenticate(sockfd, username, passwd);
     }
-    close(sockfd);
+    xclose(sockfd);
     return EXIT_SUCCESS;
 }
 

--- a/src/auth/basic/RADIUS/radius-util.cc
+++ b/src/auth/basic/RADIUS/radius-util.cc
@@ -46,19 +46,15 @@ char util_sccsid[] =
 
 #include "squid.h"
 #include "auth/basic/RADIUS/radius-util.h"
+#include "compat/netdb.h"
+#include "compat/socket.h"
 #include "md5.h"
 
 #include <cctype>
 #include <csignal>
 #include <ctime>
-#if HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
 #if HAVE_NETINET_IN_H
 #include <netinet/in.h>
-#endif
-#if HAVE_NETDB_H
-#include <netdb.h>
 #endif
 #if HAVE_PWD_H
 #include <pwd.h>
@@ -146,7 +142,7 @@ uint32_t get_ipaddr(char *host)
 
     if (good_ipaddr(host) == 0) {
         return(ipstr2long(host));
-    } else if ((hp = gethostbyname(host)) == (struct hostent *)nullptr) {
+    } else if (!(hp = xgethostbyname(host))) {
         return((uint32_t)0);
     }
     return(ntohl(*(uint32_t *)hp->h_addr));

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -40,13 +40,11 @@
 
 #if HAVE_GSSAPI
 
+#include "compat/unistd.h"
 #include "negotiate_kerberos.h"
 
 #if HAVE_SYS_STAT_H
 #include "sys/stat.h"
-#endif
-#if HAVE_UNISTD_H
-#include "unistd.h"
 #endif
 
 #if HAVE_KRB5_MEMORY_KEYTAB
@@ -97,7 +95,7 @@ gethost_name(void)
     struct addrinfo *hres = nullptr, *hres_list;
     int rc;
 
-    rc = gethostname(hostname, sizeof(hostname)-1);
+    rc = xgethostname(hostname, sizeof(hostname)-1);
     if (rc) {
         debug((char *) "%s| %s: ERROR: resolving hostname '%s' failed\n", LogTime(), PROGRAM, hostname);
         fprintf(stderr, "%s| %s: ERROR: resolving hostname '%s' failed\n",

--- a/src/auth/negotiate/wrapper/negotiate_wrapper.cc
+++ b/src/auth/negotiate/wrapper/negotiate_wrapper.cc
@@ -33,17 +33,12 @@
 #include "squid.h"
 #include "base64.h"
 #include "compat/pipe.h"
+#include "compat/unistd.h"
 
 #include <cerrno>
 #include <cstring>
 #include <cstdlib>
 #include <ctime>
-#if HAVE_NETDB_H
-#include <netdb.h>
-#endif
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 #if !defined(HAVE_DECL_XMALLOC) || !HAVE_DECL_XMALLOC
 #define xmalloc malloc
@@ -376,13 +371,13 @@ main(int argc, char *const argv[])
     if ( fpid == 0 ) {
         /* First Child for Kerberos helper */
 
-        close(pkin[1]);
+        xclose(pkin[1]);
         dup2(pkin[0],STDIN_FILENO);
-        close(pkin[0]);
+        xclose(pkin[0]);
 
-        close(pkout[0]);
+        xclose(pkout[0]);
         dup2(pkout[1],STDOUT_FILENO);
-        close(pkout[1]);
+        xclose(pkout[1]);
 
         setbuf(stdin, nullptr);
         setbuf(stdout, nullptr);
@@ -392,8 +387,8 @@ main(int argc, char *const argv[])
         exit(EXIT_FAILURE);
     }
 
-    close(pkin[0]);
-    close(pkout[1]);
+    xclose(pkin[0]);
+    xclose(pkout[1]);
 
     if (pipe(pnin) < 0) {
         fprintf(stderr, "%s| %s: Could not assign streams for pnin\n", LogTime(), PROGRAM);
@@ -412,13 +407,13 @@ main(int argc, char *const argv[])
     if ( fpid == 0 ) {
         /* Second Child for NTLM helper */
 
-        close(pnin[1]);
+        xclose(pnin[1]);
         dup2(pnin[0],STDIN_FILENO);
-        close(pnin[0]);
+        xclose(pnin[0]);
 
-        close(pnout[0]);
+        xclose(pnout[0]);
         dup2(pnout[1],STDOUT_FILENO);
-        close(pnout[1]);
+        xclose(pnout[1]);
 
         setbuf(stdin, nullptr);
         setbuf(stdout, nullptr);
@@ -428,8 +423,8 @@ main(int argc, char *const argv[])
         exit(EXIT_FAILURE);
     }
 
-    close(pnin[0]);
-    close(pnout[1]);
+    xclose(pnin[0]);
+    xclose(pnout[1]);
 
     FILE *FDKIN=fdopen(pkin[1],"w");
     FILE *FDKOUT=fdopen(pkout[0],"r");

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -28,6 +28,8 @@
 #include "cache_cf.h"
 #include "CachePeer.h"
 #include "CachePeers.h"
+#include "compat/netdb.h"
+#include "compat/socket.h"
 #include "ConfigOption.h"
 #include "ConfigParser.h"
 #include "CpuAffinityMap.h"
@@ -103,9 +105,6 @@
 #endif
 #if HAVE_GRP_H
 #include <grp.h>
-#endif
-#if HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
 #endif
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
@@ -2130,7 +2129,7 @@ GetService(const char *proto)
     }
     /** Returns either the service port number from /etc/services */
     if ( !isUnsignedNumeric(token, strlen(token)) )
-        port = getservbyname(token, proto);
+        port = xgetservbyname(token, proto);
     if (port != nullptr) {
         return ntohs((unsigned short)port->s_port);
     }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -78,6 +78,7 @@
 #include "comm/TcpAcceptor.h"
 #include "comm/Write.h"
 #include "CommCalls.h"
+#include "compat/socket.h"
 #include "debug/Messages.h"
 #include "error/ExceptionErrorDetail.h"
 #include "errorpage.h"
@@ -2134,7 +2135,7 @@ ConnStateData::start()
             (transparent() || port->disable_pmtu_discovery == DISABLE_PMTU_ALWAYS)) {
 #if defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_DONT)
         int i = IP_PMTUDISC_DONT;
-        if (setsockopt(clientConnection->fd, SOL_IP, IP_MTU_DISCOVER, &i, sizeof(i)) < 0) {
+        if (xsetsockopt(clientConnection->fd, SOL_IP, IP_MTU_DISCOVER, &i, sizeof(i)) < 0) {
             int xerrno = errno;
             debugs(33, 2, "WARNING: Path MTU discovery disabling failed on " << clientConnection << " : " << xstrerr(xerrno));
         }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -166,6 +166,7 @@ Ftp::DataChannel::DataChannel():
 
 Ftp::DataChannel::~DataChannel()
 {
+    xfree(host);
     delete readBuf;
 }
 
@@ -1165,6 +1166,7 @@ Ftp::Client::parseControlReply(size_t &bytesUsed)
 
         if (complete) {
             // use list->key for last_reply because s contains the new line
+            safe_free(ctrl.last_reply);
             ctrl.last_reply = xstrdup(list->key + 4);
             ctrl.replycode = atoi(list->key);
         }

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -696,6 +696,7 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
             switch (*ct) {
 
             case '\t':
+                safe_free(p->name); // TODO: properly handle multiple p->name occurrences
                 p->name = xstrndup(ct + 1, l + 1);
                 break;
 
@@ -709,6 +710,7 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
                 if (tmp != ct + 1)
                     break;  /* not a valid integer */
 
+                safe_free(p->date); // TODO: properly handle multiple p->name occurrences
                 p->date = xstrdup(ctime(&tm));
 
                 *(strstr(p->date, "\n")) = '\0';

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -18,6 +18,7 @@
 #include "comm/Read.h"
 #include "comm/TcpAcceptor.h"
 #include "CommCalls.h"
+#include "compat/socket.h"
 #include "compat/strtoll.h"
 #include "errorpage.h"
 #include "fd.h"
@@ -1777,8 +1778,8 @@ ftpOpenListenSocket(Ftp::Gateway * ftpState, int fallback)
     if (fallback) {
         int on = 1;
         errno = 0;
-        if (setsockopt(ftpState->ctrl.conn->fd, SOL_SOCKET, SO_REUSEADDR,
-                       (char *) &on, sizeof(on)) == -1) {
+        if (xsetsockopt(ftpState->ctrl.conn->fd, SOL_SOCKET, SO_REUSEADDR,
+                        &on, sizeof(on)) == -1) {
             int xerrno = errno;
             // SO_REUSEADDR is only an optimization, no need to be verbose about error
             debugs(9, 4, "setsockopt failed: " << xstrerr(xerrno));

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -14,6 +14,7 @@
 #include "comm/Connection.h"
 #include "comm/ConnOpener.h"
 #include "comm/Loops.h"
+#include "compat/socket.h"
 #include "fd.h"
 #include "fde.h"
 #include "globals.h"
@@ -431,7 +432,7 @@ Comm::ConnOpener::lookupLocalAddress()
 {
     struct sockaddr_storage addr = {};
     socklen_t len = sizeof(addr);
-    if (getsockname(conn_->fd, reinterpret_cast<struct sockaddr *>(&addr), &len) != 0) {
+    if (xgetsockname(conn_->fd, reinterpret_cast<struct sockaddr *>(&addr), &len) != 0) {
         int xerrno = errno;
         debugs(50, DBG_IMPORTANT, "ERROR: Failed to retrieve TCP/UDP details for socket: " << conn_ << ": " << xstrerr(xerrno));
         return;

--- a/src/comm/ModDevPoll.cc
+++ b/src/comm/ModDevPoll.cc
@@ -30,6 +30,7 @@
 
 #include "base/IoManip.h"
 #include "comm/Loops.h"
+#include "compat/unistd.h"
 #include "fd.h"
 #include "fde.h"
 #include "mgr/Registration.h"
@@ -92,7 +93,6 @@ static void commDevPollRegisterWithCacheManager(void);
 static void
 comm_flush_updates(void)
 {
-    int i;
     if (devpoll_update.cur == -1)
         return; /* array of changes to make is empty */
 
@@ -102,11 +102,11 @@ comm_flush_updates(void)
         (devpoll_update.cur + 1) << " fds queued"
     );
 
-    i = write(
-            devpoll_fd, /* open handle to /dev/poll */
-            devpoll_update.pfds, /* pointer to array of struct pollfd */
-            (devpoll_update.cur + 1) * sizeof(struct pollfd) /* bytes to process */
-        );
+    const auto i = xwrite(
+                       devpoll_fd, /* open handle to /dev/poll */
+                       devpoll_update.pfds, /* pointer to array of struct pollfd */
+                       (devpoll_update.cur + 1) * sizeof(struct pollfd) /* bytes to process */
+                   );
     assert(i > 0);
     assert(static_cast<size_t>(i) == (sizeof(struct pollfd) * (devpoll_update.cur + 1)));
     devpoll_update.cur = -1; /* reset size of array, no elements remain */
@@ -191,7 +191,7 @@ Comm::SelectLoopInit(void)
                           );
 
     /* attempt to open /dev/poll device */
-    devpoll_fd = open("/dev/poll", O_RDWR);
+    devpoll_fd = xopen("/dev/poll", O_RDWR);
     if (devpoll_fd < 0) {
         int xerrno = errno;
         fatalf("comm_select_init: can't open /dev/poll: %s\n", xstrerr(xerrno));

--- a/src/comm/ModSelect.cc
+++ b/src/comm/ModSelect.cc
@@ -15,6 +15,7 @@
 #include "anyp/PortCfg.h"
 #include "comm/Connection.h"
 #include "comm/Loops.h"
+#include "compat/select.h"
 #include "fde.h"
 #include "globals.h"
 #include "ICP.h"
@@ -156,7 +157,7 @@ comm_check_incoming_select_handlers(int nfds, int *fds)
 
     ++ statCounter.syscalls.selects;
 
-    if (select(maxfd, &read_mask, &write_mask, nullptr, &zero_tv) < 1)
+    if (xselect(maxfd, &read_mask, &write_mask, nullptr, &zero_tv) < 1)
         return incoming_sockets_accepted;
 
     for (i = 0; i < nfds; ++i) {
@@ -320,7 +321,7 @@ Comm::DoSelect(int msec)
             poll_time.tv_sec = msec / 1000;
             poll_time.tv_usec = (msec % 1000) * 1000;
             ++ statCounter.syscalls.selects;
-            num = select(maxfd, &readfds, &writefds, nullptr, &poll_time);
+            num = xselect(maxfd, &readfds, &writefds, nullptr, &poll_time);
             int xerrno = errno;
             ++ statCounter.select_loops;
 

--- a/src/comm/Tcp.cc
+++ b/src/comm/Tcp.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "comm/Tcp.h"
+#include "compat/socket.h"
 #include "debug/Stream.h"
 
 #if HAVE_NETINET_TCP_H
@@ -18,19 +19,16 @@
 #if HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-#if HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
 #include <type_traits>
 
-/// setsockopt(2) wrapper
+/// xsetsockopt(2) wrapper
 template <typename Option>
 static bool
 SetSocketOption(const int fd, const int level, const int optName, const Option &optValue)
 {
     static_assert(std::is_trivially_copyable<Option>::value, "setsockopt() expects POD-like options");
     static_assert(!std::is_same<Option, bool>::value, "setsockopt() uses int to represent boolean options");
-    if (setsockopt(fd, level, optName, reinterpret_cast<const char *>(&optValue), sizeof(optValue)) < 0) {
+    if (xsetsockopt(fd, level, optName, &optValue, sizeof(optValue)) < 0) {
         const auto xerrno = errno;
         debugs(5, DBG_IMPORTANT, "ERROR: setsockopt(2) failure: " << xstrerr(xerrno));
         // TODO: Generalize to throw on errors when some callers need that.

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -20,6 +20,7 @@
 #include "comm/Loops.h"
 #include "comm/TcpAcceptor.h"
 #include "CommCalls.h"
+#include "compat/socket.h"
 #include "eui/Config.h"
 #include "fd.h"
 #include "fde.h"
@@ -150,7 +151,7 @@ void
 Comm::TcpAcceptor::setListen()
 {
     errcode = errno = 0;
-    if (listen(conn->fd, Squid_MaxFD >> 2) < 0) {
+    if (xlisten(conn->fd, Squid_MaxFD >> 2) < 0) {
         errcode = errno;
         debugs(50, DBG_CRITICAL, "ERROR: listen(..., " << (Squid_MaxFD >> 2) << ") system call failed: " << xstrerr(errcode));
         return;
@@ -162,7 +163,7 @@ Comm::TcpAcceptor::setListen()
         bzero(&afa, sizeof(afa));
         debugs(5, DBG_IMPORTANT, "Installing accept filter '" << Config.accept_filter << "' on " << conn);
         xstrncpy(afa.af_name, Config.accept_filter, sizeof(afa.af_name));
-        if (setsockopt(conn->fd, SOL_SOCKET, SO_ACCEPTFILTER, &afa, sizeof(afa)) < 0) {
+        if (xsetsockopt(conn->fd, SOL_SOCKET, SO_ACCEPTFILTER, &afa, sizeof(afa)) < 0) {
             int xerrno = errno;
             debugs(5, DBG_CRITICAL, "WARNING: SO_ACCEPTFILTER '" << Config.accept_filter << "': '" << xstrerr(xerrno));
         }
@@ -170,7 +171,7 @@ Comm::TcpAcceptor::setListen()
         int seconds = 30;
         if (strncmp(Config.accept_filter, "data=", 5) == 0)
             seconds = atoi(Config.accept_filter + 5);
-        if (setsockopt(conn->fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &seconds, sizeof(seconds)) < 0) {
+        if (xsetsockopt(conn->fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &seconds, sizeof(seconds)) < 0) {
             int xerrno = errno;
             debugs(5, DBG_CRITICAL, "WARNING: TCP_DEFER_ACCEPT '" << Config.accept_filter << "': '" << xstrerr(xerrno));
         }
@@ -348,7 +349,7 @@ Comm::TcpAcceptor::acceptInto(Comm::ConnectionPointer &details)
     errcode = 0; // reset local errno copy.
     struct sockaddr_storage remoteAddress = {};
     socklen_t remoteAddressSize = sizeof(remoteAddress);
-    const auto rawSock = accept(conn->fd, reinterpret_cast<struct sockaddr *>(&remoteAddress), &remoteAddressSize);
+    const auto rawSock = xaccept(conn->fd, reinterpret_cast<struct sockaddr *>(&remoteAddress), &remoteAddressSize);
     if (rawSock < 0) {
         errcode = errno; // store last accept errno locally.
         if (ignoreErrno(errcode) || errcode == ECONNABORTED) {
@@ -375,7 +376,7 @@ Comm::TcpAcceptor::acceptInto(Comm::ConnectionPointer &details)
     // lookup the local-end details of this new connection
     struct sockaddr_storage localAddress = {};
     socklen_t localAddressSize = sizeof(localAddress);
-    if (getsockname(sock, reinterpret_cast<struct sockaddr *>(&localAddress), &localAddressSize) != 0) {
+    if (xgetsockname(sock, reinterpret_cast<struct sockaddr *>(&localAddress), &localAddressSize) != 0) {
         int xerrno = errno;
         debugs(50, DBG_IMPORTANT, "ERROR: Closing accepted TCP connection after failing to obtain its local IP address" <<
                Debug::Extra << "accepted connection: " << details <<

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -841,6 +841,7 @@ ErrorState::~ErrorState()
     wordlistDestroy(&ftp.server_msg);
     safe_free(ftp.request);
     safe_free(ftp.reply);
+    safe_free(ftp.cwd_msg);
     safe_free(err_msg);
 #if USE_ERR_LOCALES
     if (err_language != Config.errorDefaultLanguage)

--- a/src/eui/Eui48.cc
+++ b/src/eui/Eui48.cc
@@ -13,6 +13,8 @@
 #if USE_SQUID_EUI
 
 #include "base/IoManip.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "debug/Stream.h"
 #include "eui/Eui48.h"
 #include "globals.h"
@@ -171,7 +173,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
     int offset;
 
     /* IPv6 builds do not provide the first http_port as an IPv4 socket for ARP */
-    int tmpSocket = socket(AF_INET,SOCK_STREAM,0);
+    auto tmpSocket = xsocket(AF_INET,SOCK_STREAM,0);
     if (tmpSocket < 0) {
         int xerrno = errno;
         debugs(28, DBG_IMPORTANT, "ERROR: Attempt to open socket for EUI retrieval failed: " << xstrerr(xerrno));
@@ -204,7 +206,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
     debugs(28, 4, "id=" << (void*)this << " query ARP table");
     if (ioctl(tmpSocket, SIOCGARP, &arpReq) != -1) {
         /* Skip non-ethernet interfaces */
-        close(tmpSocket);
+        xclose(tmpSocket);
 
         if (arpReq.arp_ha.sa_family != ARPHRD_ETHER) {
             debugs(28, 4, "id=" << (void*)this << " ... not an Ethernet interface: " << arpReq.arp_ha.sa_data);
@@ -227,14 +229,14 @@ Eui::Eui48::lookup(const Ip::Address &c)
         int xerrno = errno;
         debugs(28, DBG_IMPORTANT, "ERROR: Attempt to retrieve interface list failed: " << xstrerr(xerrno));
         clear();
-        close(tmpSocket);
+        xclose(tmpSocket);
         return false;
     }
 
     if (ifc.ifc_len > (int)sizeof(ifbuffer)) {
         debugs(28, DBG_IMPORTANT, "Interface list too long - " << ifc.ifc_len);
         clear();
-        close(tmpSocket);
+        xclose(tmpSocket);
         return false;
     }
 
@@ -295,16 +297,16 @@ Eui::Eui48::lookup(const Ip::Address &c)
          */
 
         /* AYJ: 2009-10-06: for now we have to. We can only store one EUI at a time. */
-        close(tmpSocket);
+        xclose(tmpSocket);
         return true;
     }
 
-    close(tmpSocket);
+    xclose(tmpSocket);
 
 #elif _SQUID_SOLARIS_
 
     /* IPv6 builds do not provide the first http_port as an IPv4 socket for ARP */
-    int tmpSocket = socket(AF_INET,SOCK_STREAM,0);
+    auto tmpSocket = xsocket(AF_INET,SOCK_STREAM,0);
     if (tmpSocket < 0) {
         int xerrno = errno;
         debugs(28, DBG_IMPORTANT, "ERROR: Attempt to open socket for EUI retrieval failed: " << xstrerr(xerrno));
@@ -325,7 +327,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
         *  Solaris (at least 2.6/x86) does not use arp_ha.sa_family -
         * it returns 00:00:00:00:00:00 for non-ethernet media
         */
-        close(tmpSocket);
+        xclose(tmpSocket);
 
         if (arpReq.arp_ha.sa_data[0] == 0 &&
                 arpReq.arp_ha.sa_data[1] == 0 &&
@@ -341,7 +343,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
         set(arpReq.arp_ha.sa_data, 6);
         return true;
     } else {
-        close(tmpSocket);
+        xclose(tmpSocket);
     }
 
 #elif _SQUID_FREEBSD_ || _SQUID_NETBSD_ || _SQUID_OPENBSD_ || _SQUID_DRAGONFLY_ || _SQUID_KFREEBSD_

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -10,19 +10,14 @@
 
 #include "squid.h"
 #include "comm/Loops.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "debug/Messages.h"
 #include "debug/Stream.h"
 #include "fatal.h"
 #include "fd.h"
 #include "fde.h"
 #include "globals.h"
-
-// Solaris and possibly others lack MSG_NOSIGNAL optimization
-// TODO: move this into compat/? Use a dedicated compat file to avoid dragging
-// sys/socket.h into the rest of Squid??
-#ifndef MSG_NOSIGNAL
-#define MSG_NOSIGNAL 0
-#endif
 
 int default_read_method(int, char *, int);
 int default_write_method(int, const char *, int);
@@ -103,7 +98,7 @@ fd_close(int fd)
 int
 socket_read_method(int fd, char *buf, int len)
 {
-    return recv(fd, (void *) buf, len, 0);
+    return xrecv(fd, (void *) buf, len, 0);
 }
 
 int
@@ -115,7 +110,7 @@ file_read_method(int fd, char *buf, int len)
 int
 socket_write_method(int fd, const char *buf, int len)
 {
-    return send(fd, (const void *) buf, len, 0);
+    return xsend(fd, buf, len, 0);
 }
 
 int
@@ -128,13 +123,13 @@ file_write_method(int fd, const char *buf, int len)
 int
 default_read_method(int fd, char *buf, int len)
 {
-    return read(fd, buf, len);
+    return xread(fd, buf, len);
 }
 
 int
 default_write_method(int fd, const char *buf, int len)
 {
-    return write(fd, buf, len);
+    return xwrite(fd, buf, len);
 }
 
 int

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "base/AsyncJobCalls.h"
+#include "compat/unistd.h"
 #include "debug/Messages.h"
 #include "fs/rock/RockDbCell.h"
 #include "fs/rock/RockRebuild.h"
@@ -354,7 +355,7 @@ Rock::Rebuild::start()
         failure("cannot open db", errno);
 
     char hdrBuf[SwapDir::HeaderSize];
-    if (read(fd, hdrBuf, sizeof(hdrBuf)) != SwapDir::HeaderSize)
+    if (xread(fd, hdrBuf, sizeof(hdrBuf)) != SwapDir::HeaderSize)
         failure("cannot read db header", errno);
 
     // slot prefix of SM_PAGE_SIZE should fit both core entry header and ours

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -12,6 +12,8 @@
 #include "base/IoManip.h"
 #include "cache_cf.h"
 #include "CollapsedForwarding.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "ConfigOption.h"
 #include "DiskIO/DiskIOModule.h"
 #include "DiskIO/DiskIOStrategy.h"
@@ -239,7 +241,7 @@ Rock::SwapDir::create()
     }
 
     debugs (47, DBG_IMPORTANT, "Creating Rock db: " << filePath);
-    const int swap = open(filePath, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0600);
+    const auto swap = xopen(filePath, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0600);
     if (swap < 0)
         createError("create");
 
@@ -249,7 +251,7 @@ Rock::SwapDir::create()
     memset(block, '\0', sizeof(block));
 
     for (off_t offset = 0; offset < maxSize(); offset += sizeof(block)) {
-        if (write(swap, block, sizeof(block)) != sizeof(block))
+        if (xwrite(swap, block, sizeof(block)) != sizeof(block))
             createError("write");
     }
 #else
@@ -258,11 +260,11 @@ Rock::SwapDir::create()
 
     char header[HeaderSize];
     memset(header, '\0', sizeof(header));
-    if (write(swap, header, sizeof(header)) != sizeof(header))
+    if (xwrite(swap, header, sizeof(header)) != sizeof(header))
         createError("write");
 #endif
 
-    close(swap);
+    xclose(swap);
 }
 
 // report Rock DB creation error and exit

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "comm/Loops.h"
+#include "compat/unistd.h"
 #include "fd.h"
 #include "fde.h"
 #include "fs_io.h"
@@ -64,14 +65,12 @@ dwrite_q::~dwrite_q()
 int
 file_open(const char *path, int mode)
 {
-    int fd;
-
     if (FILE_MODE(mode) == O_WRONLY)
         mode |= O_APPEND;
 
     errno = 0;
 
-    fd = open(path, mode, 0644);
+    auto fd = xopen(path, mode, 0644);
 
     ++ statCounter.syscalls.disk.opens;
 
@@ -124,7 +123,7 @@ file_close(int fd)
      */
     assert(F->write_handler == nullptr);
 
-    close(fd);
+    xclose(fd);
 
     debugs(6, F->flags.close_request ? 2 : 5, "file_close: FD " << fd << " really closing");
 

--- a/src/icmp/Icmp.cc
+++ b/src/icmp/Icmp.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 37    ICMP Routines */
 
 #include "squid.h"
+#include "compat/unistd.h"
 #include "debug/Stream.h"
 #include "Icmp.h"
 #include "time/gadgets.h"
@@ -26,7 +27,7 @@ Icmp::Close()
 {
 #if USE_ICMP
     if (icmp_sock > 0)
-        close(icmp_sock);
+        xclose(icmp_sock);
     icmp_sock = -1;
     icmp_ident = 0;
 #endif

--- a/src/icmp/Icmp4.cc
+++ b/src/icmp/Icmp4.cc
@@ -14,6 +14,7 @@
 
 #if USE_ICMP
 
+#include "compat/socket.h"
 #include "debug/Stream.h"
 #include "Icmp4.h"
 #include "IcmpPinger.h"
@@ -65,7 +66,7 @@ Icmp4::~Icmp4()
 int
 Icmp4::Open(void)
 {
-    icmp_sock = socket(PF_INET, SOCK_RAW, IPPROTO_ICMP);
+    icmp_sock = xsocket(PF_INET, SOCK_RAW, IPPROTO_ICMP);
 
     if (icmp_sock < 0) {
         int xerrno = errno;
@@ -136,12 +137,12 @@ Icmp4::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     debugs(42, 5, "Send ICMP packet to " << to << ".");
 
-    x = sendto(icmp_sock,
-               (const void *) pkt,
-               icmp_pktsize,
-               0,
-               S->ai_addr,
-               S->ai_addrlen);
+    x = xsendto(icmp_sock,
+                pkt,
+                icmp_pktsize,
+                0,
+                S->ai_addr,
+                S->ai_addrlen);
 
     if (x < 0) {
         int xerrno = errno;
@@ -174,12 +175,12 @@ Icmp4::Recv(void)
         pkt = (char *)xmalloc(MAX_PKT4_SZ);
 
     Ip::Address::InitAddr(from);
-    n = recvfrom(icmp_sock,
-                 (void *)pkt,
-                 MAX_PKT4_SZ,
-                 0,
-                 from->ai_addr,
-                 &from->ai_addrlen);
+    n = xrecvfrom(icmp_sock,
+                  pkt,
+                  MAX_PKT4_SZ,
+                  0,
+                  from->ai_addr,
+                  &from->ai_addrlen);
 
     if (n <= 0) {
         debugs(42, DBG_CRITICAL, "ERROR: when calling recvfrom() on ICMP socket.");

--- a/src/icmp/Icmp6.cc
+++ b/src/icmp/Icmp6.cc
@@ -14,6 +14,7 @@
 
 #if USE_ICMP
 
+#include "compat/socket.h"
 #include "debug/Stream.h"
 #include "Icmp6.h"
 #include "IcmpPinger.h"
@@ -97,7 +98,7 @@ Icmp6::~Icmp6()
 int
 Icmp6::Open(void)
 {
-    icmp_sock = socket(PF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+    icmp_sock = xsocket(PF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
 
     if (icmp_sock < 0) {
         int xerrno = errno;
@@ -172,12 +173,12 @@ Icmp6::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     debugs(42, 5, "Send Icmp6 packet to " << to << ".");
 
-    x = sendto(icmp_sock,
-               (const void *) pkt,
-               icmp6_pktsize,
-               0,
-               S->ai_addr,
-               S->ai_addrlen);
+    x = xsendto(icmp_sock,
+                pkt,
+                icmp6_pktsize,
+                0,
+                S->ai_addr,
+                S->ai_addrlen);
 
     if (x < 0) {
         int xerrno = errno;
@@ -215,12 +216,12 @@ Icmp6::Recv(void)
 
     Ip::Address::InitAddr(from);
 
-    n = recvfrom(icmp_sock,
-                 (void *)pkt,
-                 MAX_PKT6_SZ,
-                 0,
-                 from->ai_addr,
-                 &from->ai_addrlen);
+    n = xrecvfrom(icmp_sock,
+                  pkt,
+                  MAX_PKT6_SZ,
+                  0,
+                  from->ai_addr,
+                  &from->ai_addrlen);
 
     if (n <= 0) {
         debugs(42, DBG_CRITICAL, "ERROR: when calling recvfrom() on ICMPv6 socket.");

--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -14,6 +14,8 @@
 
 #if USE_ICMP
 
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "debug/Stream.h"
 #include "Icmp4.h"
 #include "Icmp6.h"
@@ -65,26 +67,26 @@ IcmpPinger::Open(void)
 
     setmode(0, O_BINARY);
     setmode(1, O_BINARY);
-    x = read(0, buf, sizeof(wpi));
+    x = xread(0, buf, sizeof(wpi));
 
     if (x < (int)sizeof(wpi)) {
         xerrno = errno;
         getCurrentTime();
         debugs(42, DBG_CRITICAL, MYNAME << " read: FD 0: " << xstrerr(xerrno));
-        write(1, "ERR\n", 4);
+        xwrite(1, "ERR\n", 4);
         return -1;
     }
 
     memcpy(&wpi, buf, sizeof(wpi));
 
-    write(1, "OK\n", 3);
-    x = read(0, buf, sizeof(PS));
+    xwrite(1, "OK\n", 3);
+    x = xread(0, buf, sizeof(PS));
 
     if (x < (int)sizeof(PS)) {
         xerrno = errno;
         getCurrentTime();
         debugs(42, DBG_CRITICAL, MYNAME << " read: FD 0: " << xstrerr(xerrno));
-        write(1, "ERR\n", 4);
+        xwrite(1, "ERR\n", 4);
         return -1;
     }
 
@@ -96,23 +98,23 @@ IcmpPinger::Open(void)
         xerrno = errno;
         getCurrentTime();
         debugs(42, DBG_CRITICAL, MYNAME << "WSASocket: " << xstrerr(xerrno));
-        write(1, "ERR\n", 4);
+        xwrite(1, "ERR\n", 4);
         return -1;
     }
 
-    x = connect(icmp_sock, (struct sockaddr *) &PS, sizeof(PS));
+    x = xconnect(icmp_sock, (struct sockaddr *) &PS, sizeof(PS));
 
-    if (SOCKET_ERROR == x) {
+    if (x != 0) {
         xerrno = errno;
         getCurrentTime();
         debugs(42, DBG_CRITICAL, MYNAME << "connect: " << xstrerr(xerrno));
-        write(1, "ERR\n", 4);
+        xwrite(1, "ERR\n", 4);
         return -1;
     }
 
-    write(1, "OK\n", 3);
+    xwrite(1, "OK\n", 3);
     memset(buf, 0, sizeof(buf));
-    x = recv(icmp_sock, (void *) buf, sizeof(buf), 0);
+    x = xrecv(icmp_sock, buf, sizeof(buf), 0);
 
     if (x < 3) {
         xerrno = errno;
@@ -120,7 +122,7 @@ IcmpPinger::Open(void)
         return -1;
     }
 
-    x = send(icmp_sock, (const void *) buf, strlen(buf), 0);
+    x = xsend(icmp_sock, buf, strlen(buf), 0);
     xerrno = errno;
 
     if (x < 3 || strncmp("OK\n", buf, 3)) {
@@ -152,7 +154,7 @@ IcmpPinger::Close(void)
 #if _SQUID_WINDOWS_
 
     shutdown(icmp_sock, SD_BOTH);
-    close(icmp_sock);
+    xclose(icmp_sock);
     icmp_sock = -1;
 #endif
 
@@ -169,7 +171,7 @@ IcmpPinger::Recv(void)
     int guess_size;
 
     pecho = pingerEchoData();
-    n = recv(socket_from_squid, &pecho, sizeof(pecho), 0);
+    n = xrecv(socket_from_squid, &pecho, sizeof(pecho), 0);
 
     if (n < 0) {
         debugs(42, DBG_IMPORTANT, "Pinger exiting.");
@@ -219,7 +221,7 @@ IcmpPinger::SendResult(pingerReplyData &preply, int len)
 {
     debugs(42, 2, "return result to squid. len=" << len);
 
-    if (send(socket_to_squid, &preply, len, 0) < 0) {
+    if (xsend(socket_to_squid, &preply, len, 0) < 0) {
         int xerrno = errno;
         debugs(42, DBG_CRITICAL, "FATAL: send failure: " << xstrerr(xerrno));
         Close();

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "comm.h"
 #include "comm/Loops.h"
+#include "compat/socket.h"
 #include "defines.h"
 #include "fd.h"
 #include "icmp/IcmpConfig.h"
@@ -262,7 +263,7 @@ IcmpSquid::Close(void)
 
 #if _SQUID_WINDOWS_
 
-    send(icmp_sock, (const void *) "$shutdown\n", 10, 0);
+    xsend(icmp_sock, (const void *) "$shutdown\n", 10, 0);
 
 #endif
 

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -13,6 +13,8 @@
 
 #include "squid.h"
 #include "comm/Connection.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "fde.h"
 #include "ip/Intercept.h"
 #include "ip/tools.h"
@@ -75,7 +77,6 @@
 #endif /* IPF_TRANSPARENT required headers */
 
 #if PF_TRANSPARENT
-#include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <sys/fcntl.h>
 #include <net/if.h>
@@ -130,11 +131,11 @@ Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn)
 
     /** \par
      * Try NAT lookup for REDIRECT or DNAT targets. */
-    if ( getsockopt(newConn->fd,
-                    newConn->local.isIPv6() ? IPPROTO_IPV6 : IPPROTO_IP,
-                    newConn->local.isIPv6() ? IP6T_SO_ORIGINAL_DST : SO_ORIGINAL_DST,
-                    &lookup,
-                    &len) != 0) {
+    if ( xgetsockopt(newConn->fd,
+                     newConn->local.isIPv6() ? IPPROTO_IPV6 : IPPROTO_IP,
+                     newConn->local.isIPv6() ? IP6T_SO_ORIGINAL_DST : SO_ORIGINAL_DST,
+                     &lookup,
+                     &len) != 0) {
         const auto xerrno = errno;
         debugs(89, DBG_IMPORTANT, "ERROR: NF getsockopt(ORIGINAL_DST) failed on " << newConn << ": " << xstrerr(xerrno));
         return false;
@@ -250,9 +251,9 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
         int save_errno;
         enter_suid();
 #ifdef IPNAT_NAME
-        natfd = open(IPNAT_NAME, O_RDONLY, 0);
+        natfd = xopen(IPNAT_NAME, O_RDONLY, 0);
 #else
-        natfd = open(IPL_NAT, O_RDONLY, 0);
+        natfd = xopen(IPL_NAT, O_RDONLY, 0);
 #endif
         save_errno = errno;
         leave_suid();
@@ -295,7 +296,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
         const auto xerrno = errno;
         if (xerrno != ESRCH) {
             debugs(89, DBG_IMPORTANT, "ERROR: IPF (IPFilter) NAT lookup failed: ioctl(SIOCGNATL) (v=" << IPFILTER_VERSION << "): " << xstrerr(xerrno));
-            close(natfd);
+            xclose(natfd);
             natfd = -1;
         }
 
@@ -335,7 +336,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
     static int pffd = -1;
 
     if (pffd < 0)
-        pffd = open("/dev/pf", O_RDONLY);
+        pffd = xopen("/dev/pf", O_RDONLY);
 
     if (pffd < 0) {
         const auto xerrno = errno;
@@ -365,7 +366,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
         const auto xerrno = errno;
         if (xerrno != ENOENT) {
             debugs(89, DBG_IMPORTANT, "ERROR: PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
-            close(pffd);
+            xclose(pffd);
             pffd = -1;
         }
         debugs(89, 9, "address: " << newConn);
@@ -443,18 +444,18 @@ Ip::Intercept::ProbeForTproxy(Ip::Address &test)
         tmp.port(0);
         tmp.getSockAddr(tmp_ip6);
 
-        if ( (tmp_sock = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP)) >= 0 &&
-                setsockopt(tmp_sock, soLevel, soFlag, (char *)&tos, sizeof(int)) == 0 &&
-                bind(tmp_sock, (struct sockaddr*)&tmp_ip6, sizeof(struct sockaddr_in6)) == 0 ) {
+        if ( (tmp_sock = xsocket(PF_INET6, SOCK_STREAM, IPPROTO_TCP)) >= 0 &&
+                xsetsockopt(tmp_sock, soLevel, soFlag, &tos, sizeof(int)) == 0 &&
+                xbind(tmp_sock, (struct sockaddr*)&tmp_ip6, sizeof(struct sockaddr_in6)) == 0 ) {
 
             debugs(3, 3, "IPv6 TPROXY support detected. Using.");
-            close(tmp_sock);
+            xclose(tmp_sock);
             if (doneSuid)
                 leave_suid();
             return true;
         }
         if (tmp_sock >= 0) {
-            close(tmp_sock);
+            xclose(tmp_sock);
             tmp_sock = -1;
         }
     }
@@ -475,18 +476,18 @@ Ip::Intercept::ProbeForTproxy(Ip::Address &test)
         tmp.port(0);
         tmp.getSockAddr(tmp_ip4);
 
-        if ( (tmp_sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) >= 0 &&
-                setsockopt(tmp_sock, soLevel, soFlag, (char *)&tos, sizeof(int)) == 0 &&
-                bind(tmp_sock, (struct sockaddr*)&tmp_ip4, sizeof(struct sockaddr_in)) == 0 ) {
+        if ( (tmp_sock = xsocket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) >= 0 &&
+                xsetsockopt(tmp_sock, soLevel, soFlag, &tos, sizeof(int)) == 0 &&
+                xbind(tmp_sock, (struct sockaddr*)&tmp_ip4, sizeof(struct sockaddr_in)) == 0 ) {
 
             debugs(3, 3, "IPv4 TPROXY support detected. Using.");
-            close(tmp_sock);
+            xclose(tmp_sock);
             if (doneSuid)
                 leave_suid();
             return true;
         }
         if (tmp_sock >= 0) {
-            close(tmp_sock);
+            xclose(tmp_sock);
         }
     }
 

--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -11,6 +11,8 @@
 #include "squid.h"
 #include "comm/Connection.h"
 #include "compat/pipe.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "fd.h"
 #include "fde.h"
 #include "globals.h"
@@ -24,10 +26,6 @@
 #include <chrono>
 #include <thread>
 #include <cstdlib>
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 static const char *hello_string = "hi there\n";
 #ifndef HELLO_BUF_SZ
@@ -165,22 +163,22 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
         }
 
         errno = 0;
-        if (setsockopt(fds[0], SOL_SOCKET, SO_SNDBUF, (void *) &buflen, sizeof(buflen)) == -1)  {
+        if (xsetsockopt(fds[0], SOL_SOCKET, SO_SNDBUF, &buflen, sizeof(buflen)) == -1)  {
             xerrno = errno;
             debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
         }
-        if (setsockopt(fds[0], SOL_SOCKET, SO_RCVBUF, (void *) &buflen, sizeof(buflen)) == -1) {
+        if (xsetsockopt(fds[0], SOL_SOCKET, SO_RCVBUF, &buflen, sizeof(buflen)) == -1) {
             xerrno = errno;
             debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
         }
-        if (setsockopt(fds[1], SOL_SOCKET, SO_SNDBUF, (void *) &buflen, sizeof(buflen)) == -1) {
+        if (xsetsockopt(fds[1], SOL_SOCKET, SO_SNDBUF, &buflen, sizeof(buflen)) == -1) {
             xerrno = errno;
             debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
         }
-        if (setsockopt(fds[1], SOL_SOCKET, SO_RCVBUF, (void *) &buflen, sizeof(buflen)) == -1) {
+        if (xsetsockopt(fds[1], SOL_SOCKET, SO_RCVBUF, &buflen, sizeof(buflen)) == -1) {
             xerrno = errno;
             debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
@@ -218,7 +216,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     if (type == IPC_TCP_SOCKET || type == IPC_UDP_SOCKET) {
         Ip::Address::InitAddr(AI);
 
-        if (getsockname(pwfd, AI->ai_addr, &AI->ai_addrlen) < 0) {
+        if (xgetsockname(pwfd, AI->ai_addr, &AI->ai_addrlen) < 0) {
             xerrno = errno;
             Ip::Address::FreeAddr(AI);
             debugs(54, DBG_CRITICAL, "ipcCreate: getsockname: " << xstrerr(xerrno));
@@ -233,7 +231,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
         Ip::Address::InitAddr(AI);
 
-        if (getsockname(crfd, AI->ai_addr, &AI->ai_addrlen) < 0) {
+        if (xgetsockname(crfd, AI->ai_addr, &AI->ai_addrlen) < 0) {
             xerrno = errno;
             Ip::Address::FreeAddr(AI);
             debugs(54, DBG_CRITICAL, "ipcCreate: getsockname: " << xstrerr(xerrno));
@@ -249,7 +247,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     }
 
     if (type == IPC_TCP_SOCKET) {
-        if (listen(crfd, 1) < 0) {
+        if (xlisten(crfd, 1) < 0) {
             xerrno = errno;
             debugs(54, DBG_IMPORTANT, "ipcCreate: listen FD " << crfd << ": " << xstrerr(xerrno));
             return ipcCloseAllFD(prfd, pwfd, crfd, cwfd);
@@ -284,7 +282,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
         if (type == IPC_UDP_SOCKET)
             x = comm_udp_recv(prfd, hello_buf, sizeof(hello_buf)-1, 0);
         else
-            x = read(prfd, hello_buf, sizeof(hello_buf)-1);
+            x = xread(prfd, hello_buf, sizeof(hello_buf)-1);
         xerrno = errno;
         if (x >= 0)
             hello_buf[x] = '\0';
@@ -325,24 +323,24 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     no_suid();          /* give up extra privileges */
 
     /* close shared socket with parent */
-    close(prfd);
+    xclose(prfd);
 
     if (pwfd != prfd)
-        close(pwfd);
+        xclose(pwfd);
 
     pwfd = prfd = -1;
 
     if (type == IPC_TCP_SOCKET) {
         debugs(54, 3, "ipcCreate: calling accept on FD " << crfd);
 
-        if ((fd = accept(crfd, nullptr, nullptr)) < 0) {
+        if ((fd = xaccept(crfd, nullptr, nullptr)) < 0) {
             xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: FD " << crfd << " accept: " << xstrerr(xerrno));
             _exit(1);
         }
 
         debugs(54, 3, "ipcCreate: CHILD accepted new FD " << fd);
-        close(crfd);
+        xclose(crfd);
         cwfd = crfd = fd;
     } else if (type == IPC_UDP_SOCKET) {
         if (comm_connect_addr(crfd, PaS) == Comm::COMM_ERROR)
@@ -359,7 +357,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
             _exit(1);
         }
     } else {
-        if (write(cwfd, hello_string, strlen(hello_string) + 1) < 0) {
+        if (xwrite(cwfd, hello_string, strlen(hello_string) + 1) < 0) {
             xerrno = errno;
             debugs(54, DBG_CRITICAL, "write FD " << cwfd << ": " << xstrerr(xerrno));
             debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: hello write test failed");
@@ -394,7 +392,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
         x = dupOrExit(crfd);
     } while (x < 3);
 
-    close(x);
+    xclose(x);
 
     t1 = dupOrExit(crfd);
 
@@ -404,11 +402,11 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
     assert(t1 > 2 && t2 > 2 && t3 > 2);
 
-    close(crfd);
+    xclose(crfd);
 
-    close(cwfd);
+    xclose(cwfd);
 
-    close(fileno(DebugStream()));
+    xclose(fileno(DebugStream()));
 
     dup2(t1, 0);
 
@@ -416,15 +414,15 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
     dup2(t3, 2);
 
-    close(t1);
+    xclose(t1);
 
-    close(t2);
+    xclose(t2);
 
-    close(t3);
+    xclose(t3);
 
     /* Make sure all other filedescriptors are closed */
     for (x = 3; x < SQUID_MAXFD; ++x)
-        close(x);
+        xclose(x);
 
 #if HAVE_SETSID
     if (opt_no_daemon)

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -14,6 +14,7 @@
 #include "CacheManager.h"
 #include "comm.h"
 #include "comm/Connection.h"
+#include "compat/unistd.h"
 #include "ipc/Coordinator.h"
 #include "ipc/SharedListen.h"
 #include "mgr/Inquirer.h"
@@ -27,6 +28,10 @@
 #endif
 
 #include <cerrno>
+
+#if HAVE_SYS_UNISTD_H
+#include <sys/unistd.h>
+#endif
 
 CBDATA_NAMESPACED_CLASS_INIT(Ipc, Coordinator);
 Ipc::Coordinator* Ipc::Coordinator::TheInstance = nullptr;
@@ -176,7 +181,7 @@ Ipc::Coordinator::handleCacheMgrRequest(const Mgr::Request& request)
         debugs(54, DBG_IMPORTANT, "ERROR: Squid BUG: cannot aggregate mgr:" <<
                request.params.actionName << ": " << ex.what());
         // TODO: Avoid half-baked Connections or teach them how to close.
-        ::close(request.conn->fd);
+        xclose(request.conn->fd);
         request.conn->fd = -1;
         return; // the worker will timeout and close
     }

--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -14,6 +14,7 @@
 #include "comm/Connection.h"
 #include "comm/Write.h"
 #include "CommCalls.h"
+#include "compat/socket.h"
 #include "ipc/UdsOp.h"
 
 Ipc::UdsOp::UdsOp(const String& pathAddr):
@@ -195,7 +196,7 @@ Ipc::ImportFdIntoComm(const Comm::ConnectionPointer &conn, int socktype, int pro
 {
     struct sockaddr_storage addr;
     socklen_t len = sizeof(addr);
-    if (getsockname(conn->fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
+    if (xgetsockname(conn->fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
         conn->remote = addr;
         struct addrinfo* addr_info = nullptr;
         conn->remote.getAddrInfo(addr_info);

--- a/src/ipc/mem/Segment.cc
+++ b/src/ipc/mem/Segment.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "base/TextException.h"
 #include "compat/shm.h"
+#include "compat/unistd.h"
 #include "debug/Stream.h"
 #include "fatal.h"
 #include "Instance.h"
@@ -27,9 +28,6 @@
 #endif
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
-#endif
-#if HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 
 // test cases change this
@@ -70,7 +68,7 @@ Ipc::Mem::Segment::~Segment()
 {
     if (theFD >= 0) {
         detach();
-        if (close(theFD) != 0) {
+        if (xclose(theFD) != 0) {
             int xerrno = errno;
             debugs(54, 5, "close " << theName << ": " << xstrerr(xerrno));
         }

--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -12,6 +12,8 @@
 #include "cache_cf.h"
 #include "comm.h"
 #include "comm/Connection.h"
+#include "compat/socket.h"
+#include "compat/unistd.h"
 #include "fd.h"
 #include "fde.h"
 #include "globals.h"
@@ -184,7 +186,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
         Ip::Address::InitAddr(aiPS);
 
-        if (getsockname(pwfd, aiPS->ai_addr, &(aiPS->ai_addrlen) ) < 0) {
+        if (xgetsockname(pwfd, aiPS->ai_addr, &(aiPS->ai_addrlen) ) < 0) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: getsockname: " << xstrerr(xerrno));
             Ip::Address::FreeAddr(aiPS);
@@ -198,7 +200,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
         Ip::Address::InitAddr(aiCS);
 
-        if (getsockname(crfd, aiCS->ai_addr, &(aiCS->ai_addrlen) ) < 0) {
+        if (xgetsockname(crfd, aiCS->ai_addr, &(aiCS->ai_addrlen) ) < 0) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: getsockname: " << xstrerr(xerrno));
             Ip::Address::FreeAddr(aiCS);
@@ -213,7 +215,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     }
 
     if (type == IPC_TCP_SOCKET) {
-        if (listen(crfd, 1) < 0) {
+        if (xlisten(crfd, 1) < 0) {
             int xerrno = errno;
             debugs(54, DBG_IMPORTANT, "ipcCreate: listen FD " << crfd << ": " << xstrerr(xerrno));
             return ipcCloseAllFD(prfd, pwfd, crfd, cwfd);
@@ -254,7 +256,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     }
 
     memset(hello_buf, '\0', HELLO_BUF_SZ);
-    x = recv(prfd, (void *)hello_buf, HELLO_BUF_SZ - 1, 0);
+    x = xrecv(prfd, (void *)hello_buf, HELLO_BUF_SZ - 1, 0);
 
     if (x < 0) {
         int xerrno = errno;
@@ -270,7 +272,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
         return ipcCloseAllFD(prfd, pwfd, -1, -1);
     }
 
-    x = send(pwfd, (const void *)ok_string, strlen(ok_string), 0);
+    x = xsend(pwfd, ok_string, strlen(ok_string), 0);
 
     if (x < 0) {
         int xerrno = errno;
@@ -281,7 +283,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     }
 
     memset(hello_buf, '\0', HELLO_BUF_SZ);
-    x = recv(prfd, (void *)hello_buf, HELLO_BUF_SZ - 1, 0);
+    x = xrecv(prfd, (void *)hello_buf, HELLO_BUF_SZ - 1, 0);
 
     if (x < 0) {
         int xerrno = errno;
@@ -333,7 +335,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 static int
 ipcSend(int cwfd, const char *buf, int len)
 {
-    int x = send(cwfd, (const void *)buf, len, 0);
+    const auto x = xsend(cwfd, buf, len, 0);
 
     if (x < 0) {
         int xerrno = errno;
@@ -393,7 +395,7 @@ ipc_thread_1(void *in_params)
     if (type == IPC_TCP_SOCKET) {
         debugs(54, 3, "ipcCreate: calling accept on FD " << crfd);
 
-        if ((fd = accept(crfd, nullptr, nullptr)) < 0) {
+        if ((fd = xaccept(crfd, nullptr, nullptr)) < 0) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: FD " << crfd << " accept: " << xstrerr(xerrno));
             goto cleanup;
@@ -410,7 +412,7 @@ ipc_thread_1(void *in_params)
             goto cleanup;
     }
 
-    x = send(cwfd, (const void *)hello_string, strlen(hello_string) + 1, 0);
+    x = xsend(cwfd, hello_string, strlen(hello_string) + 1, 0);
 
     if (x < 0) {
         int xerrno = errno;
@@ -421,7 +423,7 @@ ipc_thread_1(void *in_params)
 
     PutEnvironment();
     memset(buf1, '\0', bufSz);
-    x = recv(crfd, (void *)buf1, bufSz-1, 0);
+    x = xrecv(crfd, (void *)buf1, bufSz-1, 0);
 
     if (x < 0) {
         int xerrno = errno;
@@ -471,7 +473,7 @@ ipc_thread_1(void *in_params)
 
         Ip::Address::InitAddr(aiPS_ipc);
 
-        if (getsockname(pwfd_ipc, aiPS_ipc->ai_addr, &(aiPS_ipc->ai_addrlen)) < 0) {
+        if (xgetsockname(pwfd_ipc, aiPS_ipc->ai_addr, &(aiPS_ipc->ai_addrlen)) < 0) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: getsockname: " << xstrerr(xerrno));
             ipcSend(cwfd, err_string, strlen(err_string));
@@ -486,7 +488,7 @@ ipc_thread_1(void *in_params)
 
         Ip::Address::InitAddr(aiCS_ipc);
 
-        if (getsockname(crfd_ipc, aiCS_ipc->ai_addr, &(aiCS_ipc->ai_addrlen)) < 0) {
+        if (xgetsockname(crfd_ipc, aiCS_ipc->ai_addr, &(aiCS_ipc->ai_addrlen)) < 0) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: getsockname: " << xstrerr(xerrno));
             ipcSend(cwfd, err_string, strlen(err_string));
@@ -602,7 +604,7 @@ ipc_thread_1(void *in_params)
             goto cleanup;
         }
 
-        x = write(c2p[1], (const char *) &wpi, sizeof(wpi));
+        x = xwrite(c2p[1], (const char *) &wpi, sizeof(wpi));
 
         if (x < (ssize_t)sizeof(wpi)) {
             int xerrno = errno;
@@ -612,7 +614,7 @@ ipc_thread_1(void *in_params)
             goto cleanup;
         }
 
-        x = read(p2c[0], buf1, bufSz-1);
+        x = xread(p2c[0], buf1, bufSz-1);
 
         if (x < 0) {
             int xerrno = errno;
@@ -629,7 +631,7 @@ ipc_thread_1(void *in_params)
             goto cleanup;
         }
 
-        x = write(c2p[1], (const char *) &PS_ipc, sizeof(PS_ipc));
+        x = xwrite(c2p[1], (const char *) &PS_ipc, sizeof(PS_ipc));
 
         if (x < (ssize_t)sizeof(PS_ipc)) {
             int xerrno = errno;
@@ -639,7 +641,7 @@ ipc_thread_1(void *in_params)
             goto cleanup;
         }
 
-        x = read(p2c[0], buf1, bufSz-1);
+        x = xread(p2c[0], buf1, bufSz-1);
 
         if (x < 0) {
             int xerrno = errno;
@@ -656,8 +658,8 @@ ipc_thread_1(void *in_params)
             goto cleanup;
         }
 
-        x = send(pwfd_ipc, (const void *)ok_string, strlen(ok_string), 0);
-        x = recv(prfd_ipc, (void *)(buf1 + 200), bufSz -1 - 200, 0);
+        x = xsend(pwfd_ipc, ok_string, strlen(ok_string), 0);
+        x = xrecv(prfd_ipc, (void *)(buf1 + 200), bufSz -1 - 200, 0);
         assert((size_t) x == strlen(ok_string)
                && !strncmp(ok_string, buf1 + 200, strlen(ok_string)));
     }               /* IPC_UDP_SOCKET */
@@ -705,7 +707,7 @@ ipc_thread_1(void *in_params)
 
     /* cycle */
     for (;;) {
-        x = recv(crfd, (void *)buf1, bufSz-1, 0);
+        x = xrecv(crfd, (void *)buf1, bufSz-1, 0);
 
         if (x <= 0) {
             debugs(54, 3, "ipc(" << prog << "," << pid << "): " << x << " bytes received from parent. Exiting...");
@@ -724,9 +726,9 @@ ipc_thread_1(void *in_params)
         debugs(54, 5, "ipc(" << prog << "," << pid << "): received from parent: " << rfc1738_escape_unescaped(buf1));
 
         if (type == IPC_TCP_SOCKET)
-            x = write(c2p[1], buf1, x);
+            x = xwrite(c2p[1], buf1, x);
         else
-            x = send(pwfd_ipc, (const void *)buf1, x, 0);
+            x = xsend(pwfd_ipc, buf1, x, 0);
 
         if (x <= 0) {
             debugs(54, 3, "ipc(" << prog << "," << pid << "): " << x << " bytes written to " << prog << ". Exiting...");
@@ -746,7 +748,7 @@ cleanup:
         ipcCloseAllFD(-1, -1, crfd, cwfd);
 
     if (prfd_ipc != -1) {
-        send(crfd_ipc, (const void *)shutdown_string, strlen(shutdown_string), 0);
+        xsend(crfd_ipc, shutdown_string, strlen(shutdown_string), 0);
         shutdown(crfd_ipc, SD_BOTH);
         shutdown(prfd_ipc, SD_BOTH);
     }
@@ -804,9 +806,9 @@ ipc_thread_2(void *in_params)
 
     for (;;) {
         if (type == IPC_TCP_SOCKET)
-            x = read(rfd, buf2, bufSz-1);
+            x = xread(rfd, buf2, bufSz-1);
         else
-            x = recv(rfd, (void *)buf2, bufSz-1, 0);
+            x = xrecv(rfd, (void *)buf2, bufSz-1, 0);
 
         if ((x <= 0 && type == IPC_TCP_SOCKET) ||
                 (x < 0 && type == IPC_UDP_SOCKET)) {
@@ -832,7 +834,7 @@ ipc_thread_2(void *in_params)
 
         debugs(54, 5, "ipc(" << prog << "," << pid << "): received from child : " << rfc1738_escape_unescaped(buf2));
 
-        x = send(send_fd, (const void *)buf2, x, 0);
+        x = xsend(send_fd, buf2, x, 0);
 
         if ((x <= 0 && type == IPC_TCP_SOCKET) ||
                 (x < 0 && type == IPC_UDP_SOCKET)) {

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "comm.h"
 #include "comm/Connection.h"
+#include "compat/unistd.h"
 #include "fatal.h"
 #include "fd.h"
 #include "fs_io.h"
@@ -40,8 +41,7 @@ static void
 logfile_mod_udp_write(Logfile * lf, const char *buf, size_t len)
 {
     l_udp_t *ll = (l_udp_t *) lf->data;
-    ssize_t s;
-    s = write(ll->fd, (char const *) buf, len);
+    const auto s = xwrite(ll->fd, buf, len);
     fd_bytes(ll->fd, s, IoDirection::Write);
 #if 0
     // TODO: Enable after polishing to properly log these errors.

--- a/src/log/file/log_file_daemon.cc
+++ b/src/log/file/log_file_daemon.cc
@@ -8,13 +8,12 @@
 
 #include "squid.h"
 
+#include "compat/unistd.h"
+
 #include <cassert>
 #include <cerrno>
 #include <csignal>
 #include <cstring>
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 #if HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
@@ -112,8 +111,8 @@ main(int argc, char *argv[])
     /* XXX stderr should not be closed, but in order to support squid must be
      * able to collect and manage modules' stderr first.
      */
-    close(2);
-    t = open(_PATH_DEVNULL, O_RDWR);
+    xclose(2);
+    t = xopen(_PATH_DEVNULL, O_RDWR);
     assert(t > -1);
     dup2(t, 2);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -25,6 +25,7 @@
 #include "client_side.h"
 #include "comm.h"
 #include "CommandLine.h"
+#include "compat/unistd.h"
 #include "ConfigParser.h"
 #include "CpuAffinity.h"
 #include "debug/Messages.h"
@@ -1857,10 +1858,7 @@ watch_child(const CommandLine &masterCommand)
     pid_t pid;
 #ifdef TIOCNOTTY
 
-    int i;
 #endif
-
-    int nullfd;
 
     // TODO: zero values are not supported because they result in
     // misconfigured SMP Squid instances running forever, endlessly
@@ -1879,7 +1877,7 @@ watch_child(const CommandLine &masterCommand)
 
 #ifdef TIOCNOTTY
 
-    if ((i = open("/dev/tty", O_RDWR | O_TEXT)) >= 0) {
+    if ((const auto i = xopen("/dev/tty", O_RDWR | O_TEXT)) >= 0) {
         ioctl(i, TIOCNOTTY, nullptr);
         close(i);
     }
@@ -1892,7 +1890,7 @@ watch_child(const CommandLine &masterCommand)
      * 1.1.3.  execvp had a bit overflow error in a loop..
      */
     /* Connect stdio to /dev/null in daemon mode */
-    nullfd = open(_PATH_DEVNULL, O_RDWR | O_TEXT);
+    const auto nullfd = xopen(_PATH_DEVNULL, O_RDWR | O_TEXT);
 
     if (nullfd < 0) {
         int xerrno = errno;

--- a/src/mgr/Action.cc
+++ b/src/mgr/Action.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "CacheManager.h"
 #include "comm/Connection.h"
+#include "compat/unistd.h"
 #include "HttpReply.h"
 #include "ipc/Port.h"
 #include "mgr/Action.h"
@@ -91,7 +92,7 @@ Mgr::Action::respond(const Request &request)
     // Assume most kid classes are fully aggregatable (i.e., they do not dump
     // local info at all). Do not import the remote HTTP fd into our Comm
     // space; collect and send an IPC msg with collected info to Coordinator.
-    ::close(request.conn->fd);
+    xclose(request.conn->fd);
     request.conn->fd = -1;
     collect();
     sendResponse(request.requestId);

--- a/src/multicast.cc
+++ b/src/multicast.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "comm/Connection.h"
+#include "compat/socket.h"
 #include "debug/Stream.h"
 // XXX: for icpIncomingConn - need to pass it as a generic parameter.
 #include "ICP.h"
@@ -22,7 +23,7 @@ mcastSetTtl(int fd, int mcast_ttl)
 #ifdef IP_MULTICAST_TTL
     char ttl = (char) mcast_ttl;
 
-    if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, 1) < 0) {
+    if (xsetsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, 1) < 0) {
         int xerrno = errno;
         debugs(50, DBG_IMPORTANT, "mcastSetTtl: FD " << fd << ", TTL: " << mcast_ttl << ": " << xstrerr(xerrno));
     }
@@ -54,11 +55,11 @@ mcastJoinGroups(const ipcache_addrs *ia, const Dns::LookupDetails &, void *)
 
         mr.imr_interface.s_addr = INADDR_ANY;
 
-        if (setsockopt(icpIncomingConn->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *) &mr, sizeof(struct ip_mreq)) < 0)
+        if (xsetsockopt(icpIncomingConn->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mr, sizeof(struct ip_mreq)) < 0)
             debugs(7, DBG_IMPORTANT, "ERROR: Join failed for " << icpIncomingConn << ", Multicast IP=" << ip);
 
         char c = 0;
-        if (setsockopt(icpIncomingConn->fd, IPPROTO_IP, IP_MULTICAST_LOOP, &c, 1) < 0) {
+        if (xsetsockopt(icpIncomingConn->fd, IPPROTO_IP, IP_MULTICAST_LOOP, &c, 1) < 0) {
             int xerrno = errno;
             debugs(7, DBG_IMPORTANT, "ERROR: " << icpIncomingConn << " can't disable multicast loopback: " << xstrerr(xerrno));
         }

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -20,6 +20,7 @@
 #include "CachePeers.h"
 #include "comm/Connection.h"
 #include "comm/ConnOpener.h"
+#include "compat/netdb.h"
 #include "debug/Messages.h"
 #include "event.h"
 #include "FwdState.h"
@@ -503,7 +504,6 @@ neighborsRegisterWithCacheManager()
 void
 neighbors_init(void)
 {
-    struct servent *sep = nullptr;
     const char *me = getMyHostname();
 
     neighborsRegisterWithCacheManager();
@@ -536,7 +536,7 @@ neighbors_init(void)
 
     peerDnsRefreshStart();
 
-    sep = getservbyname("echo", "udp");
+    const auto sep = xgetservbyname("echo", "udp");
     echo_port = sep ? ntohs((unsigned short) sep->s_port) : 7;
 }
 

--- a/src/security/cert_generators/file/certificate_db.cc
+++ b/src/security/cert_generators/file/certificate_db.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "base/HardFun.h"
 #include "base/TextException.h"
+#include "compat/unistd.h"
 #include "sbuf/Stream.h"
 #include "security/cert_generators/file/certificate_db.h"
 
@@ -52,7 +53,7 @@ void Ssl::Lock::lock()
     hFile = CreateFile(TEXT(filename.c_str()), GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (hFile == INVALID_HANDLE_VALUE)
 #else
-    fd = open(filename.c_str(), O_RDWR);
+    fd = xopen(filename.c_str(), O_RDWR);
     if (fd == -1)
 #endif
         throw TextException(ToSBuf("Failed to open file ", filename), Here());
@@ -82,7 +83,7 @@ void Ssl::Lock::unlock()
 #else
         flock(fd, LOCK_UN);
 #endif
-        close(fd);
+        xclose(fd);
         fd = -1;
     }
 #endif

--- a/src/tests/testIpAddress.cc
+++ b/src/tests/testIpAddress.cc
@@ -8,6 +8,7 @@
 
 #include "squid.h"
 #include "compat/cppunit.h"
+#include "compat/netdb.h"
 #include "ip/Address.h"
 #include "ip/tools.h"
 #include "unitTestMain.h"
@@ -20,9 +21,6 @@
 #endif
 #if HAVE_ARPA_INET_H
 #include <arpa/inet.h>
-#endif
-#if HAVE_NETDB_H
-#include <netdb.h>
 #endif
 
 /*
@@ -235,13 +233,12 @@ TestIpAddress::testCopyConstructor()
 void
 TestIpAddress::testHostentConstructor()
 {
-    struct hostent *hp = nullptr;
     struct in_addr outval;
     struct in_addr expectval;
 
     expectval.s_addr = htonl(0xC0A8640C);
 
-    hp = gethostbyname("192.168.100.12");
+    const auto hp = xgethostbyname("192.168.100.12");
     CPPUNIT_ASSERT( hp != nullptr /* gethostbyname failure.*/ );
 
     Ip::Address anIPA(*hp);

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -12,6 +12,7 @@
 #include "anyp/PortCfg.h"
 #include "base/Subscription.h"
 #include "client_side.h"
+#include "compat/unistd.h"
 #include "fatal.h"
 #include "fde.h"
 #include "fqdncache.h"
@@ -508,7 +509,7 @@ getMyHostname(void)
     }
 
     // still no host. fallback to gethostname()
-    if (gethostname(host, SQUIDHOSTNAMELEN) < 0) {
+    if (xgethostname(host, SQUIDHOSTNAMELEN) < 0) {
         int xerrno = errno;
         debugs(50, DBG_IMPORTANT, "WARNING: gethostname failed: " << xstrerr(xerrno));
     } else {

--- a/src/unlinkd_daemon.cc
+++ b/src/unlinkd_daemon.cc
@@ -12,6 +12,8 @@
 
 #include "squid.h"
 
+#include "compat/unistd.h"
+
 #include <iostream>
 #include <cstdio>
 #if HAVE_PATHS_H
@@ -53,7 +55,7 @@ main(int, char *[])
 {
     std::string sbuf;
     close(2);
-    if (open(_PATH_DEVNULL, O_RDWR) < 0) {
+    if (xopen(_PATH_DEVNULL, O_RDWR) < 0) {
         ; // the irony of having to close(2) earlier is that we cannot report this failure.
     }
     while (getline(std::cin, sbuf)) {

--- a/src/wccp.cc
+++ b/src/wccp.cc
@@ -15,6 +15,7 @@
 #include "comm.h"
 #include "comm/Connection.h"
 #include "comm/Loops.h"
+#include "compat/socket.h"
 #include "event.h"
 #include "fatal.h"
 #include "SquidConfig.h"
@@ -144,13 +145,13 @@ wccpConnectionOpen(void)
 
     struct sockaddr_in router;
     Config.Wccp.router.getSockAddr(router);
-    if (connect(theWccpConnection, (struct sockaddr*)&router, sizeof(router)))
+    if (xconnect(theWccpConnection, (struct sockaddr*)&router, sizeof(router)))
         fatal("Unable to connect WCCP out socket");
 
     struct sockaddr_in local;
     memset(&local, '\0', sizeof(local));
     socklen_t slen = sizeof(local);
-    if (getsockname(theWccpConnection, (struct sockaddr*)&local, &slen))
+    if (xgetsockname(theWccpConnection, (struct sockaddr*)&local, &slen))
         fatal("Unable to getsockname on WCCP out socket");
 
     local_ip = local;


### PR DESCRIPTION
Detected by Coverity CID 1660785,1660782: Resource leaks (RESOURCE_LEAK)
    
Also fixed Valgrind-reported leaks for:
    
    Ftp::CtrlChannel::last_reply
    ErrorPage::ftp::cwd_msg
    Ftp::DataChannel::host