### PR TITLE
Support suppressions for unused

### DIFF
--- a/test-suite/test-ast-supp-filter.pl
+++ b/test-suite/test-ast-supp-filter.pl
@@ -7,7 +7,10 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# Applies suppressions from xunused.supp to the log produced by xunused tool.
+# Applies suppressions from a suppressions file to the log
+# produced by xunused tool (read from STDIN).
+# Prints not-suppressed lines with unused functions to STDOUT.
+# Prints suppression statistics to STDERR.
 
 use strict;
 use warnings;
@@ -44,6 +47,7 @@ my %linesWithMatches;
 while (<STDIN>) {
     chomp;
     my $line = $_;
+    next if $line !~ /is unused$/;
     $linesWithMatches{$line} = [];
     my $matched = 0;
     foreach my $pattern (@patterns) {

--- a/test-suite/test-ast-supp-filter.pl
+++ b/test-suite/test-ast-supp-filter.pl
@@ -16,7 +16,6 @@ use strict;
 use warnings;
 use IO::Handle;
 
-my $xunusedSupp = $ARGV[0];
 my $tmpDir = $ENV{TMPDIR} || "/tmp";
 my %suppStats;
 my @patterns;
@@ -31,6 +30,7 @@ if (@ARGV != 1) {
 }
 
 sub readSuppressions {
+    my $xunusedSupp = $ARGV[0];
     open(my $xunusedSuppHandle, '<', $xunusedSupp) or die "Cannot open $xunusedSupp: $!";
     while (my $line = <$xunusedSuppHandle>) {
         chomp $line;

--- a/test-suite/test-ast-supp-filter.pl
+++ b/test-suite/test-ast-supp-filter.pl
@@ -1,0 +1,116 @@
+#!/usr/bin/perl
+#
+## Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+# Applies suppressions from xunused.supp to the log produced by xunused tool.
+
+use strict;
+use warnings;
+use IO::Handle;
+
+if (@ARGV != 2) {
+    die "Usage: $0 <xunused-log> <xunused-supp>\n";
+}
+
+my $xunusedLog = $ARGV[0];
+my $xunusedSupp = $ARGV[1];
+my $tmpDir = $ENV{TMPDIR} || "/tmp";
+
+my $xunusedSuppStatLog = "$tmpDir/test-ast-suppressed-stats.txt";
+
+my %suppStats;
+my @patterns;
+
+open(my $xunusedSuppHandle, '<', $xunusedSupp) or die "Cannot open $xunusedSupp: $!";
+
+# Read suppressions
+
+while (my $line = <$xunusedSuppHandle>) {
+    chomp $line;
+    next if $line =~ /^\s*#/;
+    next if $line =~ /^\s*$/;
+    push @patterns, $line;
+    $suppStats{$line} = [];
+}
+
+close($xunusedSuppHandle);
+
+# Collect suppression statistics
+
+open(my $xunusedLogHandle, '<', $xunusedLog) or die "Cannot open $xunusedLog: $!";
+
+my %linesWithMatches;
+
+while (my $line = <$xunusedLogHandle>) {
+    $linesWithMatches{$line} = [];
+    my $matched = 0;
+    foreach my $pattern (@patterns) {
+        if ($line =~ /$pattern/) {
+            $matched++;
+            push @{ $suppStats{$pattern} }, $line;
+            push @{ $linesWithMatches{$line} }, $pattern;
+        }
+    }
+    if ($matched == 0) {
+        print $line;
+    }
+}
+
+close($xunusedLogHandle);
+
+# Apply suppressions, store the suppression statistics
+
+open(my $statsHandle, '>', $xunusedSuppStatLog) or die "Cannot open $xunusedSuppStatLog for writing: $!";
+
+my @notMatchedPatterns;
+
+foreach my $pattern (@patterns) {
+    my $matches = $suppStats{$pattern};
+    my $count = scalar @$matches;
+
+    if ($count > 0) {
+        print $statsHandle "--- Suppression: $pattern (Matches: $count) ---\n";
+        foreach my $line (@$matches) {
+            print $statsHandle "    $line";
+        }
+        print $statsHandle "\n";
+    } else {
+        push @notMatchedPatterns, $pattern;
+    }
+}
+
+my $unmatchedCount = @notMatchedPatterns;
+
+if ($unmatchedCount > 0) {
+    print $statsHandle "--- Suppressions not matched by xunused output: $unmatchedCount ---\n";
+    foreach my $pattern (@notMatchedPatterns) {
+        print $statsHandle "    $pattern\n";
+    }
+    print $statsHandle "\n";
+}
+
+foreach my $line (keys %linesWithMatches) {
+    my $linePatterns = $linesWithMatches{$line};
+    my $count = scalar @$linePatterns;
+    my $printedHeader = 0;
+    if ($count > 1) {
+        if (!$printedHeader) {
+            print $statsHandle "--- Lines matched by multiple suppressions ---\n";
+            $printedHeader = 1;
+        }
+        print $statsHandle "    Line: $line";
+        print $statsHandle "    Patterns ($count):\n";
+        foreach my $pattern (@$linePatterns) {
+            print $statsHandle "        $pattern\n";
+        }
+        print $statsHandle "\n";
+    }
+}
+
+close($statsHandle);
+

--- a/test-suite/test-ast-supp-filter.pl
+++ b/test-suite/test-ast-supp-filter.pl
@@ -21,7 +21,7 @@ my $xunusedLog = $ARGV[0];
 my $xunusedSupp = $ARGV[1];
 my $tmpDir = $ENV{TMPDIR} || "/tmp";
 
-my $xunusedSuppStatLog = "$tmpDir/test-ast-suppressed-stats.txt";
+my $xunusedSuppStatLog = "$tmpDir/test-ast-suppressed-stats.log";
 
 my %suppStats;
 my @patterns;

--- a/test-suite/test-ast-supp-filter.pl
+++ b/test-suite/test-ast-supp-filter.pl
@@ -43,22 +43,28 @@ sub readSuppressions {
 }
 
 sub applySuppressions {
+    my $inSuppressionBlock = 0;
     while (<STDIN>) {
         chomp;
         my $line = $_;
-        next if $line !~ /is unused$/;
+        next if $line =~ /Processing file/;
         $linesWithMatches{$line} = [];
         my $matched = 0;
         foreach my $pattern (@patterns) {
             if ($line =~ /$pattern/) {
+                if ($line =~ /(uses=\d+|is unused)$/) {
+                    $inSuppressionBlock = 1;
+                }
                 $matched++;
                 push @{ $suppStats{$pattern} }, $line;
                 push @{ $linesWithMatches{$line} }, $pattern;
             }
         }
-        if ($matched == 0) {
-            print "$line\n"; # not suppressed lines
-        }
+        next if $matched > 0;
+        next if ($inSuppressionBlock==1 && $line =~ /^([^:\s]+):(\d+): note: (defined|declared|comment starts|definition ends|declaration ends|comment ends) here$/);
+        $inSuppressionBlock = 0;
+
+        print "$line\n"; # not suppressed lines
     }
 }
 

--- a/test-suite/test-ast.sh
+++ b/test-suite/test-ast.sh
@@ -164,7 +164,7 @@ main() {
 
     $suppressionFilter $suppressions <$xunusedLog 1>$suppressedLog 2>$suppressedStatLog || return
 
-    local unusedFunctionCount=`grep -c "is unused$" $suppressedLog`
+    local unusedFunctionCount=$(wc -l <$suppressedLog)
     echo "Unused functions: $unusedFunctionCount"
     if [ "$unusedFunctionCount" -eq 0 ]
     then

--- a/test-suite/test-ast.sh
+++ b/test-suite/test-ast.sh
@@ -27,6 +27,7 @@ xunusedLog=${TMPDIR}/test-ast-xunused.log
 suppressionFilter=./test-suite/test-ast-supp-filter.pl
 suppressions=./test-suite/xunused.supp
 suppressedLog=${TMPDIR}/test-ast-suppressed.log
+suppressedStatLog=${TMPDIR}/test-ast-suppressed-stats.log
 
 customCompileCommands=$1
 defaultCompileCommands=${TMPDIR}/compile_commands.json
@@ -161,7 +162,7 @@ main() {
 
     xunused $compileCommands > $xunusedLog 2>&1 || return
 
-    $suppressionFilter $xunusedLog $suppressions > $suppressedLog || return
+    $suppressionFilter $suppressions <$xunusedLog 1>$suppressedLog 2>$suppressedStatLog || return
 
     local unusedFunctionCount=`grep -c "is unused$" $suppressedLog`
     echo "Unused functions: $unusedFunctionCount"

--- a/test-suite/xunused.supp
+++ b/test-suite/xunused.supp
@@ -1,0 +1,2 @@
+# unused due to hard-coded zero ASYNC_WRITE #define
+DiskThreadsDiskFile::WriteDone

--- a/test-suite/xunused.supp
+++ b/test-suite/xunused.supp
@@ -1,2 +1,2 @@
 # unused due to hard-coded zero ASYNC_WRITE #define
-DiskThreadsDiskFile::WriteDone
+aioWrite

--- a/test-suite/xunused.supp
+++ b/test-suite/xunused.supp
@@ -28,3 +28,9 @@ Helper::Request::operator delete
 Helper::Request::operator new
 MimeIcon::operator delete
 MimeIcon::operator new
+
+# TODO: Use this to delete HeapPolicyData::theHeap
+delete_heap
+
+# May become useful in triage? TODO: Consider deleting.
+ntlm_dump_ntlmssp_flags

--- a/test-suite/xunused.supp
+++ b/test-suite/xunused.supp
@@ -1,2 +1,30 @@
 # unused due to hard-coded zero ASYNC_WRITE #define
 aioWrite
+
+# unused in Squid and used in eCAP adapters (external loadable modules)
+Adaptation::Ecap
+
+# unused on Linux (primarily FreeBSD feature)
+UseInterceptionAddressesLookedUpEarlier
+
+# only used when USE_OPENSSL is off
+MissingLibraryError
+
+# only used if USE_OPENSSL is off and HAVE_LIBGNUTLS is on
+PeerOptions::updateSessionOptions
+
+# Unused functions that belong to CBDATA_CLASS or MEMPROXY_CLASS
+# and thus cannot be removed separately.
+::UseCount
+::finalizedInCbdataChild
+::toCbdata
+CompositePoolNode::operator new
+VectorPool::operator new
+Fs::Ufs::UFSStoreState::_queued_read::operator delete
+Fs::Ufs::UFSStoreState::_queued_read::operator new
+Fs::Ufs::UFSStoreState::_queued_write::operator delete
+Fs::Ufs::UFSStoreState::_queued_write::operator new
+Helper::Request::operator delete
+Helper::Request::operator new
+MimeIcon::operator delete
+MimeIcon::operator new


### PR DESCRIPTION
The list of suppressions is provided in test-suite/xunused.supp
that contains function names and comments that document why the
function(s) below are excluded.