### PR TITLE
Refresh Transiens index after 304 update

### DIFF
--- a/src/Store.h
+++ b/src/Store.h
@@ -324,6 +324,8 @@ public:
     void kickProducer();
 #endif
 
+    const cache_key *calcPublicKey(KeyScope) const;
+
     /* Packable API */
     void append(char const *, int) override;
     void vappendf(const char *, va_list) override;
@@ -342,7 +344,6 @@ private:
     bool checkTooBig() const;
     void forcePublicKey(const cache_key *newkey);
     StoreEntry *adjustVary();
-    const cache_key *calcPublicKey(KeyScope) const;
     KeyScope publicKeyScope() const;
 
     /// flags [truncated or too big] entry with ENTRY_BAD_LENGTH and releases it

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -289,6 +289,7 @@ Transients::status(const StoreEntry &entry, Transients::EntryStatus &entryStatus
                          map->writeableEntry(idx) : map->readableEntry(idx);
     entryStatus.hasWriter = anchor.writing();
     entryStatus.waitingToBeFreed = anchor.waitingToBeFreed;
+    entryStatus.wasRelocated = anchor.wasRelocated;
 }
 
 void
@@ -361,11 +362,11 @@ Transients::disconnect(StoreEntry &entry)
     }
 }
 
-void
-Transients::update(StoreEntry &e)
+bool
+Transients::update(StoreEntry &e, sfileno &fresh)
 {
     assert(e.hasTransients());
-    map->replaceFileNo(e.calcPublicKey(ksDefault));
+    return map->replaceFileNo(e.calcPublicKey(ksDefault), fresh);
 }
 
 /// calculates maximum number of entries we need to store and map

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -361,6 +361,13 @@ Transients::disconnect(StoreEntry &entry)
     }
 }
 
+void
+Transients::update(StoreEntry &e)
+{
+    assert(e.hasTransients());
+    map->replaceFileNo(e.calcPublicKey(ksDefault));
+}
+
 /// calculates maximum number of entries we need to store and map
 int64_t
 Transients::EntryLimit()

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -289,7 +289,7 @@ Transients::status(const StoreEntry &entry, Transients::EntryStatus &entryStatus
                          map->writeableEntry(idx) : map->readableEntry(idx);
     entryStatus.hasWriter = anchor.writing();
     entryStatus.waitingToBeFreed = anchor.waitingToBeFreed;
-    entryStatus.wasRelocated = anchor.wasRelocated;
+    entryStatus.isRelocating = anchor.isRelocating;
 }
 
 void
@@ -363,10 +363,16 @@ Transients::disconnect(StoreEntry &entry)
 }
 
 bool
-Transients::update(StoreEntry &e, sfileno &fresh)
+Transients::updateStart(StoreEntry &e, sfileno &fresh)
 {
     assert(e.hasTransients());
-    return map->replaceFileNo(e.calcPublicKey(ksDefault), fresh);
+    return map->startFileNoReplacing(e.calcPublicKey(ksDefault), fresh);
+}
+
+void
+Transients::updateFinish(const sfileno fresh)
+{
+    map->finishFileNoReplacing(fresh);
 }
 
 /// calculates maximum number of entries we need to store and map

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -33,7 +33,7 @@ public:
     public:
         bool hasWriter = false; ///< whether some worker is storing the entry
         bool waitingToBeFreed = false; ///< whether the entry was marked for deletion
-        bool wasRelocated = false; ///< whether the entry was relocated (obtaining a fresh fileno)
+        bool isRelocating = false; ///< whether the entry is being relocated (obtaining a fresh fileno)
     };
 
     Transients();
@@ -59,7 +59,8 @@ public:
     void disconnect(StoreEntry &);
 
     /// the caller is done with entry updating
-    bool update(StoreEntry &, sfileno &fresh);
+    bool updateStart(StoreEntry &, sfileno &fresh);
+    void updateFinish(sfileno fresh);
 
     /* Store API */
     StoreEntry *get(const cache_key *) override;

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -57,6 +57,9 @@ public:
     /// the caller is done writing or reading the given entry
     void disconnect(StoreEntry &);
 
+    /// the caller is done with entry updating
+    void update(StoreEntry &);
+
     /* Store API */
     StoreEntry *get(const cache_key *) override;
     void create() override {}

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -33,6 +33,7 @@ public:
     public:
         bool hasWriter = false; ///< whether some worker is storing the entry
         bool waitingToBeFreed = false; ///< whether the entry was marked for deletion
+        bool wasRelocated = false; ///< whether the entry was relocated (obtaining a fresh fileno)
     };
 
     Transients();
@@ -58,7 +59,7 @@ public:
     void disconnect(StoreEntry &);
 
     /// the caller is done with entry updating
-    void update(StoreEntry &);
+    bool update(StoreEntry &, sfileno &fresh);
 
     /* Store API */
     StoreEntry *get(const cache_key *) override;

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "base/IoManip.h"
+#include "CollapsedForwarding.h"
 #include "ipc/StoreMap.h"
 #include "sbuf/SBuf.h"
 #include "SquidConfig.h"
@@ -375,7 +376,7 @@ Ipc::StoreMap::abortUpdating(Update &update)
 
 // XXX: duplication with StoreMap::openForWriting()
 bool
-Ipc::StoreMap::replaceFileNo(const cache_key *const key)
+Ipc::StoreMap::replaceFileNo(const cache_key *const key, sfileno &fresh)
 {
     const auto name = nameByKey(key);
     const int currentIdx = fileNoByName(name);
@@ -418,6 +419,8 @@ Ipc::StoreMap::replaceFileNo(const cache_key *const key)
     // swap anchor "pointers": fileNos[name] <-> fileNos[available.name]
     relocate(name, available.fileNo);
     relocate(available.name, currentIdx);
+    available.anchor->wasRelocated = true;
+    fresh = available.fileNo;
 
     staleAnchor->lock.unlockHeaders();
     closeForReading(currentIdx);
@@ -815,7 +818,8 @@ Ipc::StoreMap::closeForUpdating(Update &update)
     // either way, fresh chain uses the stale chain suffix now
 
     // update Transients entry index before the fresh anchor becomes available
-    Store::Root().transientsUpdate(*update.entry);
+    sfileno freshTransientsFileNo = 0;
+    const bool transientsUpdated = Store::Root().transientsUpdate(*update.entry, freshTransientsFileNo);
 
     // make the fresh anchor/chain readable for everybody
     update.fresh.anchor->lock.switchExclusiveToShared();
@@ -858,6 +862,11 @@ Ipc::StoreMap::closeForUpdating(Update &update)
     // finally, unlock the fresh entry
     closeForReading(update.fresh.fileNo);
     update.fresh = Update::Edition();
+
+    // notify those who could have attached to the updated Transients entry
+    // so that they could anchorToCache()
+    if (transientsUpdated)
+        CollapsedForwarding::Broadcast(freshTransientsFileNo, Here(), false);
 
     debugs(54, 5, "closed entry " << updateSaved.stale.fileNo << " of " << *updateSaved.entry <<
            " named " << updateSaved.stale.name << " for updating " << path <<
@@ -1286,6 +1295,7 @@ Ipc::StoreMapAnchor::rewind()
     waitingToBeFreed = false;
     // no freeingCheckpoint() here because we are only called for a locked entry
     writerHalted = false;
+    wasRelocated = false;
     // but keep the lock
 }
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -164,6 +164,14 @@ Ipc::StoreMap::openForWriting(const cache_key *const key, sfileno &fileno)
     if (!staleAnchor)
         return nullptr;
 
+    return replaceFileNoCommon(name, currentIdx, staleAnchor, fileno);
+}
+
+Ipc::StoreMap::Anchor *
+Ipc::StoreMap::replaceFileNoCommon(sfileno name, sfileno currentIdx, const Ipc::StoreMap::Anchor * const staleAnchor, sfileno &fresh)
+{
+    assert(staleAnchor);
+
     Update::Edition available;
     if (!openKeyless(available)) { // XXX: debugs() will say "for updating"
         debugs(54, 5, "no anchors to replace stale entry " << currentIdx << " to write " << path);
@@ -195,14 +203,14 @@ Ipc::StoreMap::openForWriting(const cache_key *const key, sfileno &fileno)
     relocate(name, available.fileNo);
     relocate(available.name, currentIdx);
 
+    fresh = available.fileNo;
+
     staleAnchor->lock.unlockHeaders();
     closeForReading(currentIdx);
 
-    debugs(54, 5, "opened entry " << available.fileNo << " under name " << name << " for writing " << path <<
-           " after moving marked entry " << currentIdx << " to name " << available.name);
+    debugs(54, 5, "replaced stale entry " << currentIdx << " under name " << name << " with fresh entry " <<
+            available.fileNo << " under name " << available.name << " in " << path);
 
-    // available.fileNo is left locked for writing
-    fileno = available.fileNo;
     return available.anchor;
 }
 
@@ -374,7 +382,6 @@ Ipc::StoreMap::abortUpdating(Update &update)
     debugs(54, 5, "aborted entry " << fileno << " for updating " << path);
 }
 
-// XXX: duplication with StoreMap::openForWriting()
 bool
 Ipc::StoreMap::replaceFileNo(const cache_key *const key, sfileno &fresh)
 {
@@ -389,48 +396,13 @@ Ipc::StoreMap::replaceFileNo(const cache_key *const key, sfileno &fresh)
 
     debugs(54, 5, "replacing stale entry " << currentIdx << " to write " << path);
 
-    Update::Edition available;
-    if (!openKeyless(available)) { // XXX: debugs() will say "for updating"
-        debugs(54, 5, "no anchors to replace stale entry " << currentIdx << " to write " << path);
-        closeForReading(currentIdx);
-        return false;
+    if (auto freshAnchor = replaceFileNoCommon(name, currentIdx, staleAnchor, fresh)) {
+        freshAnchor->wasRelocated = true;
+        closeForWriting(fresh);
+        freeEntry(currentIdx);
+        return true;
     }
-
-    if (!staleAnchor->lock.lockHeaders()) {
-        debugs(54, 5, "no access to replace stale entry " << currentIdx << " to write " << path);
-        abortWriting(available.fileNo);
-        closeForReading(currentIdx);
-        return false;
-    }
-
-    // fileNos[name] may have been updated many times before our lockHeaders(),
-    // including ABA-like updates that restore the same index value, but we do
-    // not care about past updates as long as the now-locked fileNos[name] value
-    // currently points to the previously locked stale entry (i.e. that the swap
-    // below swaps two locked fileNos entries).
-    if (fileNoByName(name) != currentIdx) {
-        debugs(54, 5, "somebody else replaced stale entry " << currentIdx << " to write " << path);
-        abortWriting(available.fileNo);
-        staleAnchor->lock.unlockHeaders();
-        closeForReading(currentIdx);
-        return false;
-    }
-
-    // swap anchor "pointers": fileNos[name] <-> fileNos[available.name]
-    relocate(name, available.fileNo);
-    relocate(available.name, currentIdx);
-    available.anchor->wasRelocated = true;
-    fresh = available.fileNo;
-
-    staleAnchor->lock.unlockHeaders();
-    closeForReading(currentIdx);
-    closeForWriting(available.fileNo);
-    freeEntry(currentIdx);
-
-    debugs(54, 5, "replaced stale entry " << currentIdx << " under name " << name << " with fresh entry " <<
-            available.fileNo << " under name " << available.name << " in " << path);
-
-    return true;
+    return false;
 }
 
 const Ipc::StoreMap::Anchor *

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -383,7 +383,7 @@ Ipc::StoreMap::abortUpdating(Update &update)
 }
 
 bool
-Ipc::StoreMap::replaceFileNo(const cache_key *const key, sfileno &fresh)
+Ipc::StoreMap::startFileNoReplacing(const cache_key *const key, sfileno &fresh)
 {
     const auto name = nameByKey(key);
     const int currentIdx = fileNoByName(name);
@@ -397,12 +397,21 @@ Ipc::StoreMap::replaceFileNo(const cache_key *const key, sfileno &fresh)
     debugs(54, 5, "replacing stale entry " << currentIdx << " to write " << path);
 
     if (auto freshAnchor = replaceFileNoCommon(name, currentIdx, staleAnchor, fresh)) {
-        freshAnchor->wasRelocated = true;
-        closeForWriting(fresh);
+        freshAnchor->isRelocating = true;
+        freshAnchor->lock.switchExclusiveToShared();
         freeEntry(currentIdx);
         return true;
     }
     return false;
+}
+
+void
+Ipc::StoreMap::finishFileNoReplacing(const sfileno fresh)
+{
+    auto &s = anchorAt(fresh);
+    assert(s.reading());
+    s.isRelocating = false;
+    closeForReading(fresh);
 }
 
 const Ipc::StoreMap::Anchor *
@@ -791,7 +800,7 @@ Ipc::StoreMap::closeForUpdating(Update &update)
 
     // update Transients entry index before the fresh anchor becomes available
     sfileno freshTransientsFileNo = 0;
-    const bool transientsUpdated = Store::Root().transientsUpdate(*update.entry, freshTransientsFileNo);
+    const bool transientsUpdated = Store::Root().transientsUpdateStart(*update.entry, freshTransientsFileNo);
 
     // make the fresh anchor/chain readable for everybody
     update.fresh.anchor->lock.switchExclusiveToShared();
@@ -835,6 +844,7 @@ Ipc::StoreMap::closeForUpdating(Update &update)
     closeForReading(update.fresh.fileNo);
     update.fresh = Update::Edition();
 
+    Store::Root().transientsUpdateFinish(freshTransientsFileNo);
     // notify those who could have attached to the updated Transients entry
     // so that they could anchorToCache()
     if (transientsUpdated)
@@ -1267,7 +1277,7 @@ Ipc::StoreMapAnchor::rewind()
     waitingToBeFreed = false;
     // no freeingCheckpoint() here because we are only called for a locked entry
     writerHalted = false;
-    wasRelocated = false;
+    isRelocating = false;
     // but keep the lock
 }
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -373,6 +373,63 @@ Ipc::StoreMap::abortUpdating(Update &update)
     debugs(54, 5, "aborted entry " << fileno << " for updating " << path);
 }
 
+// XXX: duplication with StoreMap::openForWriting()
+bool
+Ipc::StoreMap::replaceFileNo(const cache_key *const key)
+{
+    const auto name = nameByKey(key);
+    const int currentIdx = fileNoByName(name);
+
+    const auto staleAnchor = openForReadingAt(currentIdx, key);
+    if (!staleAnchor) {
+        debugs(54, 5, "cannot open unreadable entry " << currentIdx << " for reading " << path);
+        return false;
+    }
+
+    debugs(54, 5, "replacing stale entry " << currentIdx << " to write " << path);
+
+    Update::Edition available;
+    if (!openKeyless(available)) { // XXX: debugs() will say "for updating"
+        debugs(54, 5, "no anchors to replace stale entry " << currentIdx << " to write " << path);
+        closeForReading(currentIdx);
+        return false;
+    }
+
+    if (!staleAnchor->lock.lockHeaders()) {
+        debugs(54, 5, "no access to replace stale entry " << currentIdx << " to write " << path);
+        abortWriting(available.fileNo);
+        closeForReading(currentIdx);
+        return false;
+    }
+
+    // fileNos[name] may have been updated many times before our lockHeaders(),
+    // including ABA-like updates that restore the same index value, but we do
+    // not care about past updates as long as the now-locked fileNos[name] value
+    // currently points to the previously locked stale entry (i.e. that the swap
+    // below swaps two locked fileNos entries).
+    if (fileNoByName(name) != currentIdx) {
+        debugs(54, 5, "somebody else replaced stale entry " << currentIdx << " to write " << path);
+        abortWriting(available.fileNo);
+        staleAnchor->lock.unlockHeaders();
+        closeForReading(currentIdx);
+        return false;
+    }
+
+    // swap anchor "pointers": fileNos[name] <-> fileNos[available.name]
+    relocate(name, available.fileNo);
+    relocate(available.name, currentIdx);
+
+    staleAnchor->lock.unlockHeaders();
+    closeForReading(currentIdx);
+    closeForWriting(available.fileNo);
+    freeEntry(currentIdx);
+
+    debugs(54, 5, "replaced stale entry " << currentIdx << " under name " << name << " with fresh entry " <<
+            available.fileNo << " under name " << available.name << " in " << path);
+
+    return true;
+}
+
 const Ipc::StoreMap::Anchor *
 Ipc::StoreMap::peekAtReader(const sfileno fileno) const
 {
@@ -756,6 +813,9 @@ Ipc::StoreMap::closeForUpdating(Update &update)
     else
         Must(freshSplicingSlice.next == suffixStart);
     // either way, fresh chain uses the stale chain suffix now
+
+    // update Transients entry index before the fresh anchor becomes available
+    Store::Root().transientsUpdate(*update.entry);
 
     // make the fresh anchor/chain readable for everybody
     update.fresh.anchor->lock.switchExclusiveToShared();

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -402,6 +402,8 @@ private:
     void freeChain(const sfileno fileno, Anchor &inode, const bool keepLock);
     void freeChainAt(const Anchor &);
 
+    Ipc::StoreMap::Anchor * replaceFileNoCommon(sfileno name, sfileno currentIdx, const Ipc::StoreMap::Anchor *staleAnchor, sfileno &fresh);
+
     /// whether paranoid_hit_validation should be performed
     bool hitValidation;
 };

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -81,6 +81,9 @@ public:
     std::atomic<uint8_t> waitingToBeFreed; ///< may be accessed w/o a lock
     /// whether StoreMap::abortWriting() was called for a read-locked entry
     std::atomic<uint8_t> writerHalted;
+    /// whether this anchor corresponds to a fresh fileno that replaced
+    /// a stale fileno by StoreMap::replaceFileNo()
+    std::atomic<bool> wasRelocated = false;
 
     // fields marked with [app] can be modified when appending-while-reading
     // fields marked with [update] can be modified when updating-while-reading
@@ -278,7 +281,7 @@ public:
     /// undoes partial update, unlocks, and cleans up
     void abortUpdating(Update &update);
     /// replaces entry's stale fileno with a fresh fileno
-    bool replaceFileNo(const cache_key *const key);
+    bool replaceFileNo(const cache_key *const key, sfileno &fresh);
 
     /// the caller must hold a lock on the entry
     /// \returns nullptr unless the slice is readable

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -81,9 +81,9 @@ public:
     std::atomic<uint8_t> waitingToBeFreed; ///< may be accessed w/o a lock
     /// whether StoreMap::abortWriting() was called for a read-locked entry
     std::atomic<uint8_t> writerHalted;
-    /// whether this anchor corresponds to a fresh fileno that replaced
+    /// whether this anchor corresponds to a fresh fileno that is replacing
     /// a stale fileno by StoreMap::replaceFileNo()
-    std::atomic<bool> wasRelocated = false;
+    std::atomic<bool> isRelocating = false;
 
     // fields marked with [app] can be modified when appending-while-reading
     // fields marked with [update] can be modified when updating-while-reading
@@ -281,7 +281,8 @@ public:
     /// undoes partial update, unlocks, and cleans up
     void abortUpdating(Update &update);
     /// replaces entry's stale fileno with a fresh fileno
-    bool replaceFileNo(const cache_key *const key, sfileno &fresh);
+    bool startFileNoReplacing(const cache_key *const key, sfileno &fresh);
+    void finishFileNoReplacing(sfileno fresh);
 
     /// the caller must hold a lock on the entry
     /// \returns nullptr unless the slice is readable

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -277,6 +277,8 @@ public:
     void closeForUpdating(Update &update);
     /// undoes partial update, unlocks, and cleans up
     void abortUpdating(Update &update);
+    /// replaces entry's stale fileno with a fresh fileno
+    bool replaceFileNo(const cache_key *const key);
 
     /// the caller must hold a lock on the entry
     /// \returns nullptr unless the slice is readable

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -627,6 +627,14 @@ Store::Controller::transientsDisconnect(StoreEntry &e)
 }
 
 void
+Store::Controller::transientsUpdate(StoreEntry &e)
+{
+    if (e.hasTransients()) {
+        transients->update(e);
+    }
+}
+
+void
 Store::Controller::handleIdleEntry(StoreEntry &e)
 {
     bool keepInLocalMemory = false;

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -626,12 +626,10 @@ Store::Controller::transientsDisconnect(StoreEntry &e)
         transients->disconnect(e);
 }
 
-void
-Store::Controller::transientsUpdate(StoreEntry &e)
+bool
+Store::Controller::transientsUpdate(StoreEntry &e, sfileno &fresh)
 {
-    if (e.hasTransients()) {
-        transients->update(e);
-    }
+    return e.hasTransients() ? transients->update(e, fresh) : false;
 }
 
 void
@@ -904,7 +902,8 @@ Store::Controller::anchorToCache(StoreEntry &entry)
     if (entryStatus.waitingToBeFreed)
         throw TextException("will never be able to anchor to an already marked entry", Here());
 
-    if (!entryStatus.hasWriter)
+    // the entry that is being updated is not opened for writing
+    if (!entryStatus.hasWriter && !entryStatus.wasRelocated)
         throw TextException("will never be able to anchor to an abandoned-by-writer entry", Here());
 
     debugs(20, 7, "skipping not yet cached " << entry);

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -627,9 +627,15 @@ Store::Controller::transientsDisconnect(StoreEntry &e)
 }
 
 bool
-Store::Controller::transientsUpdate(StoreEntry &e, sfileno &fresh)
+Store::Controller::transientsUpdateStart(StoreEntry &e, sfileno &fresh)
 {
-    return e.hasTransients() ? transients->update(e, fresh) : false;
+    return e.hasTransients() ? transients->updateStart(e, fresh) : false;
+}
+
+void
+Store::Controller::transientsUpdateFinish(const sfileno fresh)
+{
+    transients->updateFinish(fresh);
 }
 
 void
@@ -887,6 +893,12 @@ Store::Controller::anchorToCache(StoreEntry &entry)
     Transients::EntryStatus entryStatus;
     transients->status(entry, entryStatus);
 
+    if (entryStatus.isRelocating) {
+        debugs(20, 7, "skipping being relocated " << entry);
+        entry.setCollapsingRequirement(true);
+        return false;
+    }
+
     bool found = false;
     if (sharedMemStore)
         found = sharedMemStore->anchorToCache(entry);
@@ -903,7 +915,7 @@ Store::Controller::anchorToCache(StoreEntry &entry)
         throw TextException("will never be able to anchor to an already marked entry", Here());
 
     // the entry that is being updated is not opened for writing
-    if (!entryStatus.hasWriter && !entryStatus.wasRelocated)
+    if (!entryStatus.hasWriter)
         throw TextException("will never be able to anchor to an abandoned-by-writer entry", Here());
 
     debugs(20, 7, "skipping not yet cached " << entry);

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -116,6 +116,9 @@ public:
     /// disassociates the entry from the intransit table
     void transientsDisconnect(StoreEntry &);
 
+    /// associates a new intransit table index with the entry key
+    void transientsUpdate(StoreEntry &);
+
     /// disassociates the entry from the memory cache, preserving cached data
     void memoryDisconnect(StoreEntry &);
 

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -117,7 +117,7 @@ public:
     void transientsDisconnect(StoreEntry &);
 
     /// associates a new intransit table index with the entry key
-    void transientsUpdate(StoreEntry &);
+    bool transientsUpdate(StoreEntry &, sfileno &fresh);
 
     /// disassociates the entry from the memory cache, preserving cached data
     void memoryDisconnect(StoreEntry &);

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -117,7 +117,8 @@ public:
     void transientsDisconnect(StoreEntry &);
 
     /// associates a new intransit table index with the entry key
-    bool transientsUpdate(StoreEntry &, sfileno &fresh);
+    bool transientsUpdateStart(StoreEntry &, sfileno &fresh);
+    void transientsUpdateFinish(sfileno fresh);
 
     /// disassociates the entry from the memory cache, preserving cached data
     void memoryDisconnect(StoreEntry &);

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -55,6 +55,7 @@ StoreSearch *Controller::search() STUB_RETVAL(nullptr)
 bool Controller::SmpAware() STUB_RETVAL(false)
 int Controller::store_dirs_rebuilding = 0;
 Controller &Root() STUB_RETREF(Controller)
+void Controller::transientsUpdate(StoreEntry &) STUB
 }
 
 #include "store/Disk.h"


### PR DESCRIPTION
During 304 update an SMP Store (MemStore or Rock) calls
StoreMap::closeForUpdating() that marks the old entry index for deletion
and makes the new same-key index available. The Transients index,
however, was not refreshed. When at some point during cleanup the
StoreEntry object marks its Transients entry index for deletion, the new
(refreshed) entry becomes unavailable in Store because
Controller::peek() returns nil. This problem manifested itself in
unexpected misses (for new clients) or failures to swap out fresher
replies (for clients attached before the update and getting a 200
reply). Now we assign a new Transients index to the key just
before the update is about to finish successfully.

Note that we do not refresh the StoreEntry object with the new
Transients index (unlike MemStore/Rock indexes that are refreshed
by Controlled::updateHeaders()): The old Transients index should be
kept as is in order to continue process notifications via
Controller::syncCollapsed().
