### PR TITLE
Make ConnStateData::ClientConnection const

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.dimInactiveRegions": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "C_Cpp.dimInactiveRegions": false
-}

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -435,6 +435,7 @@ Thank you!
     Reinhard Sojka <reinhard.sojka@parlament.gv.at>
     Rene Geile <rene.geile@t-online.de>
     Reuben Farrelly <reuben@reub.net>
+    Ricardo Ferreira Ribeiro <garb12@pm.me>
     Richard Huveneers <Richard.Huveneers@hekkihek.hacom.nl>
     Richard Huveneers <richard@hekkihek.hacom.nl>
     Richard Sharpe

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -759,8 +759,8 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
         flags.ignoreCc = port->ignore_cc;
     }
 
-    auto clientConnection = clientConnectionManager->clientConnection;
-    {
+    const auto clientConnection = clientConnectionManager->clientConnection;
+    { // TODO: Remove this diff reducer.
         client_addr = clientConnection->remote; // XXX: remove request->client_addr member.
 #if FOLLOW_X_FORWARDED_FOR
         // indirect client gets stored here because it is an HTTP header result (from X-Forwarded-For:)

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -759,7 +759,8 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
         flags.ignoreCc = port->ignore_cc;
     }
 
-    if (auto clientConnection = clientConnectionManager->clientConnection) {
+    auto clientConnection = clientConnectionManager->clientConnection;
+    {
         client_addr = clientConnection->remote; // XXX: remove request->client_addr member.
 #if FOLLOW_X_FORWARDED_FOR
         // indirect client gets stored here because it is an HTTP header result (from X-Forwarded-For:)

--- a/src/acl/ConnMark.cc
+++ b/src/acl/ConnMark.cc
@@ -45,7 +45,7 @@ Acl::ConnMark::match(ACLChecklist *cl)
     const auto *checklist = Filled(cl);
     const auto conn = checklist->conn();
 
-    if (conn && conn->clientConnection) {
+    if (conn) {
         const auto connmark = conn->clientConnection->nfConnmark;
 
         for (const auto &m : marks) {

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -47,8 +47,7 @@ ACLDestinationIP::match(ACLChecklist *cl)
     // In which case, we also need this ACL to accurately match the destination
     if (Config.onoff.client_dst_passthru && (checklist->request->flags.intercepted || checklist->request->flags.interceptTproxy)) {
         const auto conn = checklist->conn();
-        return (conn && conn->clientConnection) ?
-               ACLIP::match(conn->clientConnection->local) : -1;
+        return conn ? ACLIP::match(conn->clientConnection->local) : -1;
     }
 
     if (lookupBanned) {

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -146,14 +146,14 @@ int
 ACLFilledChecklist::fd() const
 {
     const auto c = conn();
-    return (c && c->clientConnection) ? c->clientConnection->fd : fd_;
+    return c ? c->clientConnection->fd : fd_;
 }
 
 void
 ACLFilledChecklist::fd(int aDescriptor)
 {
     const auto c = conn();
-    assert(!c || !c->clientConnection || c->clientConnection->fd == aDescriptor);
+    assert(!c || c->clientConnection->fd == aDescriptor);
     fd_ = aDescriptor;
 }
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -416,7 +416,7 @@ ClientHttpRequest::logRequest()
     /* This is broken. Fails if the connection has been closed. Needs
      * to snarf the ssl details some place earlier..
      */
-    if (getConn())
+    if (getConn() != NULL)
         al->cache.ssluser = sslGetUserEmail(fd_table[getConn()->fd].ssl);
 
 #endif

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2168,7 +2168,6 @@ void
 httpAccept(const CommAcceptCbParams &params)
 {
     Assure(params.port);
-    Assure(params.conn);
 
     // NP: it is possible the port was reconfigured when the call or accept() was queued.
 
@@ -2177,6 +2176,8 @@ httpAccept(const CommAcceptCbParams &params)
         debugs(33, 2, params.port->listenConn << ": accept failure: " << xstrerr(params.xerrno));
         return;
     }
+
+    Assure(params.conn);
 
     debugs(33, 4, params.conn << ": accepted");
     fd_note(params.conn->fd, "client http connect");
@@ -2371,7 +2372,6 @@ static void
 httpsAccept(const CommAcceptCbParams &params)
 {
     Assure(params.port);
-    Assure(params.conn);
 
     // NP: it is possible the port was reconfigured when the call or accept() was queued.
 
@@ -2380,6 +2380,8 @@ httpsAccept(const CommAcceptCbParams &params)
         debugs(33, 2, "httpsAccept: " << params.port->listenConn << ": accept failure: " << xstrerr(params.xerrno));
         return;
     }
+
+    Assure(params.conn);
 
     const auto xact = MasterXaction::MakePortful(params.port);
     xact->tcpClient = params.conn;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2044,6 +2044,7 @@ ConnStateData::ConnStateData(const MasterXaction::Pointer &xact) :
     port(xact->squidPort),
     receivedFirstByte_(false)
 {
+    Assure(clientConnection);
     clientConnection->leaveOrphanage();
 
     // store the details required for creating more MasterXaction objects as new requests come in

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -416,7 +416,7 @@ ClientHttpRequest::logRequest()
     /* This is broken. Fails if the connection has been closed. Needs
      * to snarf the ssl details some place earlier..
      */
-    if (getConn() != NULL)
+    if (getConn())
         al->cache.ssluser = sslGetUserEmail(fd_table[getConn()->fd].ssl);
 
 #endif

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2168,6 +2168,7 @@ void
 httpAccept(const CommAcceptCbParams &params)
 {
     Assure(params.port);
+    Assure(params.conn);
 
     // NP: it is possible the port was reconfigured when the call or accept() was queued.
 
@@ -2370,6 +2371,7 @@ static void
 httpsAccept(const CommAcceptCbParams &params)
 {
     Assure(params.port);
+    Assure(params.conn);
 
     // NP: it is possible the port was reconfigured when the call or accept() was queued.
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -974,8 +974,7 @@ ConnStateData::endingShutdown()
 
     // force the client connection to close immediately
     // swanSong() in the close handler will cleanup.
-    if (Comm::IsConnOpen(clientConnection))
-        clientConnection->close();
+    clientConnection->close();
 }
 
 char *

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -974,7 +974,8 @@ ConnStateData::endingShutdown()
 
     // force the client connection to close immediately
     // swanSong() in the close handler will cleanup.
-    clientConnection->close();
+    if (Comm::IsConnOpen(clientConnection))
+        clientConnection->close();
 }
 
 char *

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2178,8 +2178,6 @@ httpAccept(const CommAcceptCbParams &params)
         return;
     }
 
-    Assure(params.conn);
-
     debugs(33, 4, params.conn << ": accepted");
     fd_note(params.conn->fd, "client http connect");
     const auto xact = MasterXaction::MakePortful(params.port);
@@ -2381,8 +2379,6 @@ httpsAccept(const CommAcceptCbParams &params)
         debugs(33, 2, "httpsAccept: " << params.port->listenConn << ": accept failure: " << xstrerr(params.xerrno));
         return;
     }
-
-    Assure(params.conn);
 
     const auto xact = MasterXaction::MakePortful(params.port);
     xact->tcpClient = params.conn;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -453,7 +453,7 @@ ClientHttpRequest::logRequest()
         if (request)
             updateCounters();
 
-        if (getConn() != nullptr && getConn()->clientConnection != nullptr)
+        if (getConn())
             clientdbUpdate(getConn()->clientConnection->remote, loggingTags(), AnyP::PROTO_HTTP, out.size);
     }
 }
@@ -478,10 +478,8 @@ httpRequestFree(void *data)
 /* This is a handler normally called by comm_close() */
 void ConnStateData::connStateClosed(const CommCloseCbParams &)
 {
-    if (clientConnection) {
-        clientConnection->noteClosure();
-        // keep closed clientConnection for logging, clientdb cleanup, etc.
-    }
+    clientConnection->noteClosure();
+    // keep closed clientConnection for logging, clientdb cleanup, etc.
     deleteThis("ConnStateData::connStateClosed");
 }
 
@@ -976,8 +974,7 @@ ConnStateData::endingShutdown()
 
     // force the client connection to close immediately
     // swanSong() in the close handler will cleanup.
-    if (Comm::IsConnOpen(clientConnection))
-        clientConnection->close();
+    clientConnection->close();
 }
 
 char *
@@ -3421,7 +3418,6 @@ void
 ConnStateData::fillConnectionLevelDetails(ACLFilledChecklist &checklist) const
 {
     assert(checklist.conn() == this);
-    assert(clientConnection);
 
     if (!checklist.request) { // preserve (better) addresses supplied by setRequest()
         checklist.src_addr = clientConnection->remote;
@@ -3453,7 +3449,7 @@ ConnStateData::write(char *buf, int len)
 bool
 ConnStateData::transparent() const
 {
-    return clientConnection != nullptr && (clientConnection->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION));
+    return clientConnection->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION);
 }
 
 BodyPipe::Pointer
@@ -3605,7 +3601,7 @@ ConnStateData::clientPinnedConnectionClosed(const CommCloseCbParams &io)
     pinning.serverConnection->noteClosure();
     unpinConnection(false);
 
-    if (sawZeroReply && clientConnection != nullptr) {
+    if (sawZeroReply) {
         debugs(33, 3, "Closing client connection on pinned zero reply.");
         clientConnection->close();
         return;
@@ -3804,7 +3800,7 @@ ConnStateData::closeIfIdle(const char * const reason)
     // If we are still sending data to the client, do not close now. When we are done sending,
     // ConnStateData::kick() checks pinning.serverConnection and will close.
     // However, if we are idle, then we must close to inform the idle client and minimize races.
-    if (clientIsIdle && clientConnection != nullptr)
+    if (clientIsIdle)
         clientConnection->close();
 }
 

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -407,7 +407,7 @@ public:
 //      but all sorts of code likes to play directly
 //      with the I/O buffers and socket.
 public:
-    // Client TCP connection details from comm layer.
+    /// Client-to-Squid TCP connection details. This pointer is never nil.
     const Comm::ConnectionPointer clientConnection;
 
     /**

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -408,7 +408,7 @@ public:
 //      with the I/O buffers and socket.
 public:
     // Client TCP connection details from comm layer.
-    Comm::ConnectionPointer clientConnection;
+    const Comm::ConnectionPointer clientConnection;
 
     /**
      * The transfer protocol currently being spoken on this connection.

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2012,7 +2012,7 @@ clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
                  const ConnStateData *conn, HttpRequest *request, const AccessLogEntry::Pointer &al)
 {
     const auto err = new ErrorState(page_id, status, request, al);
-    err->src_addr = conn && conn->clientConnection ? conn->clientConnection->remote : Ip::Address::NoAddr();
+    err->src_addr = conn ? conn->clientConnection->remote : Ip::Address::NoAddr();
 
     if (url)
         err->url = xstrdup(url);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -130,7 +130,7 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
         al->updateError(aConn->bareError);
 
 #if USE_OPENSSL
-        if (aConn->clientConnection != nullptr && aConn->clientConnection->isOpen()) {
+        if (aConn->clientConnection->isOpen()) {
             if (auto ssl = fd_table[aConn->clientConnection->fd].ssl.get())
                 al->cache.sslClientCert.resetWithoutLocking(SSL_get_peer_certificate(ssl));
         }
@@ -706,7 +706,7 @@ ClientHttpRequest::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer g)
 #if ICAP_CLIENT
     Adaptation::Icap::History::Pointer ih = request->icapHistory();
     if (ih != nullptr) {
-        if (getConn() != nullptr && getConn()->clientConnection != nullptr) {
+        if (getConn()) {
 #if USE_OPENSSL
             if (getConn()->clientConnection->isOpen()) {
                 ih->ssluser = sslGetUserEmail(fd_table[getConn()->clientConnection->fd].ssl.get());

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -470,8 +470,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
         case LFT_CLIENT_EUI:
 #if USE_SQUID_EUI
             // TODO make the ACL checklist have a direct link to any TCP details.
-            if (al->request && al->request->clientConnectionManager.valid() &&
-                    al->request->clientConnectionManager->clientConnection) {
+            if (al->request && al->request->clientConnectionManager.valid()) {
                 const auto &conn = al->request->clientConnectionManager->clientConnection;
                 if (conn->remote.isIPv4())
                     conn->remoteEui48.encode(tmp, sizeof(tmp));
@@ -485,7 +484,6 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
         case LFT_EXT_ACL_CLIENT_EUI48:
 #if USE_SQUID_EUI
             if (al->request && al->request->clientConnectionManager.valid() &&
-                    al->request->clientConnectionManager->clientConnection &&
                     al->request->clientConnectionManager->clientConnection->remote.isIPv4()) {
                 al->request->clientConnectionManager->clientConnection->remoteEui48.encode(tmp, sizeof(tmp));
                 out = tmp;
@@ -496,7 +494,6 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
         case LFT_EXT_ACL_CLIENT_EUI64:
 #if USE_SQUID_EUI
             if (al->request && al->request->clientConnectionManager.valid() &&
-                    al->request->clientConnectionManager->clientConnection &&
                     !al->request->clientConnectionManager->clientConnection->remote.isIPv4()) {
                 al->request->clientConnectionManager->clientConnection->remoteEui64.encode(tmp, sizeof(tmp));
                 out = tmp;

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -182,7 +182,7 @@ Ip::Qos::getNfConnmark(const Comm::ConnectionPointer &conn, const Ip::Qos::Conne
 }
 
 bool
-Ip::Qos::setNfConnmark(Comm::ConnectionPointer &conn, const Ip::Qos::ConnectionDirection connDir, const Ip::NfMarkConfig &cm)
+Ip::Qos::setNfConnmark(const Comm::ConnectionPointer &conn, const Ip::Qos::ConnectionDirection connDir, const Ip::NfMarkConfig &cm)
 {
     bool ret = false;
 

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -99,7 +99,7 @@ nfmark_t getNfConnmark(const Comm::ConnectionPointer &conn, const ConnectionDire
 * @param connDir Specifies connection type (incoming or outgoing)
 * @cm            Netfilter mark configuration (mark and mask)
 */
-bool setNfConnmark(const Comm::ConnectionPointer &conn, const ConnectionDirection connDir, const NfMarkConfig &cm);
+bool setNfConnmark(const Comm::ConnectionPointer &conn, ConnectionDirection connDir, const NfMarkConfig &cm);
 
 /**
 * Function to work out and then apply to the socket the appropriate

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -99,7 +99,7 @@ nfmark_t getNfConnmark(const Comm::ConnectionPointer &conn, const ConnectionDire
 * @param connDir Specifies connection type (incoming or outgoing)
 * @cm            Netfilter mark configuration (mark and mask)
 */
-bool setNfConnmark(Comm::ConnectionPointer &conn, const ConnectionDirection connDir, const NfMarkConfig &cm);
+bool setNfConnmark(const Comm::ConnectionPointer &conn, const ConnectionDirection connDir, const NfMarkConfig &cm);
 
 /**
 * Function to work out and then apply to the socket the appropriate

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -241,6 +241,7 @@ void
 Ftp::Server::AcceptCtrlConnection(const CommAcceptCbParams &params)
 {
     Assure(params.port);
+    Assure(params.conn);
 
     // NP: it is possible the port was reconfigured when the call or accept() was queued.
 

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -241,7 +241,6 @@ void
 Ftp::Server::AcceptCtrlConnection(const CommAcceptCbParams &params)
 {
     Assure(params.port);
-    Assure(params.conn);
 
     // NP: it is possible the port was reconfigured when the call or accept() was queued.
 
@@ -250,6 +249,8 @@ Ftp::Server::AcceptCtrlConnection(const CommAcceptCbParams &params)
         debugs(33, 2, params.port->listenConn << ": FTP accept failure: " << xstrerr(params.xerrno));
         return;
     }
+
+    Assure(params.conn);
 
     debugs(33, 4, params.conn << ": accepted");
     fd_note(params.conn->fd, "client ftp connect");

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -318,8 +318,7 @@ Ftp::Server::clientPinnedConnectionClosed(const CommCloseCbParams &io)
 
     // TODO: Keep the control connection open after fixing the reset
     // problem below
-    if (Comm::IsConnOpen(clientConnection))
-        clientConnection->close();
+    clientConnection->close();
 
     // TODO: If the server control connection is gone, reset state to login
     // again. Resetting login alone is not enough: FtpRelay::sendCommand() will
@@ -409,11 +408,7 @@ Ftp::Server::acceptDataConnection(const CommAcceptCbParams &params)
     debugs(33, 4, "accepted " << params.conn);
     fd_note(params.conn->fd, "passive client ftp data");
 
-    if (!clientConnection) {
-        debugs(33, 5, "late data connection?");
-        closeDataConnection(); // in case we are still listening
-        params.conn->close();
-    } else if (params.conn->remote != clientConnection->remote) {
+    if (params.conn->remote != clientConnection->remote) {
         debugs(33, 2, "rogue data conn? ctrl: " << clientConnection->remote);
         params.conn->close();
         // Some FTP servers close control connection here, but it may make
@@ -1419,7 +1414,6 @@ Ftp::Server::handlePasvRequest(String &, String &params)
 bool
 Ftp::Server::createDataConnection(Ip::Address cltAddr)
 {
-    assert(clientConnection != nullptr);
     assert(!clientConnection->remote.isAnyAddr());
 
     if (cltAddr != clientConnection->remote) {
@@ -1737,8 +1731,7 @@ Ftp::Server::callException(const std::exception &e)
     debugs(33, 2, "FTP::Server job caught: " << e.what());
     closeDataConnection();
     unpinConnection(true);
-    if (Comm::IsConnOpen(clientConnection))
-        clientConnection->close();
+    clientConnection->close();
     AsyncJob::callException(e);
 }
 

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -250,8 +250,6 @@ Ftp::Server::AcceptCtrlConnection(const CommAcceptCbParams &params)
         return;
     }
 
-    Assure(params.conn);
-
     debugs(33, 4, params.conn << ": accepted");
     fd_note(params.conn->fd, "client ftp connect");
 

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -320,7 +320,8 @@ Ftp::Server::clientPinnedConnectionClosed(const CommCloseCbParams &io)
 
     // TODO: Keep the control connection open after fixing the reset
     // problem below
-    clientConnection->close();
+    if (Comm::IsConnOpen(clientConnection))
+        clientConnection->close();
 
     // TODO: If the server control connection is gone, reset state to login
     // again. Resetting login alone is not enough: FtpRelay::sendCommand() will
@@ -1733,7 +1734,8 @@ Ftp::Server::callException(const std::exception &e)
     debugs(33, 2, "FTP::Server job caught: " << e.what());
     closeDataConnection();
     unpinConnection(true);
-    clientConnection->close();
+    if (Comm::IsConnOpen(clientConnection))
+        clientConnection->close();
     AsyncJob::callException(e);
 }
 

--- a/src/tests/stub_libip.cc
+++ b/src/tests/stub_libip.cc
@@ -81,7 +81,7 @@ CBDATA_CLASS_INIT(acl_nfmark);
 acl_nfmark::~acl_nfmark() STUB
 void Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB
 nfmark_t Ip::Qos::getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1)
-bool Ip::Qos::setNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false)
+bool Ip::Qos::setNfConnmark(const Comm::ConnectionPointer &, ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false)
 int Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
 int Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
 int Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)

--- a/src/tests/stub_libip.cc
+++ b/src/tests/stub_libip.cc
@@ -81,7 +81,7 @@ CBDATA_CLASS_INIT(acl_nfmark);
 acl_nfmark::~acl_nfmark() STUB
 void Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB
 nfmark_t Ip::Qos::getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1)
-bool Ip::Qos::setNfConnmark(Comm::ConnectionPointer &, const ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false)
+bool Ip::Qos::setNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false)
 int Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
 int Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
 int Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)


### PR DESCRIPTION
`ConnStateData::clientConnection` pointer is initialized with a non-nil
pointer and never changes, even after the connection is closed.
Declaring this data member as `const` and removing code implying that
`clientConnection` may be nil improves code quality.