### PR TITLE
Replace RawCachePeers with SelectedCachePeers

### DIFF
--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -146,7 +146,7 @@ template <>
 void
 Configuration::Component<CachePeers*>::FinishSmoothReconfiguration(SmoothReconfiguration &sr)
 {
-    // disable cache_peers that were not mentioned in the fresh configuration
+    // workspace to find and remove cache_peers that were not mentioned in the fresh configuration
     SelectedCachePeers peersToRemove;
 
     for (const auto &p: CurrentCachePeers()) {

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -147,11 +147,11 @@ void
 Configuration::Component<CachePeers*>::FinishSmoothReconfiguration(SmoothReconfiguration &sr)
 {
     // disable cache_peers that were not mentioned in the fresh configuration
-    RawCachePeers peersToRemove;
+    SelectedCachePeers peersToRemove;
 
     for (const auto &p: CurrentCachePeers()) {
         if (p->stale)
-            peersToRemove.push_back(p.getRaw());
+            peersToRemove.push_back(p);
     }
 
     while (peersToRemove.size()) {
@@ -159,7 +159,7 @@ Configuration::Component<CachePeers*>::FinishSmoothReconfiguration(SmoothReconfi
         peersToRemove.pop_back();
         debugs(15, DBG_IMPORTANT, "WARNING: Removing old cache_peer not present in new configuration: " << *p);
         Assure(!p->access); // parse_peer_access() rejects cache_peer_access directives naming stale peers
-        DeleteConfigured(sr, p);
+        DeleteConfigured(sr, p.getRaw());
     }
 }
 

--- a/src/CachePeers.cc
+++ b/src/CachePeers.cc
@@ -154,9 +154,7 @@ Configuration::Component<CachePeers*>::FinishSmoothReconfiguration(SmoothReconfi
             peersToRemove.push_back(p);
     }
 
-    while (peersToRemove.size()) {
-        const auto p = peersToRemove.back();
-        peersToRemove.pop_back();
+    for (const auto &p: peersToRemove) {
         debugs(15, DBG_IMPORTANT, "WARNING: Removing old cache_peer not present in new configuration: " << *p);
         Assure(!p->access); // parse_peer_access() rejects cache_peer_access directives naming stale peers
         DeleteConfigured(sr, p.getRaw());

--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -79,9 +79,6 @@ void DeleteConfigured(CachePeer *);
 /// DeleteConfigured() must keep every stored copy in sync.
 using SelectedCachePeers = CachePeers::Storage;
 
-/// Temporary, local storage of raw pointers to zero or more Config.peers.
-using RawCachePeers = std::vector<CachePeer *, PoolingAllocator<CachePeer*> >;
-
 /// Template parameter type for Configuration::Component specialization that
 /// handles smooth cache_peer_access reconfiguration
 class CachePeerAccesses {};

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -95,11 +95,9 @@ carpInit(void)
     }
 
     /* Sort our list on weight */
-    std::sort(rawCarpPeers.begin(), rawCarpPeers.end(),
-    [](const auto &p1, const auto &p2) {
+    std::sort(rawCarpPeers.begin(), rawCarpPeers.end(), [](const auto &p1, const auto &p2) {
         return p1->weight < p2->weight; // ascending order
-    }
-             );
+    });
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -58,25 +58,25 @@ carpInit(void)
     /* find out which peers we have */
 
     SelectedCachePeers rawCarpPeers;
-    for (const auto &peer: CurrentCachePeers()) {
-        if (!peer->options.carp)
+    for (const auto &p: CurrentCachePeers()) {
+        if (!p->options.carp)
             continue;
 
-        assert(peer->type == PEER_PARENT);
+        assert(p->type == PEER_PARENT);
 
-        if (peer->weight == 0)
+        if (p->weight == 0)
             continue;
 
-        rawCarpPeers.push_back(peer);
+        rawCarpPeers.push_back(p);
 
-        W += peer->weight;
+        W += p->weight;
     }
 
     if (rawCarpPeers.empty())
         return;
 
     /* calculate hashes and load factors */
-    for (const auto p: rawCarpPeers) {
+    for (const auto &p: rawCarpPeers) {
         /* calculate this peers hash */
         p->carp.hash = 0;
 

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -125,7 +125,7 @@ carpInit(void)
         P_last = p->carp.load_factor;
     }
 
-    CarpPeers().assign(rawCarpPeers.begin(), rawCarpPeers.end());
+    CarpPeers() = rawCarpPeers;
 }
 
 void

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -55,9 +55,9 @@ carpInit(void)
     /* initialize cache manager before we have a chance to leave the execution path */
     carpRegisterWithCacheManager();
 
-    /* find out which peers we have */
-
+    // workspace to find, finalize, and sort CARP cache_peers into CarpPeers()
     SelectedCachePeers rawCarpPeers;
+
     for (const auto &p: CurrentCachePeers()) {
         if (!p->options.carp)
             continue;

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -94,9 +94,8 @@ carpInit(void)
             p->carp.load_factor = 0.0;
     }
 
-    /* Sort our list on weight */
     std::sort(rawCarpPeers.begin(), rawCarpPeers.end(), [](const auto &p1, const auto &p2) {
-        return p1->weight < p2->weight; // ascending order
+        return p1->weight < p2->weight; // ascending weight order
     });
 
     /* Calculate the load factor multipliers X_k

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -96,10 +96,10 @@ carpInit(void)
 
     /* Sort our list on weight */
     std::sort(rawCarpPeers.begin(), rawCarpPeers.end(),
-        [](const auto &p1, const auto &p2) {
-            return p1->weight < p2->weight; // ascending order
-        }
-    );
+    [](const auto &p1, const auto &p2) {
+        return p1->weight < p2->weight; // ascending order
+    }
+             );
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -36,14 +36,6 @@ CarpPeers()
 
 static OBJH carpCachemgr;
 
-static int
-peerSortWeight(const void *a, const void *b)
-{
-    const CachePeer *const *p1 = (const CachePeer *const *)a;
-    const CachePeer *const *p2 = (const CachePeer *const *)b;
-    return (*p1)->weight - (*p2)->weight;
-}
-
 static void
 carpRegisterWithCacheManager(void)
 {
@@ -65,21 +57,19 @@ carpInit(void)
 
     /* find out which peers we have */
 
-    RawCachePeers rawCarpPeers;
+    SelectedCachePeers rawCarpPeers;
     for (const auto &peer: CurrentCachePeers()) {
-        const auto p = peer.getRaw();
-
-        if (!p->options.carp)
+        if (!peer->options.carp)
             continue;
 
-        assert(p->type == PEER_PARENT);
+        assert(peer->type == PEER_PARENT);
 
-        if (p->weight == 0)
+        if (peer->weight == 0)
             continue;
 
-        rawCarpPeers.push_back(p);
+        rawCarpPeers.push_back(peer);
 
-        W += p->weight;
+        W += peer->weight;
     }
 
     if (rawCarpPeers.empty())
@@ -105,7 +95,11 @@ carpInit(void)
     }
 
     /* Sort our list on weight */
-    qsort(rawCarpPeers.data(), rawCarpPeers.size(), sizeof(decltype(rawCarpPeers)::value_type), peerSortWeight);
+    std::sort(rawCarpPeers.begin(), rawCarpPeers.end(),
+        [](const auto &p1, const auto &p2) {
+            return p1->weight < p2->weight; // ascending order
+        }
+    );
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -507,6 +507,7 @@ neighbors_init(void)
     neighborsRegisterWithCacheManager();
 
     if (Comm::IsConnOpen(icpIncomingConn)) {
+        // workspace to find and remove cache_peers that "look like this host"
         SelectedCachePeers peersToRemove;
 
         // TODO: After we stop reconfiguring pliable directives with unchanged

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -530,11 +530,8 @@ neighbors_init(void)
             }
         }
 
-        while (peersToRemove.size()) {
-            const auto p = peersToRemove.back();
-            peersToRemove.pop_back();
+        for (const auto &p: peersToRemove)
             DeleteConfigured(p.getRaw());
-        }
     }
 
     peerDnsRefreshStart();

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -507,7 +507,7 @@ neighbors_init(void)
     neighborsRegisterWithCacheManager();
 
     if (Comm::IsConnOpen(icpIncomingConn)) {
-        RawCachePeers peersToRemove;
+        SelectedCachePeers peersToRemove;
 
         // TODO: After we stop reconfiguring pliable directives with unchanged
         // spelling: cache_peer A dropped here (because config1 had a matching
@@ -525,7 +525,7 @@ neighbors_init(void)
                 debugs(15, DBG_IMPORTANT, "WARNING: Peer looks like this host." <<
                        Debug::Extra << "Ignoring cache_peer " << *thisPeer);
 
-                peersToRemove.push_back(thisPeer.getRaw());
+                peersToRemove.push_back(thisPeer);
                 break; // avoid warning about (and removing) the same CachePeer twice
             }
         }
@@ -533,7 +533,7 @@ neighbors_init(void)
         while (peersToRemove.size()) {
             const auto p = peersToRemove.back();
             peersToRemove.pop_back();
-            DeleteConfigured(p);
+            DeleteConfigured(p.getRaw());
         }
     }
 

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -88,9 +88,8 @@ peerSourceHashInit(void)
             p->sourcehash.load_factor = 0.0;
     }
 
-    /* Sort our list on weight */
     std::sort(rawSourceHashPeers.begin(), rawSourceHashPeers.end(), [](const auto &p1, const auto &p2) {
-        return p1->weight < p2->weight; // ascending order
+        return p1->weight < p2->weight; // ascending weight order
     });
 
     /* Calculate the load factor multipliers X_k

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -37,14 +37,6 @@ SourceHashPeers()
 static OBJH peerSourceHashCachemgr;
 static void peerSourceHashRegisterWithCacheManager(void);
 
-static int
-peerSortWeight(const void *a, const void *b)
-{
-    const CachePeer *const *p1 = (const CachePeer *const *)a;
-    const CachePeer *const *p2 = (const CachePeer *const *)b;
-    return (*p1)->weight - (*p2)->weight;
-}
-
 void
 peerSourceHashInit(void)
 {
@@ -56,10 +48,8 @@ peerSourceHashInit(void)
     SourceHashPeers().clear();
     /* find out which peers we have */
 
-    RawCachePeers rawSourceHashPeers;
+    SelectedCachePeers rawSourceHashPeers;
     for (const auto &p: CurrentCachePeers()) {
-        const auto peer = p.getRaw();
-
         if (!p->options.sourcehash)
             continue;
 
@@ -68,7 +58,7 @@ peerSourceHashInit(void)
         if (p->weight == 0)
             continue;
 
-        rawSourceHashPeers.push_back(peer);
+        rawSourceHashPeers.push_back(p);
 
         W += p->weight;
     }
@@ -98,7 +88,11 @@ peerSourceHashInit(void)
     }
 
     /* Sort our list on weight */
-    qsort(rawSourceHashPeers.data(), rawSourceHashPeers.size(), sizeof(decltype(rawSourceHashPeers)::value_type), peerSortWeight);
+    std::sort(rawSourceHashPeers.begin(), rawSourceHashPeers.end(),
+        [](const auto &p1, const auto &p2) {
+            return p1->weight < p2->weight; // ascending order
+        }
+    );
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -89,10 +89,10 @@ peerSourceHashInit(void)
 
     /* Sort our list on weight */
     std::sort(rawSourceHashPeers.begin(), rawSourceHashPeers.end(),
-        [](const auto &p1, const auto &p2) {
-            return p1->weight < p2->weight; // ascending order
-        }
-    );
+    [](const auto &p1, const auto &p2) {
+        return p1->weight < p2->weight; // ascending order
+    }
+             );
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -119,7 +119,7 @@ peerSourceHashInit(void)
         P_last = p->sourcehash.load_factor;
     }
 
-    SourceHashPeers().assign(rawSourceHashPeers.begin(), rawSourceHashPeers.end());
+    SourceHashPeers() = rawSourceHashPeers;
 }
 
 void

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -46,9 +46,10 @@ peerSourceHashInit(void)
     /* Clean up */
 
     SourceHashPeers().clear();
-    /* find out which peers we have */
 
+    // workspace to find, finalize, and sort sourcehash cache_peers into SourceHashPeers()
     SelectedCachePeers rawSourceHashPeers;
+
     for (const auto &p: CurrentCachePeers()) {
         if (!p->options.sourcehash)
             continue;

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -89,11 +89,9 @@ peerSourceHashInit(void)
     }
 
     /* Sort our list on weight */
-    std::sort(rawSourceHashPeers.begin(), rawSourceHashPeers.end(),
-    [](const auto &p1, const auto &p2) {
+    std::sort(rawSourceHashPeers.begin(), rawSourceHashPeers.end(), [](const auto &p1, const auto &p2) {
         return p1->weight < p2->weight; // ascending order
-    }
-             );
+    });
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -124,7 +124,7 @@ peerUserHashInit(void)
         P_last = p->userhash.load_factor;
     }
 
-    UserHashPeers().assign(rawUserHashPeers.begin(), rawUserHashPeers.end());
+    UserHashPeers() = rawUserHashPeers;
 }
 
 void

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -51,11 +51,12 @@ peerUserHashInit(void)
     /* Clean up */
 
     UserHashPeers().clear();
-    /* find out which peers we have */
 
     peerUserHashRegisterWithCacheManager();
 
+    // workspace to find, finalize, and sort userhash cache_peers into UserHashPeers().
     SelectedCachePeers rawUserHashPeers;
+
     for (const auto &p: CurrentCachePeers()) {
         if (!p->options.userhash)
             continue;

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -93,9 +93,8 @@ peerUserHashInit(void)
             p->userhash.load_factor = 0.0;
     }
 
-    /* Sort our list on weight */
     std::sort(rawUserHashPeers.begin(), rawUserHashPeers.end(), [](const auto &p1, const auto &p2) {
-        return p1->weight < p2->weight; // ascending order
+        return p1->weight < p2->weight; // ascending weight order
     });
 
     /* Calculate the load factor multipliers X_k

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -94,11 +94,9 @@ peerUserHashInit(void)
     }
 
     /* Sort our list on weight */
-    std::sort(rawUserHashPeers.begin(), rawUserHashPeers.end(),
-    [](const auto &p1, const auto &p2) {
+    std::sort(rawUserHashPeers.begin(), rawUserHashPeers.end(), [](const auto &p1, const auto &p2) {
         return p1->weight < p2->weight; // ascending order
-    }
-             );
+    });
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -42,14 +42,6 @@ UserHashPeers()
 static OBJH peerUserHashCachemgr;
 static void peerUserHashRegisterWithCacheManager(void);
 
-static int
-peerSortWeight(const void *a, const void *b)
-{
-    const CachePeer *const *p1 = (const CachePeer *const *)a;
-    const CachePeer *const *p2 = (const CachePeer *const *)b;
-    return (*p1)->weight - (*p2)->weight;
-}
-
 void
 peerUserHashInit(void)
 {
@@ -63,10 +55,8 @@ peerUserHashInit(void)
 
     peerUserHashRegisterWithCacheManager();
 
-    RawCachePeers rawUserHashPeers;
+    SelectedCachePeers rawUserHashPeers;
     for (const auto &p: CurrentCachePeers()) {
-        const auto peer = p.getRaw();
-
         if (!p->options.userhash)
             continue;
 
@@ -75,7 +65,7 @@ peerUserHashInit(void)
         if (p->weight == 0)
             continue;
 
-        rawUserHashPeers.push_back(peer);
+        rawUserHashPeers.push_back(p);
 
         W += p->weight;
     }
@@ -103,7 +93,11 @@ peerUserHashInit(void)
     }
 
     /* Sort our list on weight */
-    qsort(rawUserHashPeers.data(), rawUserHashPeers.size(), sizeof(decltype(rawUserHashPeers)::value_type), peerSortWeight);
+    std::sort(rawUserHashPeers.begin(), rawUserHashPeers.end(),
+        [](const auto &p1, const auto &p2) {
+            return p1->weight < p2->weight; // ascending order
+        }
+    );
 
     /* Calculate the load factor multipliers X_k
      *

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -94,10 +94,10 @@ peerUserHashInit(void)
 
     /* Sort our list on weight */
     std::sort(rawUserHashPeers.begin(), rawUserHashPeers.end(),
-        [](const auto &p1, const auto &p2) {
-            return p1->weight < p2->weight; // ascending order
-        }
-    );
+    [](const auto &p1, const auto &p2) {
+        return p1->weight < p2->weight; // ascending order
+    }
+             );
 
     /* Calculate the load factor multipliers X_k
      *


### PR DESCRIPTION
The risks of misusing the RawCachePeers temporary storage of pointers
outweigh its optimization benefits. Now we remove the unsafe
RawCachePeers storage in favor of its safer counterpart.