### PR TITLE
Optimization: Do not findPreviouslyCachedEntry() twice

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -163,7 +163,7 @@ findPreviouslyCachedEntry(StoreEntry *newEntry) {
 /// whether the incoming response (to be stored in a currently private entry)
 /// obsoletes the existing matching public cache entries
 bool
-HttpStateData::incomingInvalidates(const Http::StatusCode status) const
+HttpStateData::incomingInvalidates(const Http::StatusCode statusCode) const
 {
     // Stop incoming response from purging a _newer_ stored entry per RFC 9111
     // section 4: "When more than one suitable response is stored, a cache MUST
@@ -191,7 +191,7 @@ HttpStateData::incomingInvalidates(const Http::StatusCode status) const
     if (e->mem_obj->request && !e->mem_obj->request->flags.cachable)
         return false;
 
-    switch (status) {
+    switch (statusCode) {
 
     case Http::scOkay:
 
@@ -239,13 +239,13 @@ HttpStateData::incomingInvalidates(const Http::StatusCode status) const
 }
 
 void
-HttpStateData::maybeRemovePublic(const Http::StatusCode status)
+HttpStateData::maybeRemovePublic(const Http::StatusCode statusCode)
 {
     auto pe = findPreviouslyCachedEntry(entry);
 
     sawDateGoBack = pe && finalReply()->olderThan(pe->hasFreshestReply());
 
-    if (!incomingInvalidates(status)) {
+    if (!incomingInvalidates(statusCode)) {
         if (pe)
             pe->abandon("HttpStateData::maybeRemovePublic");
         return;

--- a/src/http.cc
+++ b/src/http.cc
@@ -74,7 +74,6 @@ CBDATA_CLASS_INIT(HttpStateData);
 
 static const char *const crlf = "\r\n";
 
-static void httpMaybeRemovePublic(StoreEntry *, Http::StatusCode);
 static void copyOneHeaderFromClientsideRequestToUpstreamRequest(const HttpHeaderEntry *e, const String strConnection, const HttpRequest * request,
         HttpHeader * hdr_out, const CachePeer *, const int we_do_ranges, const Http::StateFlags &);
 
@@ -161,24 +160,36 @@ findPreviouslyCachedEntry(StoreEntry *newEntry) {
            storeGetPublic(newEntry->mem_obj->storeId(), newEntry->mem_obj->method);
 }
 
-/// Remove an existing public store entry if the incoming response (to be
-/// stored in a currently private entry) is going to invalidate it.
-static void
-httpMaybeRemovePublic(StoreEntry * e, Http::StatusCode status)
+/// whether the incoming response (to be stored in a currently private entry)
+/// obsoletes the existing matching public cache entries
+bool
+HttpStateData::incomingInvalidates(const Http::StatusCode status) const
 {
+    // Stop incoming response from purging a _newer_ stored entry per RFC 9111
+    // section 4: "When more than one suitable response is stored, a cache MUST
+    // use the most recent one (as determined by the Date header)."
+    if (sawDateGoBack)
+        return false;
+
+    if (!neighbors_do_private_keys)
+        return false;
+
+    // TODO: Refactor, removing these three(?) diff-reducer lines before merging:
+    const auto e = entry;
+
     int remove = 0;
     int forbidden = 0;
 
     // If the incoming response already goes into a public entry, then there is
     // nothing to remove. This protects ready-for-collapsing entries as well.
     if (!EBIT_TEST(e->flags, KEY_PRIVATE))
-        return;
+        return false;
 
     // If the new/incoming response cannot be stored, then it does not
     // compete with the old stored response for the public key, and the
     // old stored response should be left as is.
     if (e->mem_obj->request && !e->mem_obj->request->flags.cachable)
-        return;
+        return false;
 
     switch (status) {
 
@@ -222,9 +233,25 @@ httpMaybeRemovePublic(StoreEntry * e, Http::StatusCode status)
     }
 
     if (!remove && !forbidden)
-        return;
+        return false;
 
-    StoreEntry *pe = findPreviouslyCachedEntry(e);
+    return true;
+}
+
+void
+HttpStateData::maybeRemovePublic(const Http::StatusCode status)
+{
+    auto pe = findPreviouslyCachedEntry(entry);
+
+    sawDateGoBack = pe && finalReply()->olderThan(pe->hasFreshestReply());
+
+    if (!incomingInvalidates(status)) {
+        if (pe)
+            pe->abandon("HttpStateData::maybeRemovePublic");
+        return;
+    }
+
+    const auto e = entry; // TODO: Remove this diff-reducer before merging.
 
     if (pe != nullptr) {
         assert(e != pe);
@@ -943,14 +970,7 @@ HttpStateData::haveParsedReplyHeaders()
     /* Check if object is cacheable or not based on reply code */
     debugs(11, 3, "HTTP CODE: " << statusCode);
 
-    if (StoreEntry *oldEntry = findPreviouslyCachedEntry(entry)) {
-        oldEntry->lock("HttpStateData::haveParsedReplyHeaders");
-        sawDateGoBack = rep->olderThan(oldEntry->hasFreshestReply());
-        oldEntry->unlock("HttpStateData::haveParsedReplyHeaders");
-    }
-
-    if (neighbors_do_private_keys && !sawDateGoBack)
-        httpMaybeRemovePublic(entry, rep->sline.status());
+    maybeRemovePublic(statusCode);
 
     bool varyFailure = false;
     if (rep->header.has(Http::HdrType::VARY)

--- a/src/http.h
+++ b/src/http.h
@@ -144,6 +144,9 @@ private:
     bool peerSupportsConnectionPinning() const;
     const char *blockSwitchingProtocols(const HttpReply&) const;
 
+    bool incomingInvalidates(Http::StatusCode) const;
+    void maybeRemovePublic(Http::StatusCode);
+ 
     /// Parser being used at present to parse the HTTP/ICY server response.
     Http1::ResponseParserPointer hp;
     Http1::TeChunkedParser *httpChunkDecoder = nullptr;

--- a/src/http.h
+++ b/src/http.h
@@ -146,7 +146,7 @@ private:
 
     bool incomingInvalidates(Http::StatusCode) const;
     void maybeRemovePublic(Http::StatusCode);
- 
+
     /// Parser being used at present to parse the HTTP/ICY server response.
     Http1::ResponseParserPointer hp;
     Http1::TeChunkedParser *httpChunkDecoder = nullptr;


### PR DESCRIPTION
----
Cherry picked bag51 commit 39693e99944dddcabefadcc89e53e23ecff84076
and SQUID-762-fewer-findPreviouslyCachedEntry-bag51 commit d7090b83