### PR TITLE
Reject intercepted real CONNECT requests

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1301,7 +1301,7 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
 
     /* deny CONNECT via intercepted ports */
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
-        debugs(33, 2, "WARNING: Rejecting CONNECT request received on an intercepting port: " << port->s.port());
+        debugs(33, 2, "WARNING: Rejecting CONNECT request received on " << transferProtocol << " intercepting port " << port->s.port());
         static const auto d = MakeNamedErrorDetail("CONNECT_INTERCEPT_PORT");
         // The specific error is set later in the request processing based on parseStatusCode.
         updateError(ERR_NONE, d);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1299,6 +1299,14 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
         return abortRequestParsing("error:method-not-allowed");
     }
 
+    /* deny CONNECT via intercepted ports */
+    if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
+        debugs(33, DBG_IMPORTANT, "WARNING: CONNECT method received on " << transferProtocol << " Intercept/TPROXY port " << port->s.port());
+        debugs(33, DBG_IMPORTANT, "WARNING: for request: " << hp->method() << " " << hp->requestUri() << " " << hp->messageProtocol());
+        hp->parseStatusCode = Http::scMethodNotAllowed;
+        return abortRequestParsing("error:method-not-allowed");
+    }
+
     /* HTTP/2 connection magic prefix starts with "PRI ".
      * Deny "PRI" method if used in HTTP/1.x or 0.9 versions.
      * If seen it signals a broken client or proxy has corrupted the traffic.

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1301,7 +1301,7 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
 
     /* deny CONNECT via intercepted ports */
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
-        debugs(33, 2, "WARNING: Rejecting CONNECT request received on an intercepting port: " << *port);
+        debugs(33, 2, "WARNING: Rejecting CONNECT request received on an intercepting port: " << port->s.port());
         hp->parseStatusCode = Http::scMethodNotAllowed;
         return abortRequestParsing("error:method-not-allowed");
     }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1301,8 +1301,7 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
 
     /* deny CONNECT via intercepted ports */
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
-        debugs(33, DBG_IMPORTANT, "WARNING: CONNECT method received on " << transferProtocol << " Intercept/TPROXY port " << port->s.port());
-        debugs(33, DBG_IMPORTANT, "WARNING: for request: " << hp->method() << " " << hp->requestUri() << " " << hp->messageProtocol());
+        debugs(33, 2, "WARNING: Rejecting CONNECT request received on an intercepting port: " << *port);
         hp->parseStatusCode = Http::scMethodNotAllowed;
         return abortRequestParsing("error:method-not-allowed");
     }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1303,7 +1303,7 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
         debugs(33, 2, "WARNING: Rejecting CONNECT request received on " << transferProtocol << " intercepting port " << port->s.port());
         static const auto d = MakeNamedErrorDetail("INTERCEPTED_CONNECT");
-        updateError(ERR_NONE, d); // The specific error is set later, during request processing, based on parseStatusCode.
+        updateError(ERR_NONE, d); // buildHttpRequest() sets ERR_UNSUP_REQ based on parseStatusCode set below
         hp->parseStatusCode = Http::scMethodNotAllowed;
         return abortRequestParsing("error:method-not-allowed");
     }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1303,7 +1303,8 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
         debugs(33, 2, "WARNING: Rejecting CONNECT request received on an intercepting port: " << port->s.port());
         static const auto d = MakeNamedErrorDetail("CONNECT_INTERCEPT_PORT");
-        updateError(ERR_UNSUP_REQ, d);
+        // The specific error is set later in the request processing based on parseStatusCode.
+        updateError(ERR_NONE, d);
         hp->parseStatusCode = Http::scMethodNotAllowed;
         return abortRequestParsing("error:method-not-allowed");
     }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1302,7 +1302,7 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     /* deny CONNECT via intercepted ports */
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
         debugs(33, 2, "WARNING: Rejecting CONNECT request received on " << transferProtocol << " intercepting port " << port->s.port());
-        static const auto d = MakeNamedErrorDetail("CONNECT_INTERCEPT_PORT");
+        static const auto d = MakeNamedErrorDetail("INTERCEPTED_CONNECT");
         updateError(ERR_NONE, d); // The specific error is set later, during request processing, based on parseStatusCode.
         hp->parseStatusCode = Http::scMethodNotAllowed;
         return abortRequestParsing("error:method-not-allowed");

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1303,8 +1303,7 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
         debugs(33, 2, "WARNING: Rejecting CONNECT request received on an intercepting port: " << port->s.port());
         static const auto d = MakeNamedErrorDetail("CONNECT_INTERCEPT_PORT");
-        // The specific error is set later in the request processing based on parseStatusCode.
-        updateError(ERR_NONE, d);
+        updateError(ERR_NONE, d); // The specific error is set later, during request processing, based on parseStatusCode.
         hp->parseStatusCode = Http::scMethodNotAllowed;
         return abortRequestParsing("error:method-not-allowed");
     }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1302,6 +1302,8 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     /* deny CONNECT via intercepted ports */
     if (hp->method() == Http::METHOD_CONNECT && port != nullptr && port->flags.isIntercepted()) {
         debugs(33, 2, "WARNING: Rejecting CONNECT request received on an intercepting port: " << port->s.port());
+        static const auto d = MakeNamedErrorDetail("CONNECT_INTERCEPT_PORT");
+        updateError(ERR_UNSUP_REQ, d);
         hp->parseStatusCode = Http::scMethodNotAllowed;
         return abortRequestParsing("error:method-not-allowed");
     }


### PR DESCRIPTION
When handling a real CONNECT request received on an intercepted
connection, Squid either rejects that request (if it violates Host
validation rules) or honors it, opening a TCP connection to the server
address specified in the request. After opening a TCP connection, Squid
does not respond to the CONNECT request, leading to a stuck client (that
awaits such a response to start talking) or an HTTP framing violation
(if the server starts talking to the client). These tunneling problems
affect non-SslBump and SslBump configurations alike.

This change is not expected to break any previously working transactions
because no intercepted CONNECT requests previously resulted in
successful transactions (e.g., working TCP tunnels).

Requests are rejected using HTTP 405 (Method not allowed) responses that
are access-logged with `error:method-not-allowed` request URI (`%>ru`)
and `ERR_UNSUP_REQ/INTERCEPTED_CONNECT` error details
(`%err_code/%err_detail`, if used in `logformat`).
