### PR TITLE
Refresh Transiens index after 304 update

### DIFF
--- a/src/Store.h
+++ b/src/Store.h
@@ -324,6 +324,10 @@ public:
     void kickProducer();
 #endif
 
+    /// Calculates correct public key for feeding forcePublicKey().
+    /// Assumes adjustVary() has been called for this entry already.
+    const cache_key *calcPublicKey(KeyScope) const;
+
     /* Packable API */
     void append(char const *, int) override;
     void vappendf(const char *, va_list) override;
@@ -342,7 +346,6 @@ private:
     bool checkTooBig() const;
     void forcePublicKey(const cache_key *newkey);
     StoreEntry *adjustVary();
-    const cache_key *calcPublicKey(KeyScope) const;
     KeyScope publicKeyScope() const;
 
     /// flags [truncated or too big] entry with ENTRY_BAD_LENGTH and releases it

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -429,7 +429,7 @@ TransientsRr::~TransientsRr()
 }
 
 void
-Transients::forgetMarkedEntry(StoreEntry &e)
+Transients::forgetMarkedEntry(const StoreEntry &e)
 {
     const auto key = e.calcPublicKey(ksDefault);
     sfileno index = 0;

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -428,3 +428,12 @@ TransientsRr::~TransientsRr()
     delete mapOwner;
 }
 
+void
+Transients::forgetMarkedEntry(StoreEntry &e)
+{
+    const auto key = e.calcPublicKey(ksDefault);
+    sfileno index = 0;
+    if (map->openMarkedForWriting(key, index))
+        map->closeForWriting(index);
+}
+

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -90,6 +90,10 @@ public:
     /// Can we create and initialize Transients?
     static bool Enabled() { return EntryLimit(); }
 
+    /// Associates a new Transients slot with the entry key,
+    /// if that entry is marked for deletion. Does nothing otherwise.
+    void forgetMarkedEntry(StoreEntry &e);
+
 private:
     void addEntry(StoreEntry*, const cache_key *, const Store::IoStatus);
     void addWriterEntry(StoreEntry &, const cache_key *);

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -92,7 +92,7 @@ public:
 
     /// Associates a new Transients slot with the entry key,
     /// if that entry is marked for deletion. Does nothing otherwise.
-    void forgetMarkedEntry(StoreEntry &e);
+    void forgetMarkedEntry(const StoreEntry &);
 
 private:
     void addEntry(StoreEntry*, const cache_key *, const Store::IoStatus);

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -1135,7 +1135,7 @@ Ipc::StoreMapAnchor::rewind()
     splicingPoint = -1;
     memset(&key, 0, sizeof(key));
     basics.clear();
-//    waitingToBeFreed = false;
+    waitingToBeFreed = false;
     writerHalted = false;
     // but keep the lock
 }

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -1135,7 +1135,7 @@ Ipc::StoreMapAnchor::rewind()
     splicingPoint = -1;
     memset(&key, 0, sizeof(key));
     basics.clear();
-    waitingToBeFreed = false;
+//    waitingToBeFreed = false;
     writerHalted = false;
     // but keep the lock
 }

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -150,11 +150,20 @@ Ipc::StoreMap::openForWriting(const cache_key *const key, sfileno &fileno)
         return anchor;
     }
 
-    debugs(54, 5, "replacing stale entry " << currentIdx << " to write " << path);
+    return openMarkedForWriting(key, fileno);
+}
+
+Ipc::StoreMap::Anchor *
+Ipc::StoreMap::openMarkedForWriting(const cache_key *const key, sfileno &fileno)
+{
+    const auto name = nameByKey(key);
+    const int currentIdx = fileNoByName(name);
 
     const auto staleAnchor = openForReplacingAt(currentIdx, key);
     if (!staleAnchor)
         return nullptr;
+
+    debugs(54, 5, "replacing stale entry " << currentIdx << " to write " << path);
 
     Update::Edition available;
     if (!openKeyless(available)) { // XXX: debugs() will say "for updating"
@@ -759,6 +768,8 @@ Ipc::StoreMap::closeForUpdating(Update &update)
     // finally, unlock the fresh entry
     closeForReading(update.fresh.fileNo);
     update.fresh = Update::Edition();
+
+    Store::Root().updateFinished(*update.entry);
 
     debugs(54, 5, "closed entry " << updateSaved.stale.fileNo << " of " << *updateSaved.entry <<
            " named " << updateSaved.stale.name << " for updating " << path <<

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -261,6 +261,9 @@ public:
     /// locks and returns an anchor for the empty fileno position; if
     /// overwriteExisting is false and the position is not empty, returns nil
     Anchor *openForWritingAt(sfileno fileno, bool overwriteExisting = true);
+    /// like openForWriting() but does nothing if the old entry does not exist
+    Anchor *openMarkedForWriting(const cache_key *const key, sfileno &fileno);
+
     /// restrict opened for writing entry to appending operations; allow reads
     void startAppending(const sfileno fileno);
     /// successfully finish creating or updating the entry at fileno pos

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -72,7 +72,12 @@ void Ipc::Strand::registerSelf()
 
     selfRegistrationTracker.start(ScopedId("Ipc::Strand self-registration"));
     NotifyCoordinator(mtRegisterStrand, tag);
-    setTimeout(6, "Ipc::Strand::timeoutHandler"); // TODO: make 6 configurable?
+    auto timeout = time_t(6); // TODO: make 6 configurable?
+#if WITH_VALGRIND
+    if (RUNNING_ON_VALGRIND)
+        timeout *= 10; // compensate for Valgrind overheads, especially during startup
+#endif
+    setTimeout(timeout, "Ipc::Strand::timeoutHandler");
 }
 
 void Ipc::Strand::receive(const TypedMsgHdr &message)

--- a/src/store.cc
+++ b/src/store.cc
@@ -687,8 +687,6 @@ StoreEntry::forcePublicKey(const cache_key *newkey)
         storeDirSwapLog(this, SWAP_LOG_ADD);
 }
 
-/// Calculates correct public key for feeding forcePublicKey().
-/// Assumes adjustVary() has been called for this entry already.
 const cache_key *
 StoreEntry::calcPublicKey(const KeyScope keyScope) const
 {

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -919,7 +919,7 @@ Store::Controller::checkTransients(const StoreEntry &e) const
 }
 
 void
-Store::Controller::updateFinished(StoreEntry &e)
+Store::Controller::updateFinished(const StoreEntry &e)
 {
     if (e.hasTransients())
         transients->forgetMarkedEntry(e);

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -919,10 +919,12 @@ Store::Controller::checkTransients(const StoreEntry &e) const
 }
 
 void
-Store::Controller::updateFinished(const StoreEntry &e)
+Store::Controller::updateFinished(StoreEntry &e)
 {
-    if (e.hasTransients())
+    if (e.hasTransients()) {
+        transients->evictCached(e);
         transients->forgetMarkedEntry(e);
+    }
 }
 
 Store::Controller&

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -918,6 +918,13 @@ Store::Controller::checkTransients(const StoreEntry &e) const
     assert(!transients || e.hasTransients());
 }
 
+void
+Store::Controller::updateFinished(StoreEntry &e)
+{
+    if (e.hasTransients())
+        transients->forgetMarkedEntry(e);
+}
+
 Store::Controller&
 Store::Root()
 {

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -89,7 +89,7 @@ public:
 
     /// Is called when any of the shared caches finish the update
     /// initiated by updateOnNotModified().
-    void updateFinished(const StoreEntry &);
+    void updateFinished(StoreEntry &);
 
     /// tries to make the entry available for collapsing future requests
     bool allowCollapsing(StoreEntry *, const RequestFlags &, const HttpRequestMethod &);

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -87,6 +87,10 @@ public:
     /// \returns whether the old entry can be used (and is considered fresh)
     bool updateOnNotModified(StoreEntry *old, StoreEntry &e304);
 
+    /// Is called when any of the shared caches finish the update
+    /// initiated by updateOnNotModified().
+    void updateFinished(StoreEntry &e);
+
     /// tries to make the entry available for collapsing future requests
     bool allowCollapsing(StoreEntry *, const RequestFlags &, const HttpRequestMethod &);
 

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -89,7 +89,7 @@ public:
 
     /// Is called when any of the shared caches finish the update
     /// initiated by updateOnNotModified().
-    void updateFinished(StoreEntry &e);
+    void updateFinished(const StoreEntry &);
 
     /// tries to make the entry available for collapsing future requests
     bool allowCollapsing(StoreEntry *, const RequestFlags &, const HttpRequestMethod &);

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -55,7 +55,7 @@ StoreSearch *Controller::search() STUB_RETVAL(nullptr)
 bool Controller::SmpAware() STUB_RETVAL(false)
 int Controller::store_dirs_rebuilding = 0;
 Controller &Root() STUB_RETREF(Controller)
-void Controller::updateFinished(const StoreEntry &) STUB
+void Controller::updateFinished(StoreEntry &) STUB
 }
 
 #include "store/Disk.h"

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -55,6 +55,7 @@ StoreSearch *Controller::search() STUB_RETVAL(nullptr)
 bool Controller::SmpAware() STUB_RETVAL(false)
 int Controller::store_dirs_rebuilding = 0;
 Controller &Root() STUB_RETREF(Controller)
+void Controller::updateFinished(const StoreEntry &) STUB
 }
 
 #include "store/Disk.h"


### PR DESCRIPTION
During update StoreEntry::hideFromNewcomers() marks the old entry's
shared metadata for deletion. After update, the marked transients entry
may be around for some time (while it is still locked by some workers)
rendering the updated entry unavailable for other workers because
Controller::peek() returns nil for marked entries.  Now we associate
a new Transients slot with the updated entry as soon as possible.

The bug broke Daft's hit-revalidation.js test (at least).
