### PR TITLE
Initial support client_http_version directive

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2250,8 +2250,8 @@ nodist_tests_testCacheManager_SOURCES = \
 # comm.cc only requires comm/libcomm.la until fdc_table is dead.
 tests_testCacheManager_LDADD = \
 	libsquid.la \
-	clients/libclients.la \
 	servers/libservers.la \
+	clients/libclients.la \
 	ftp/libftp.la \
 	helper/libhelper.la \
 	http/libhttp.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -504,9 +504,9 @@ squid_LDADD = \
 	acl/libstate.la \
 	$(AUTH_LIBS) \
 	acl/libapi.la \
-	clients/libclients.la \
-	configuration/libconfiguration.la \
 	servers/libservers.la \
+	configuration/libconfiguration.la \
+	clients/libclients.la \
 	ftp/libftp.la \
 	helper/libhelper.la \
 	http/libhttp.la \

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -12,6 +12,7 @@
 #include "acl/forward.h"
 #include "base/RefCount.h"
 #include "base/YesNoNone.h"
+#include "clients/forward.h"
 #include "configuration/forward.h"
 #if USE_DELAY_POOLS
 #include "ClientDelayConfig.h"
@@ -550,6 +551,8 @@ public:
     } happyEyeballs;
 
     Configuration::ReconfigurationMode *reconfigurationMode;
+
+    ClientHttpVersionSelector *clientHttpVersionSelector;
 };
 
 extern SquidConfig Config;

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -194,6 +194,35 @@ aclParseAclList(ConfigParser &, ACLList **config, const char *label)
     return aclCount;
 }
 
+void
+ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl)
+{
+    assert(treePointer);
+    auto &access = *treePointer;
+    if (!access) {
+        const auto tree = new Acl::Tree;
+        tree->context(ToSBuf('(', desc, " rules)"), config_input_line);
+        access = new acl_access(tree);
+    }
+    assert(access);
+
+    Acl::AndNode *rule = new Acl::AndNode;
+    rule->context(ToSBuf('(', desc, " rule)"), config_input_line);
+    if (acl)
+        rule->add(acl);
+    else
+        rule->lineParse();
+    (*access)->add(rule, action);
+}
+
+void
+ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc)
+{
+    if (!parser.skipOptional("if"))
+        return; // the directive has no ACLs
+    ParseAclWithAction(treePointer, action, desc);
+}
+
 /*********************/
 /* Destroy functions */
 /*********************/

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -218,8 +218,7 @@ ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const ch
 void
 ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc)
 {
-    if (!parser.skipOptional("if"))
-        return; // the directive has no ACLs
+    (void) parser.skipOptional("if");
     ParseAclWithAction(treePointer, action, desc);
 }
 

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -44,11 +44,12 @@ aclParseAclList(ConfigParser &parser, ACLList ** const tree, const Any any)
     return aclParseAclList(parser, tree, buf.str().c_str());
 }
 
-/// parses an [!]<acl>... line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+/// parses an optional [ [!]<acl>... ] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+/// \deprecated use ParseOptionalAclWithAction() instead
 void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
 
-/// parses an optional [if [!]<acl>...] line as ParseAclWithAction()
-void ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc);
+/// parses an optional [ if [!]<acl>...] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+void ParseOptionalAclWithAction(ConfigParser &, acl_access **treePointer, const Acl::Answer &action, const char *desc);
 
 /// Whether the given name names an Acl::Node object with true isProxyAuth() result.
 /// This is a safe variation of Acl::Node::FindByName(*name)->isProxyAuth().

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -26,7 +26,7 @@ void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 
-/// Parses a single line of a "action followed by acls" directive (e.g., http_access).
+/// Parses a single line of the "allow" or "deny" action followed by acls" directive (e.g., http_access).
 void aclParseAccessLine(const char *directive, ConfigParser &, acl_access **);
 
 /// Parses a single line of a "some context followed by acls" directive (e.g., note n v).
@@ -43,6 +43,12 @@ aclParseAclList(ConfigParser &parser, ACLList ** const tree, const Any any)
     buf << any;
     return aclParseAclList(parser, tree, buf.str().c_str());
 }
+
+/// parses an [!]<acl>... line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
+
+/// parses an optional [if [!]<acl>...] line as ParseAclWithAction()
+void ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc);
 
 /// Whether the given name names an Acl::Node object with true isProxyAuth() result.
 /// This is a safe variation of Acl::Node::FindByName(*name)->isProxyAuth().

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -26,7 +26,7 @@ void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 
-/// Parses a single line of the "allow" or "deny" action followed by acls" directive (e.g., http_access).
+/// Parses a single line of a "action followed by acls" directive (e.g., http_access).
 void aclParseAccessLine(const char *directive, ConfigParser &, acl_access **);
 
 /// Parses a single line of a "some context followed by acls" directive (e.g., note n v).

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -68,7 +68,8 @@ Tree::treeDump(const SBuf &prefix, const ActionToStringConverter converter) cons
     typedef Nodes::const_iterator NCI;
     for (NCI node = nodes.begin(); node != nodes.end(); ++node) {
 
-        text.push_back(prefix);
+        if (!prefix.isEmpty())
+            text.push_back(prefix);
 
         if (action != actions.end()) {
             static const SBuf DefaultActString("???");
@@ -77,7 +78,11 @@ Tree::treeDump(const SBuf &prefix, const ActionToStringConverter converter) cons
             ++action;
         }
 
-        text.splice(text.end(), (*node)->dump());
+        auto nodeText = (*node)->dump();
+        if (!nodeText.empty()) {
+            text.push_back(SBuf("if"));
+            text.splice(text.end(), nodeText);
+        }
         text.push_back(SBuf("\n"));
     }
     return text;

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -80,7 +80,8 @@ Tree::treeDump(const SBuf &prefix, const ActionToStringConverter converter) cons
 
         auto nodeText = (*node)->dump();
         if (!nodeText.empty()) {
-            text.push_back(SBuf("if"));
+            static const SBuf ifToken("if");
+            text.push_back(ifToken);
             text.splice(text.end(), nodeText);
         }
         text.push_back(SBuf("\n"));

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1178,6 +1178,23 @@ dump_SBufList(StoreEntry * entry, const char *name, SBufList &list)
     }
 }
 
+void
+dump_SBufList(std::ostream &os, const SBufList &words)
+{
+    for (const auto &i : words) {
+        os << i << ' ';
+    }
+}
+
+void
+dump_SBufList(std::ostream &os, const char * const name, const SBufList &list)
+{
+    if (!list.empty()) {
+        os << name << ' ';
+        dump_SBufList(os, list);
+    }
+}
+
 static void
 free_SBufList(SBufList *list)
 {

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -242,7 +242,6 @@ static void free_UrlHelperTimeout(SquidConfig::UrlHelperTimeout *);
 static void parse_on_unsupported_protocol(acl_access **access);
 static void dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *access);
 static void free_on_unsupported_protocol(acl_access **access);
-static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
 static void parse_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
 static void dump_http_upgrade_request_protocols(StoreEntry *entry, const char *name, HttpUpgradeProtocolAccess *protoGuards);
 static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
@@ -1709,27 +1708,6 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 }
 
 #endif /* USE_AUTH */
-
-static void
-ParseAclWithAction(acl_access **config, const Acl::Answer &action, const char *desc, Acl::Node *acl)
-{
-    assert(config);
-    auto &access = *config;
-    if (!access) {
-        const auto tree = new Acl::Tree;
-        tree->context(ToSBuf('(', desc, " rules)"), config_input_line);
-        access = new acl_access(tree);
-    }
-    assert(access);
-
-    Acl::AndNode *rule = new Acl::AndNode;
-    rule->context(ToSBuf('(', desc, " rule)"), config_input_line);
-    if (acl)
-        rule->add(acl);
-    else
-        rule->lineParse();
-    (*access)->add(rule, action);
-}
 
 static void
 parse_cachedir(Store::DiskConfig *swap)

--- a/src/cache_cf.h
+++ b/src/cache_cf.h
@@ -14,6 +14,8 @@
 #include "configuration/forward.h"
 #include "sbuf/forward.h"
 
+#include <iosfwd>
+
 class wordlist;
 
 void configFreeMemory(void);
@@ -29,6 +31,10 @@ void requirePathnameExists(const char *name, const char *path);
 void parse_time_t(time_t * var);
 /// Parse bytes number from a string
 void parseBytesOptionValue(size_t * bptr, const char *units, char const * value);
+
+void dump_SBufList(std::ostream &, const SBufList &);
+// dumps SBufList with name prefix
+void dump_SBufList(std::ostream &, const char *name, const SBufList &);
 
 namespace Configuration {
 

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -115,3 +115,4 @@ sslproxy_cert_sign	acl
 sslproxy_cert_adapt	acl
 ftp_epsv                acl
 cache_log_message
+::ClientHttpVersionSelector* acl

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2736,6 +2736,105 @@ DOC_START
 	- ssl-bump
 DOC_END
 
+NAME: client_http_version
+TYPE: ::ClientHttpVersionSelector*
+DEFAULT: none
+DEFAULT_DOC: Use client preferences (if signaled) or HTTP/1 (otherwise).
+LOC: Config.clientHttpVersionSelector
+IFDEF: USE_OPENSSL
+DOC_START
+	Determines the major HTTP version to use on an accepted client-to-Squid
+	connection or a CONNECT tunnel stared at or bumped by SslBump rules.
+
+	    client_http_version <version> [if [!]<aclname>...]
+
+	This directive is checked in three cases: After accepting a TCP connection
+	on an `http_port`, after accepting a TLS connection on an `https_port`,
+	and when Squid generates a TLS ServerHello response while meddling with
+	client CONNECT tunnel traffic using SslBump rules. When this directive is
+	evaluated after accepting a client connection, no HTTP transaction-level
+	information is available yet (e.g., a `has request` ACL does not match).
+
+	Client preferences signaled via TLS ALPN (RFC 7301) can be tested using
+	`tls::client_alpn` ACLs. When the client sends an ALPN ClientHello
+	extension, Squid responds with an ALPN ServerHello extension value
+	determined by this directive.
+
+	When a client sent a TLS ALPN extension that did not list the HTTP version
+	subsequently selected by this directive, Squid terminates the TLS connect
+	after sending a fatal TLS `no_application_protocol` alert. Thus, this
+	directive can be used to block traffic. It is used before `http_access`
+	directive is checked.
+
+	The following `version` values are supported:
+
+	    http/1.1: Use HTTP/1.1. If a TLS client sends ALPN, but its list of
+	              client-supported protocols does not contain `http/1.1`, then
+	              Squid terminates the TLS connection after sending a fatal
+	              TLS `no_application_protocol` alert. When accepting a plain
+	              text `http_port` connection or serving a TLS client that
+	              does not send ALPN, Squid uses HTTP/1.1. In this context,
+	              Squid does not treat (unusual) ALPN `http/1.0` values
+	              specially. Unlike `any`, this option overwrites client
+	              protocol version preferences.
+
+	    h2: Use HTTP/2. If a TLS client does not send ALPN, or the sent ALPN
+	              list of client-supported protocols does not contain `h2`,
+	              then Squid terminates the TLS connection after sending a
+	              fatal TLS `no_application_protocol` alert. When accepting a
+	              plain text `http_port` connection, Squid terminates it. In
+	              this context, Squid does not treat (unusual) ALPN `h2c`
+	              values specially. Unlike `any`, this option overwrites
+	              client protocol version preferences.
+
+	    any: Use HTTP/1.1 or HTTP/2, whichever is preferred by the client. If
+	              a TLS client does not send ALPN, use HTTP/1.1. If the sent
+	              ALPN list of client-supported protocols contains neither
+	              `http/1.1` nor `h2` values, then Squid terminates the TLS
+	              connection after sending a fatal TLS
+	              `no_application_protocol` alert. When accepting a plain text
+	              `http_port` connection, Squid uses HTTP/1.1.
+
+	A rule matches if all of its ACLs match. A rule without ACLs always
+	matches.
+
+	The rules are checked in the directives configuration order. The first
+	matching rule wins. If there are no rules or if no rules match, an
+	implicit `client_http_version any` rule is used.
+
+	Examples:
+
+	    # Require HTTP/1.1 but use HTTP/2 for connections to https_port named "modern".
+	    acl received_on_h2_port myportname modern
+	    client_http_version h2 if received_on_h2_port
+	    client_http_version http/1.1
+
+	    # Follow client preferences but require a certain client to use HTTP/2.
+	    acl testClient src 127.0.0.10
+	    client_http_version h2 if mustUseH2
+	    client_http_version any
+
+	    # Use HTTP/1 if the TLS client supports it and require HTTP/2 otherwise.
+	    acl client_supports_h1 tls::client_alpn http/1.1
+	    client_http_version http/1.1 if client_supports_h1
+	    client_http_version h2
+
+	    # Use HTTP/1 if the TLS client prefers it and require HTTP/2 otherwise.
+	    acl client_prefers_h1 tls::client_alpn http/1.1 h2
+	    client_http_version http/1.1 if client_prefers_h1
+	    client_http_version h2
+
+	    # Follow client preferences if the client supports both versions and
+	    # require HTTP/1 otherwise.
+	    acl client_supports_h1 tls::client_alpn http/1.1
+	    acl client_supports_h2 tls::client_alpn h2
+	    client_http_version any if client_supports_h1 client_supports_h2
+	    client_http_version http/1.1
+
+	This clause only supports fast acl types.
+	See https://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
+DOC_END
+
 NAME: tcp_outgoing_tos tcp_outgoing_ds tcp_outgoing_dscp
 TYPE: acl_tos
 DEFAULT: none

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2741,6 +2741,8 @@ TYPE: ::ClientHttpVersionSelector*
 DEFAULT: none
 DEFAULT_DOC: The default implements `client_http_version any` behavior.
 LOC: Config.clientHttpVersionSelector
+COMPONENT_RECONFIGURATION_TYPE: ClientHttpVersionSelector*
+REPETITIONS: update
 IFDEF: USE_OPENSSL
 DOC_START
 	Determines the major HTTP version to use on an accepted client-to-Squid

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2739,7 +2739,7 @@ DOC_END
 NAME: client_http_version
 TYPE: ::ClientHttpVersionSelector*
 DEFAULT: none
-DEFAULT_DOC: Use client preferences (if signaled) or HTTP/1 (otherwise).
+DEFAULT_DOC: The default implements `client_http_version any` behavior.
 LOC: Config.clientHttpVersionSelector
 IFDEF: USE_OPENSSL
 DOC_START
@@ -2760,40 +2760,49 @@ DOC_START
 	extension, Squid responds with an ALPN ServerHello extension value
 	determined by this directive.
 
-	When a client sent a TLS ALPN extension that did not list the HTTP version
-	subsequently selected by this directive, Squid terminates the TLS connect
-	after sending a fatal TLS `no_application_protocol` alert. Thus, this
-	directive can be used to block traffic. It is used before `http_access`
-	directive is checked.
+	Squid terminates the connection if the client does not support the HTTP
+	version selected by this directive. Thus, this directive can be used to
+	block traffic. This directive is used before the `http_access` directive.
 
 	The following `version` values are supported:
 
 	    http/1.1: Use HTTP/1.1. If a TLS client sends ALPN, but its list of
-	              client-supported protocols does not contain `http/1.1`, then
-	              Squid terminates the TLS connection after sending a fatal
-	              TLS `no_application_protocol` alert. When accepting a plain
-	              text `http_port` connection or serving a TLS client that
-	              does not send ALPN, Squid uses HTTP/1.1. In this context,
-	              Squid does not treat (unusual) ALPN `http/1.0` values
-	              specially. Unlike `any`, this option overwrites client
-	              protocol version preferences.
+	        client-supported protocols does not contain `http/1.1`, then Squid
+	        terminates the TLS connection after sending a fatal TLS
+	        `no_application_protocol` alert. When accepting a plain text
+	        `http_port` connection or serving a TLS client that does not send
+	        ALPN, Squid uses HTTP/1.1. In this context, Squid does not treat
+	        (unusual) ALPN `http/1.0` values specially. Unlike `any`, this
+	        option ignores client protocol version preferences.
 
-	    h2: Use HTTP/2. If a TLS client does not send ALPN, or the sent ALPN
-	              list of client-supported protocols does not contain `h2`,
-	              then Squid terminates the TLS connection after sending a
-	              fatal TLS `no_application_protocol` alert. When accepting a
-	              plain text `http_port` connection, Squid terminates it. In
-	              this context, Squid does not treat (unusual) ALPN `h2c`
-	              values specially. Unlike `any`, this option overwrites
-	              client protocol version preferences.
+	    h2: Use HTTP/2. If a TLS client does not send ALPN, then Squid
+	        terminates the TLS connection. If a TLS client sends ALPN, but its
+	        list of client-supported protocols does not contain `h2`, then
+	        Squid terminates the TLS connection after sending a fatal TLS
+	        `no_application_protocol` alert. If the client opened a plain text
+	        `http_port` connection, Squid terminates it. In this context,
+	        Squid does not treat (unusual) ALPN `h2c` values specially. Unlike
+	        `any`, this option ignores client protocol version preferences.
 
-	    any: Use HTTP/1.1 or HTTP/2, whichever is preferred by the client. If
-	              a TLS client does not send ALPN, use HTTP/1.1. If the sent
-	              ALPN list of client-supported protocols contains neither
-	              `http/1.1` nor `h2` values, then Squid terminates the TLS
-	              connection after sending a fatal TLS
-	              `no_application_protocol` alert. When accepting a plain text
-	              `http_port` connection, Squid uses HTTP/1.1.
+	        Currently, Squid does not support HTTP/2, so this option results
+	        in client connection termination. When Squid supports HTTP/2, the
+	        same `h2`-based rule would enable HTTP/2 transactions for clients
+	        that claim HTTP/2 support.
+
+	    any: Use any protocol supported by Squid that is also supported by the
+	        client. If a TLS client sends ALPN list with multiple protocols
+	        supported by Squid, use the first such protocol (i.e. use a
+	        mutually-supported protocol preferred by the client). If a TLS
+	        client does not send ALPN, use HTTP/1.1. If the sent ALPN list of
+	        client-supported protocols does not name any protocol supported by
+	        Squid, then Squid terminates the TLS connection after sending a
+	        fatal TLS `no_application_protocol` alert. When accepting a plain
+	        text `http_port` connection, Squid uses HTTP/1.1.
+
+	        Currently, Squid does not support HTTP/2, so this option is
+	        equivalent to `http/1.1`. When Squid support for HTTP/2 is mature
+	        enough, the same `any`-based rule would would enable HTTP/2
+	        transactions for clients that claim HTTP/2 support.
 
 	A rule matches if all of its ACLs match. A rule without ACLs always
 	matches.

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2174,10 +2174,8 @@ httpAccept(const CommAcceptCbParams &params)
         ACLFilledChecklist ch(nullptr, nullptr);
         ch.src_addr = params.conn->remote;
         ch.my_addr = params.conn->local;
-        if (const auto proto = Config.clientHttpVersionSelector->check(ch)) {
-            if (proto->empty())
-                return;
-        }
+        if (Config.clientHttpVersionSelector->check(ch).empty())
+            return;
     }
 
     debugs(33, 4, params.conn << ": accepted");
@@ -2236,7 +2234,6 @@ clientNegotiateSSL(int fd, void *data)
     }
 
     Security::SessionPointer session(fd_table[fd].ssl);
-
 
 #if USE_OPENSSL
     if (Security::SessionIsResumed(session)) {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2174,7 +2174,7 @@ httpAccept(const CommAcceptCbParams &params)
         ACLFilledChecklist ch(nullptr, nullptr);
         ch.src_addr = params.conn->remote;
         ch.my_addr = params.conn->local;
-        if (ClientHttpVersionSelector::Check(&ch, nullptr, 0).isEmpty())
+        if (!ClientHttpVersionSelector::Check(&ch, nullptr, 0))
             return;
     }
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2174,7 +2174,8 @@ httpAccept(const CommAcceptCbParams &params)
         ACLFilledChecklist ch(nullptr, nullptr);
         ch.src_addr = params.conn->remote;
         ch.my_addr = params.conn->local;
-        if (!Config.clientHttpVersionSelector->check(ClientHttpVersion::http11, ch))
+        static const SBufList defaultAlpnList{SBuf("http/1.1")};
+        if (!Config.clientHttpVersionSelector->check(defaultAlpnList, ch))
             return;
     }
 
@@ -2234,6 +2235,18 @@ clientNegotiateSSL(int fd, void *data)
     }
 
     Security::SessionPointer session(fd_table[fd].ssl);
+
+    if (const auto protocolList = static_cast<SBufList *>(SSL_get_ex_data(session.get(), ssl_ex_index_ssl_error_detail))) {
+        if (Config.clientHttpVersionSelector) {
+            ACLFilledChecklist ch(nullptr, nullptr);
+            conn->fillChecklist(ch);
+            if (!Config.clientHttpVersionSelector->check(*protocolList, ch)) {
+                // TODO: set an error?
+                conn->clientConnection->close();
+                return;
+            }
+        }
+    }
 
 #if USE_OPENSSL
     if (Security::SessionIsResumed(session)) {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2177,14 +2177,6 @@ httpAccept(const CommAcceptCbParams &params)
         return;
     }
 
-    if (Config.clientHttpVersionSelector) {
-        ACLFilledChecklist ch(nullptr, nullptr);
-        ch.src_addr = params.conn->remote;
-        ch.my_addr = params.conn->local;
-        if (!ClientHttpVersionSelector::Check(&ch, nullptr, 0))
-            return;
-    }
-
     debugs(33, 4, params.conn << ": accepted");
     fd_note(params.conn->fd, "client http connect");
     const auto xact = MasterXaction::MakePortful(params.port);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2174,7 +2174,7 @@ httpAccept(const CommAcceptCbParams &params)
         ACLFilledChecklist ch(nullptr, nullptr);
         ch.src_addr = params.conn->remote;
         ch.my_addr = params.conn->local;
-        if (Config.clientHttpVersionSelector->check(ch).empty())
+        if (ClientHttpVersionSelector::Check(&ch, nullptr, 0).isEmpty())
             return;
     }
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -71,6 +71,7 @@
 #include "client_side_reply.h"
 #include "client_side_request.h"
 #include "ClientRequestContext.h"
+#include "clients/HttpVersionSelector.h"
 #include "comm.h"
 #include "comm/Connection.h"
 #include "comm/Loops.h"
@@ -2167,6 +2168,14 @@ httpAccept(const CommAcceptCbParams &params)
         // Its possible the call was still queued when the client disconnected
         debugs(33, 2, params.port->listenConn << ": accept failure: " << xstrerr(params.xerrno));
         return;
+    }
+
+    if (Config.clientHttpVersionSelector) {
+        ACLFilledChecklist ch(nullptr, nullptr);
+        ch.src_addr = params.conn->remote;
+        ch.my_addr = params.conn->local;
+        if (!Config.clientHttpVersionSelector->check(ClientHttpVersion::http11, ch))
+            return;
     }
 
     debugs(33, 4, params.conn << ": accepted");

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1850,6 +1850,13 @@ ConnStateData::afterClientRead()
     if (pipeline.empty())
         fd_note(clientConnection->fd, "Reading next request");
 
+    if (auto ssl = fd_table[clientConnection->fd].ssl.get()) {
+        const auto proto = static_cast<const std::optional<SBuf> *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn_selected));
+        Assure(proto);
+        Assure(*proto);
+        Assure(proto->value() == ClientHttpVersionSelector::Http11Protocol);
+    }
+
     parseRequests();
 
     if (!isOpen())

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2174,9 +2174,10 @@ httpAccept(const CommAcceptCbParams &params)
         ACLFilledChecklist ch(nullptr, nullptr);
         ch.src_addr = params.conn->remote;
         ch.my_addr = params.conn->local;
-        static const SBufList defaultAlpnList{SBuf("http/1.1")};
-        if (!Config.clientHttpVersionSelector->check(defaultAlpnList, ch))
-            return;
+        if (const auto proto = Config.clientHttpVersionSelector->check(ch)) {
+            if (proto->empty())
+                return;
+        }
     }
 
     debugs(33, 4, params.conn << ": accepted");
@@ -2236,17 +2237,6 @@ clientNegotiateSSL(int fd, void *data)
 
     Security::SessionPointer session(fd_table[fd].ssl);
 
-    if (const auto protocolList = static_cast<SBufList *>(SSL_get_ex_data(session.get(), ssl_ex_index_ssl_error_detail))) {
-        if (Config.clientHttpVersionSelector) {
-            ACLFilledChecklist ch(nullptr, nullptr);
-            conn->fillChecklist(ch);
-            if (!Config.clientHttpVersionSelector->check(*protocolList, ch)) {
-                // TODO: set an error?
-                conn->clientConnection->close();
-                return;
-            }
-        }
-    }
 
 #if USE_OPENSSL
     if (Security::SessionIsResumed(session)) {
@@ -2344,6 +2334,15 @@ httpsEstablish(ConnStateData *connState, const Security::ContextPointer &ctx)
         return;
 
     connState->resetReadTimeout(Config.Timeout.request);
+
+#if USE_OPENSSL
+    if (Config.clientHttpVersionSelector) {
+        Security::SessionPointer session(fd_table[details->fd].ssl);
+        auto ch = ACLFilledChecklist::Make(nullptr, nullptr);
+        connState->fillChecklist(*ch);
+        SSL_set_ex_data(session.get(), ssl_ex_index_ssl_alpn, ch.release());
+    }
+#endif
 
     Comm::SetSelect(details->fd, COMM_SELECT_READ, clientNegotiateSSL, connState, 0);
 }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1850,13 +1850,6 @@ ConnStateData::afterClientRead()
     if (pipeline.empty())
         fd_note(clientConnection->fd, "Reading next request");
 
-    if (auto ssl = fd_table[clientConnection->fd].ssl.get()) {
-        const auto proto = static_cast<const std::optional<SBuf> *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn_selected));
-        Assure(proto);
-        Assure(*proto);
-        Assure(proto->value() == ClientHttpVersionSelector::Http11Protocol);
-    }
-
     parseRequests();
 
     if (!isOpen())

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -19,48 +19,46 @@
 #include "sbuf/Stream.h"
 #include "SquidConfig.h"
 
+#include <algorithm>
+#include <array>
+#include <utility>
 
-static bool
+static const std::array<std::pair<ClientHttpVersionSelector::Protocol, const char *>, 3> ProtoVersionMap = {{
+    {ClientHttpVersionSelector::http11, "http/1.1" },
+    {ClientHttpVersionSelector::h2, "h2"},
+    {ClientHttpVersionSelector::any, "any"}
+}};
+
+const SBuf ClientHttpVersionSelector::Http11Protocol(ProtoVersionMap[ClientHttpVersionSelector::http11].second);
+const SBuf ClientHttpVersionSelector::Http2Protocol(ProtoVersionMap[ClientHttpVersionSelector::h2].second);
+const SBuf ClientHttpVersionSelector::AnyProtocol(ProtoVersionMap[ClientHttpVersionSelector::any].second);
+
+static std::optional<ClientHttpVersionSelector::Protocol>
 parseProtocol(const SBuf &protocol)
 {
-    if (protocol == ClientHttpVersionSelector::Http11Protocol)
-        return true;
-    else if (protocol.cmp("h2") == 0)
-        return true;
-    else if (protocol == ClientHttpVersionSelector::AnyProtocol)
-        return true;
-    return false;
-}
-
-ClientHttpVersion::ClientHttpVersion(ConfigParser &parser)
-{
-    const auto version = parser.token("client http version type");
-    if (!parseProtocol(version))
-        throw TextException(ToSBuf("unsupported client http version: '", version, "'"), Here());
-    protocol = version;
-    aclList = parser.optionalAclList();
-}
-
-ClientHttpVersion::~ClientHttpVersion()
-{
-    aclDestroyAclList(&aclList);
-}
-
-void
-ClientHttpVersion::print(std::ostream &os) const
-{
-    os << protocol << '\n';
+    auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {
+            return protocol.cmp(p.second) == 0;
+            });
+    if (it == ProtoVersionMap.end())
+        return std::nullopt;
+    return it->first;
 }
 
 static std::optional<SBuf>
-Supported(const char *clientProtocol, const unsigned int protoLen)
+ClientSupported(const char *clientProtocol, const unsigned int protoLen)
 {
     const auto &supportedProtocol = ClientHttpVersionSelector::Http11Protocol;
     return supportedProtocol.cmp(clientProtocol, protoLen) == 0 ? std::make_optional(supportedProtocol) : std::nullopt;
 }
 
 static bool
-Matched(const SBuf &candidateProtocol, const char *clientProto, unsigned int clientProtoLen)
+ConfigurationSupported(const SBuf &candidateProtocol)
+{
+    return candidateProtocol == ClientHttpVersionSelector::Http11Protocol || candidateProtocol == ClientHttpVersionSelector::AnyProtocol;
+}
+
+static bool
+ClientMatched(const SBuf &candidateProtocol, const char *clientProto, unsigned int clientProtoLen)
 {
     return candidateProtocol.cmp(clientProto, clientProtoLen) == 0 || candidateProtocol.cmp("any") == 0;
 }
@@ -68,42 +66,57 @@ Matched(const SBuf &candidateProtocol, const char *clientProto, unsigned int cli
 static std::optional<SBuf>
 CheckProtocol(const char *in, unsigned int inLen, const SBuf &matchedProtocol)
 {
-    std::optional<SBuf> resultProtocol = std::nullopt;
+    debugs(11, 5, "Configuration candidate: " << matchedProtocol << " has ALPN: " << bool(in));
+
+    if (!ConfigurationSupported(matchedProtocol))
+        return std::nullopt;
 
     if (!in) {
         assert(!inLen);
         // A client not providing ALPN usually intends to use http/1.1.
-        const auto &clientDefault = ClientHttpVersionSelector::Http11Protocol;
-        if (Matched(matchedProtocol, clientDefault.rawContent(), clientDefault.length()))
-            resultProtocol = clientDefault;
-    } else {
-        assert(inLen);
-
-        auto current = in;
-        auto remaining = inLen;
-        while (remaining > 0) {
-            unsigned int protoLen = *current;
-            assert(remaining > protoLen);
-            auto clientProtocol = current+1;
-            debugs(11, 5, Raw("ALPN candidate", clientProtocol, protoLen));
-            if (Matched(matchedProtocol, clientProtocol, protoLen)) {
-                resultProtocol = Supported(clientProtocol, protoLen);
-                break;
-            }
-
-            // the buffer boundaries must have been checked by tls_parse_ctos_alpn()
-            current += (protoLen + 1);
-            remaining -= (protoLen + 1);
-        }
+        return (matchedProtocol == ClientHttpVersionSelector::AnyProtocol) ? ClientHttpVersionSelector::Http11Protocol : matchedProtocol;
     }
-    debugs(11, 2, "Selected HTTP version: " << (resultProtocol ? resultProtocol->c_str() : "none"));
-    return resultProtocol;
+
+    assert(inLen);
+
+    auto current = in;
+    auto remaining = inLen;
+    while (remaining > 0) {
+        unsigned int protoLen = *current;
+        Assure(remaining > protoLen);
+        auto clientProtocol = current+1;
+        debugs(11, 5, Raw("ALPN candidate", clientProtocol, protoLen));
+        if (ClientMatched(matchedProtocol, clientProtocol, protoLen)) {
+            if (auto resultProtocol = ClientSupported(clientProtocol, protoLen)) {
+                debugs(11, 2, "Selected HTTP version: " << *resultProtocol);
+                return resultProtocol;
+            }
+        }
+        // the buffer boundaries must have been checked by the OpenSSL library (tls_parse_ctos_alpn() or equivalent)
+        current += (protoLen + 1);
+        remaining -= (protoLen + 1);
+    }
+
+    debugs(11, 2, "Selected none");
+    return std::nullopt;
 }
 
 void
-ClientHttpVersionSelector::add(ConfigParser &parser)
+ClientHttpVersionSelector::parse(ConfigParser &parser)
 {
-    directives.emplace_back(std::make_shared<ClientHttpVersion>(parser));
+    const auto version = parser.token("client http version type");
+
+    auto proto = parseProtocol(version);
+    if (!proto)
+        throw TextException(ToSBuf("unsupported client http version: '", version, "'"), Here());
+
+    auto action = Acl::Answer(ACCESS_ALLOWED);
+    action.kind = *proto;
+
+    auto raw = aclList.get();
+    ParseOptionalAclWithAction(parser, &raw, action, "client_http_version");
+    if (!aclList)
+        aclList.reset(raw);
 }
 
 const std::optional<SBuf>
@@ -119,11 +132,16 @@ ClientHttpVersionSelector::Check(ACLFilledChecklist *ch, const char *alpn, unsig
 const std::optional<SBuf>
 ClientHttpVersionSelector::check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist &ch)
 {
-    auto matchedVersion = std::find_if(directives.begin(), directives.end(), [&](const ClientHttpVersion::Pointer& version) {
-        return !version->aclList || ch.fastCheck(version->aclList).allowed();
-    });
+    const auto &answer = ch.fastCheck(aclList.get());
+    auto proto = AnyProtocol;
+    if (answer.allowed()) {
+        auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {
+            return answer.kind == p.first;
+        });
+        Assure(it != ProtoVersionMap.end());
+        proto = it->second;
+    }
 
-    const auto proto = (matchedVersion == directives.end()) ?  AnyProtocol : (*matchedVersion)->protocol;
     return CheckProtocol(alpn, alpnLen, proto);
 }
 
@@ -145,20 +163,21 @@ template <>
 void
 Configuration::Component<ClientHttpVersionSelector*>::FinishSmoothReconfiguration(SmoothReconfiguration &sr)
 {
-    if (!Config.clientHttpVersionSelector && sr.fresh.clientHttpVersionSelector->directives.empty())
+    if (!Config.clientHttpVersionSelector && !sr.fresh.clientHttpVersionSelector->aclList)
         return;
 
     Reset(Config.clientHttpVersionSelector);
 
-    if (sr.fresh.clientHttpVersionSelector->directives.size())
-        Config.clientHttpVersionSelector = new ClientHttpVersionSelector(*sr.fresh.clientHttpVersionSelector);
+    // if parsed at least one directive
+    if (sr.fresh.clientHttpVersionSelector->aclList)
+        Config.clientHttpVersionSelector = new ClientHttpVersionSelector(std::move(*sr.fresh.clientHttpVersionSelector));
  }
 
 template <>
 void
 Configuration::Component<ClientHttpVersionSelector*>::Reconfigure(SmoothReconfiguration &sr, ClientHttpVersionSelector *&, ConfigParser &parser)
 {
-    sr.fresh.clientHttpVersionSelector->add(parser);
+    sr.fresh.clientHttpVersionSelector->parse(parser);
 }
 
 template <>
@@ -167,7 +186,8 @@ Configuration::Component<ClientHttpVersionSelector*>::Parse(ClientHttpVersionSel
 {
     if (!raw)
         raw = new ClientHttpVersionSelector();
-    raw->add(parser);
+
+    raw->parse(parser);
 }
 
 template <>
@@ -176,8 +196,17 @@ Configuration::Component<ClientHttpVersionSelector*>::Print(std::ostream &os, Cl
 {
     Assure(selector);
 
-    for (const auto &version: selector->directives) {
-        os << directiveName << ' ';
-        version->print(os);
+    if (auto list = selector->aclList.get()) {
+        const auto lines = ToTree(list).treeDump(directiveName, [](const Acl::Answer &action) {
+            auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {
+                    return p.first == action.kind;
+            });
+            assert(it == ProtoVersionMap.end());
+            return it->second;
+        });
+        for (const auto &line : lines)
+            os << line << " ";
+        os << "\n";
     }
 }
+

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -12,6 +12,7 @@
 #include "acl/Gadgets.h"
 #include "acl/Tree.h"
 #include "base/Raw.h"
+#include "cache_cf.h"
 #include "ConfigOption.h"
 #include "ConfigParser.h"
 #include "configuration/Smooth.h"
@@ -68,13 +69,17 @@ CheckProtocol(const char *in, unsigned int inLen, const SBuf &matchedProtocol)
 {
     debugs(11, 5, "Configuration candidate: " << matchedProtocol << " has ALPN: " << bool(in));
 
-    if (!ConfigurationSupported(matchedProtocol))
+    if (!ConfigurationSupported(matchedProtocol)) {
+        debugs(11, 2, "The configured HTTP version " << matchedProtocol << " is unsupported.");
         return std::nullopt;
+    }
 
     if (!in) {
         assert(!inLen);
         // A client not providing ALPN usually intends to use http/1.1.
-        return (matchedProtocol == ClientHttpVersionSelector::AnyProtocol) ? ClientHttpVersionSelector::Http11Protocol : matchedProtocol;
+        const auto resultProtocol = (matchedProtocol == ClientHttpVersionSelector::AnyProtocol) ? ClientHttpVersionSelector::Http11Protocol : matchedProtocol;
+        debugs(11, 2, "Selected HTTP version: " << resultProtocol);
+        return resultProtocol;
     }
 
     assert(inLen);
@@ -196,14 +201,15 @@ Configuration::Component<ClientHttpVersionSelector*>::Print(std::ostream &os, Cl
     if (auto list = selector->aclList.get()) {
         const auto lines = ToTree(list).treeDump(directiveName, [](const Acl::Answer &action) {
             auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {
-                    return p.first == action.kind;
+                return p.first == action.kind;
             });
-            assert(it == ProtoVersionMap.end());
-            return it->second;
+            assert(it != ProtoVersionMap.end());
+            // TODO: get rid of this static SBuf
+            static SBuf result;
+            result = ToSBuf(it->second, " if ");
+            return result.c_str();
         });
-        for (const auto &line : lines)
-            os << line << " ";
-        os << "\n";
+        dump_SBufList(os, lines);
     }
 }
 

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -125,14 +125,11 @@ ClientHttpVersionSelector::Check(ACLFilledChecklist *ch, const char *alpn, unsig
     if (!ch)
         return CheckProtocol(alpn, alpnLen, ClientHttpVersionSelector::AnyProtocol);
 
-    assert(Config.clientHttpVersionSelector);
-    return Config.clientHttpVersionSelector->check(alpn ,alpnLen, *ch);
-}
+    Assure(Config.clientHttpVersionSelector);
+    auto aclList =  Config.clientHttpVersionSelector->aclList.get();
+    Assure(aclList);
 
-const std::optional<SBuf>
-ClientHttpVersionSelector::check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist &ch)
-{
-    const auto &answer = ch.fastCheck(aclList.get());
+    const auto &answer = ch->fastCheck(aclList);
     auto proto = AnyProtocol;
     if (answer.allowed()) {
         auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -18,25 +18,24 @@
 #include "sbuf/Stream.h"
 #include "SquidConfig.h"
 
-static ClientHttpVersion::Protocol
+static bool
 parseProtocol(const SBuf &protocol)
 {
     if (protocol.cmp("http/1.1") == 0)
-        return ClientHttpVersion::http11;
+        return true;
     else if (protocol.cmp("h2") == 0)
-        return ClientHttpVersion::h2;
+        return true;
     else if (protocol.cmp("any") == 0)
-        return ClientHttpVersion::any;
-    else
-        return ClientHttpVersion::none;
+        return true;
+    return false;
 }
 
 ClientHttpVersion::ClientHttpVersion(ConfigParser &parser)
 {
     const auto version = parser.token("client http version type");
-    protocol = parseProtocol(version);
-    if (protocol == none)
+    if (parseProtocol(version))
         throw TextException(ToSBuf("unsupported client http version: '", version, "'"), Here());
+    protocol = version;
     aclList = parser.optionalAclList();
 }
 
@@ -48,21 +47,7 @@ ClientHttpVersion::~ClientHttpVersion()
 void
 ClientHttpVersion::print(std::ostream &os) const
 {
-    switch (protocol) {
-    case none:
-        os << "none";
-        break;
-    case http11:
-        os << "http/1.1";
-        break;
-    case h2:
-        os << "h2";
-        break;
-    case any:
-        os << "any";
-        break;
-    }
-    os << "\n";
+    os << protocol << '\n';
 }
 
 void
@@ -72,22 +57,44 @@ ClientHttpVersionSelector::add(ConfigParser &parser)
 }
 
 bool
-ClientHttpVersionSelector::check(const SBufList &protocols, ACLFilledChecklist &ch)
+ClientHttpVersionSelector::supported(const char *proto, const unsigned int protoLen) const {
+    return strncmp(proto, "http/1.1", protoLen) == 0;
+}
+
+std::optional<std::string_view>
+ClientHttpVersionSelector::check(ACLFilledChecklist &ch)
 {
-    std::vector<ClientHttpVersion::Protocol> clientProtocols;
-    for (auto p: protocols) {
-        const auto parsed = parseProtocol(p);
-        if (parsed != ClientHttpVersion::none)
-            clientProtocols.push_back(parsed);
+    return check(nullptr, 0, ch);
+}
+
+std::optional<std::string_view>
+ClientHttpVersionSelector::check(const char *in, unsigned int inLen, ACLFilledChecklist &ch)
+{
+    static const char http11_alpn[] = {8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+    if (!in) {
+        in = &http11_alpn[1];
+        inLen = http11_alpn[0];
     }
 
     for (auto &version: directives) {
         if (!version->aclList || ch.fastCheck(version->aclList).allowed()) {
-            for (auto p: clientProtocols)
-                return (p == version->protocol || version->protocol == ClientHttpVersion::any);
+            // 'in' contains the client's offered ALPN protocols in format:
+            // [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
+            auto current = in;
+            auto remaining = inLen;
+            while (remaining > 0) {
+                unsigned int protoLen = *current;
+                const char *proto = current+1;
+                if ((version->protocol.cmp(proto, protoLen) == 0 || version->protocol.cmp("any") == 0) && supported(proto, protoLen)) {
+                    return std::make_optional<std::string_view>(current, protoLen+1);
+                }
+                current += (protoLen + 1);
+                remaining -= (protoLen + 1);
+            }
+            return std::string_view{};
         }
     }
-    return true;
+    return std::nullopt;
 }
 
 template <>

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -18,19 +18,25 @@
 #include "sbuf/Stream.h"
 #include "SquidConfig.h"
 
+static ClientHttpVersion::Protocol
+parseProtocol(const SBuf &protocol)
+{
+    if (protocol.cmp("http/1.1") == 0)
+        return ClientHttpVersion::http11;
+    else if (protocol.cmp("h2") == 0)
+        return ClientHttpVersion::h2;
+    else if (protocol.cmp("any") == 0)
+        return ClientHttpVersion::any;
+    else
+        return ClientHttpVersion::none;
+}
 
 ClientHttpVersion::ClientHttpVersion(ConfigParser &parser)
 {
     const auto version = parser.token("client http version type");
-    if (version.cmp("http/1.1") == 0)
-    	protocol = http11;
-    else if (version.cmp("h2") == 0)
-        protocol = h2;
-    else if (version.cmp("any") == 0)
-    	protocol = any;
-    else
+    protocol = parseProtocol(version);
+    if (protocol == none)
         throw TextException(ToSBuf("unsupported client http version: '", version, "'"), Here());
-
     aclList = parser.optionalAclList();
 }
 
@@ -43,6 +49,9 @@ void
 ClientHttpVersion::print(std::ostream &os) const
 {
     switch (protocol) {
+    case none:
+        os << "none";
+        break;
     case http11:
         os << "http/1.1";
         break;
@@ -59,17 +68,26 @@ ClientHttpVersion::print(std::ostream &os) const
 void
 ClientHttpVersionSelector::add(ConfigParser &parser)
 {
-	directives.emplace_back(std::make_shared<ClientHttpVersion>(parser));
+    directives.emplace_back(std::make_shared<ClientHttpVersion>(parser));
 }
 
 bool
-ClientHttpVersionSelector::check(const ClientHttpVersion::Protocol clientProtocol, ACLFilledChecklist &ch)
+ClientHttpVersionSelector::check(const SBufList &protocols, ACLFilledChecklist &ch)
 {
-	for (auto &version: directives) {
-        if (!version->aclList || ch.fastCheck(version->aclList).allowed())
-            return (clientProtocol == version->protocol || version->protocol == ClientHttpVersion::any);
-	}
-	return true;
+    std::vector<ClientHttpVersion::Protocol> clientProtocols;
+    for (auto p: protocols) {
+        const auto parsed = parseProtocol(p);
+        if (parsed != ClientHttpVersion::none)
+            clientProtocols.push_back(parsed);
+    }
+
+    for (auto &version: directives) {
+        if (!version->aclList || ch.fastCheck(version->aclList).allowed()) {
+            for (auto p: clientProtocols)
+                return (p == version->protocol || version->protocol == ClientHttpVersion::any);
+        }
+    }
+    return true;
 }
 
 template <>
@@ -110,9 +128,9 @@ template <>
 void
 Configuration::Component<ClientHttpVersionSelector*>::Parse(ClientHttpVersionSelector *&raw, ConfigParser &parser)
 {
-	if (!raw)
+    if (!raw)
         raw = new ClientHttpVersionSelector();
-	raw->add(parser);
+    raw->add(parser);
 }
 
 template <>
@@ -122,7 +140,7 @@ Configuration::Component<ClientHttpVersionSelector*>::Print(std::ostream &os, Cl
     Assure(selector);
 
     for (const auto &version: selector->directives) {
-    	os << directiveName << ' ';
-    	version->print(os);
+        os << directiveName << ' ';
+        version->print(os);
     }
 }

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 1996-2026 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#include "acl/FilledChecklist.h"
+#include "acl/Gadgets.h"
+#include "acl/Tree.h"
+#include "ConfigOption.h"
+#include "ConfigParser.h"
+#include "configuration/Smooth.h"
+#include "HttpVersionSelector.h"
+#include "sbuf/Stream.h"
+#include "SquidConfig.h"
+
+
+ClientHttpVersion::ClientHttpVersion(ConfigParser &parser)
+{
+    const auto version = parser.token("client http version type");
+    if (version.cmp("http/1.1") == 0)
+    	protocol = http11;
+    else if (version.cmp("h2") == 0)
+        protocol = h2;
+    else if (version.cmp("any") == 0)
+    	protocol = any;
+    else
+        throw TextException(ToSBuf("unsupported client http version: '", version, "'"), Here());
+
+    aclList = parser.optionalAclList();
+}
+
+ClientHttpVersion::~ClientHttpVersion()
+{
+    aclDestroyAclList(&aclList);
+}
+
+void
+ClientHttpVersion::print(std::ostream &os) const
+{
+    switch (protocol) {
+    case http11:
+        os << "http/1.1";
+        break;
+    case h2:
+        os << "h2";
+        break;
+    case any:
+        os << "any";
+        break;
+    }
+    os << "\n";
+}
+
+void
+ClientHttpVersionSelector::add(ConfigParser &parser)
+{
+	directives.emplace_back(std::make_shared<ClientHttpVersion>(parser));
+}
+
+bool
+ClientHttpVersionSelector::check(const ClientHttpVersion::Protocol clientProtocol, ACLFilledChecklist &ch)
+{
+	for (auto &version: directives) {
+        if (!version->aclList || ch.fastCheck(version->aclList).allowed())
+            return (clientProtocol == version->protocol || version->protocol == ClientHttpVersion::any);
+	}
+	return true;
+}
+
+template <>
+void
+Configuration::Component<ClientHttpVersionSelector*>::Reset(ClientHttpVersionSelector *&selector)
+{
+    delete selector;
+    selector = nullptr;
+}
+
+template <>
+void
+Configuration::Component<ClientHttpVersionSelector*>::StartSmoothReconfiguration(SmoothReconfiguration &)
+{
+}
+
+template <>
+void
+Configuration::Component<ClientHttpVersionSelector*>::FinishSmoothReconfiguration(SmoothReconfiguration &sr)
+{
+    if (!Config.clientHttpVersionSelector && sr.fresh.clientHttpVersionSelector->directives.empty())
+        return;
+
+    Reset(Config.clientHttpVersionSelector);
+
+    if (sr.fresh.clientHttpVersionSelector->directives.size())
+        Config.clientHttpVersionSelector = new ClientHttpVersionSelector(*sr.fresh.clientHttpVersionSelector);
+ }
+
+template <>
+void
+Configuration::Component<ClientHttpVersionSelector*>::Reconfigure(SmoothReconfiguration &sr, ClientHttpVersionSelector *&, ConfigParser &parser)
+{
+    sr.fresh.clientHttpVersionSelector->add(parser);
+}
+
+template <>
+void
+Configuration::Component<ClientHttpVersionSelector*>::Parse(ClientHttpVersionSelector *&raw, ConfigParser &parser)
+{
+	if (!raw)
+        raw = new ClientHttpVersionSelector();
+	raw->add(parser);
+}
+
+template <>
+void
+Configuration::Component<ClientHttpVersionSelector*>::Print(std::ostream &os, ClientHttpVersionSelector * const &selector, const char * const directiveName)
+{
+    Assure(selector);
+
+    for (const auto &version: selector->directives) {
+    	os << directiveName << ' ';
+    	version->print(os);
+    }
+}

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -22,11 +22,11 @@
 static bool
 parseProtocol(const SBuf &protocol)
 {
-    if (protocol.cmp("http/1.1") == 0)
+    if (protocol == ClientHttpVersionSelector::Http11Protocol)
         return true;
     else if (protocol.cmp("h2") == 0)
         return true;
-    else if (protocol.cmp("any") == 0)
+    else if (protocol == ClientHttpVersionSelector::AnyProtocol)
         return true;
     return false;
 }
@@ -51,36 +51,48 @@ ClientHttpVersion::print(std::ostream &os) const
     os << protocol << '\n';
 }
 
-static const SBuf &
+static std::optional<SBuf>
 Supported(const char *clientProtocol, const unsigned int protoLen)
 {
-    static const SBuf SupportedProtocol = SBuf("http/1.1");
-    return SupportedProtocol.cmp(clientProtocol, protoLen) == 0 ? SupportedProtocol : ClientHttpVersionSelector::UnsupportedProtocol;
+    const auto &supportedProtocol = ClientHttpVersionSelector::Http11Protocol;
+    return supportedProtocol.cmp(clientProtocol, protoLen) == 0 ? std::make_optional(supportedProtocol) : std::nullopt;
 }
 
-static const SBuf &
+static bool
+Matched(const SBuf &candidateProtocol, const char *clientProto, unsigned int clientProtoLen)
+{
+    return candidateProtocol.cmp(clientProto, clientProtoLen) == 0 || candidateProtocol.cmp("any") == 0;
+}
+
+static std::optional<SBuf>
 CheckProtocol(const char *in, unsigned int inLen, const SBuf &matchedProtocol)
 {
-    // Use these defaults if client does not provide ALPN
-    // This usually means that the client intends to use http/1.1.
-    static const char http11Alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+    if (!in) {
+        assert(!inLen);
+        // A client not providing ALPN usually intends to use http/1.1.
+        const auto &clientDefault = ClientHttpVersionSelector::Http11Protocol;
+        if (Matched(matchedProtocol, clientDefault.rawContent(), clientDefault.length()))
+            return clientDefault;
+        return std::nullopt;
+    }
 
-    auto current = in ? in : &http11Alpn[0];
-    auto remaining = inLen ? inLen : http11Alpn[0]+1;
+    assert(inLen);
+
+    auto current = in;
+    auto remaining = inLen;
     while (remaining > 0) {
         unsigned int protoLen = *current;
-        const char *clientProtocol = current+1;
-        if ((matchedProtocol.cmp(clientProtocol, protoLen) == 0 || matchedProtocol.cmp("any") == 0)) {
-            const auto &result = Supported(clientProtocol, protoLen);
-            if (result != ClientHttpVersionSelector::UnsupportedProtocol)
-                return result;
-        }
+        assert(remaining > protoLen);
+        auto clientProtocol = current+1;
+        if (Matched(matchedProtocol, clientProtocol, protoLen))
+            return Supported(clientProtocol, protoLen);
+
         // the buffer boundaries must have been checked by tls_parse_ctos_alpn()
         current += (protoLen + 1);
         remaining -= (protoLen + 1);
     }
 
-    return ClientHttpVersionSelector::UnsupportedProtocol;
+    return std::nullopt;
 }
 
 void
@@ -89,7 +101,7 @@ ClientHttpVersionSelector::add(ConfigParser &parser)
     directives.emplace_back(std::make_shared<ClientHttpVersion>(parser));
 }
 
-const SBuf &
+const std::optional<SBuf>
 ClientHttpVersionSelector::Check(ACLFilledChecklist *ch, const char *alpn, unsigned int alpnLen)
 {
     if (!ch)
@@ -99,7 +111,7 @@ ClientHttpVersionSelector::Check(ACLFilledChecklist *ch, const char *alpn, unsig
     return Config.clientHttpVersionSelector->check(alpn ,alpnLen, *ch);
 }
 
-const SBuf &
+const std::optional<SBuf>
 ClientHttpVersionSelector::check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist &ch)
 {
     auto matchedVersion = std::find_if(directives.begin(), directives.end(), [&](const ClientHttpVersion::Pointer& version) {

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -18,6 +18,7 @@
 #include "sbuf/Stream.h"
 #include "SquidConfig.h"
 
+
 static bool
 parseProtocol(const SBuf &protocol)
 {
@@ -33,7 +34,7 @@ parseProtocol(const SBuf &protocol)
 ClientHttpVersion::ClientHttpVersion(ConfigParser &parser)
 {
     const auto version = parser.token("client http version type");
-    if (parseProtocol(version))
+    if (!parseProtocol(version))
         throw TextException(ToSBuf("unsupported client http version: '", version, "'"), Here());
     protocol = version;
     aclList = parser.optionalAclList();
@@ -50,51 +51,65 @@ ClientHttpVersion::print(std::ostream &os) const
     os << protocol << '\n';
 }
 
+static bool
+Supported(const char *clientProtocol, const unsigned int protoLen)
+{
+    return strncmp(clientProtocol, "http/1.1", protoLen) == 0;
+}
+
+static std::string_view
+CheckProtocol(const char *in, unsigned int inLen, const SBuf &matchedProtocol)
+{
+    // Use these defaults if client does not provide ALPN
+    // This usually means that the client intends to use http/1.1.
+    static const char http11Alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+
+    auto current = in ? in : &http11Alpn[0];
+    auto remaining = inLen ? inLen : http11Alpn[0]+1;
+    while (remaining > 0) {
+        unsigned int protoLen = *current;
+        const char *clientProtocol = current+1;
+        if ((matchedProtocol.cmp(clientProtocol, protoLen) == 0 || matchedProtocol.cmp("any") == 0) && Supported(clientProtocol, protoLen)) {
+            return std::string_view(current, protoLen+1);
+        }
+        current += (protoLen + 1);
+        remaining -= (protoLen + 1);
+    }
+
+    return std::string_view{};
+}
+
 void
 ClientHttpVersionSelector::add(ConfigParser &parser)
 {
     directives.emplace_back(std::make_shared<ClientHttpVersion>(parser));
 }
 
-bool
-ClientHttpVersionSelector::supported(const char *proto, const unsigned int protoLen) const {
-    return strncmp(proto, "http/1.1", protoLen) == 0;
-}
-
-std::optional<std::string_view>
+std::string_view
 ClientHttpVersionSelector::check(ACLFilledChecklist &ch)
 {
     return check(nullptr, 0, ch);
 }
 
-std::optional<std::string_view>
-ClientHttpVersionSelector::check(const char *in, unsigned int inLen, ACLFilledChecklist &ch)
+std::string_view
+ClientHttpVersionSelector::Check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist *ch)
 {
-    static const char http11_alpn[] = {8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
-    if (!in) {
-        in = &http11_alpn[1];
-        inLen = http11_alpn[0];
-    }
+    if (!ch)
+        return CheckProtocol(alpn, alpnLen, ClientHttpVersionSelector::AnyProtocol);
 
-    for (auto &version: directives) {
-        if (!version->aclList || ch.fastCheck(version->aclList).allowed()) {
-            // 'in' contains the client's offered ALPN protocols in format:
-            // [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
-            auto current = in;
-            auto remaining = inLen;
-            while (remaining > 0) {
-                unsigned int protoLen = *current;
-                const char *proto = current+1;
-                if ((version->protocol.cmp(proto, protoLen) == 0 || version->protocol.cmp("any") == 0) && supported(proto, protoLen)) {
-                    return std::make_optional<std::string_view>(current, protoLen+1);
-                }
-                current += (protoLen + 1);
-                remaining -= (protoLen + 1);
-            }
-            return std::string_view{};
-        }
-    }
-    return std::nullopt;
+    assert(Config.clientHttpVersionSelector);
+    return Config.clientHttpVersionSelector->check(alpn ,alpnLen, *ch);
+}
+
+std::string_view
+ClientHttpVersionSelector::check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist &ch)
+{
+    auto matchedVersion = std::find_if(directives.begin(), directives.end(), [&](const ClientHttpVersion::Pointer& version) {
+        return !version->aclList || ch.fastCheck(version->aclList).allowed();
+    });
+
+    const auto proto = (matchedVersion == directives.end()) ?  AnyProtocol : (*matchedVersion)->protocol;
+    return CheckProtocol(alpn, alpnLen, proto);
 }
 
 template <>

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -51,13 +51,14 @@ ClientHttpVersion::print(std::ostream &os) const
     os << protocol << '\n';
 }
 
-static bool
+static const SBuf &
 Supported(const char *clientProtocol, const unsigned int protoLen)
 {
-    return strncmp(clientProtocol, "http/1.1", protoLen) == 0;
+    static const SBuf SupportedProtocol = SBuf("http/1.1");
+    return SupportedProtocol.cmp(clientProtocol, protoLen) == 0 ? SupportedProtocol : ClientHttpVersionSelector::UnsupportedProtocol;
 }
 
-static std::string_view
+static const SBuf &
 CheckProtocol(const char *in, unsigned int inLen, const SBuf &matchedProtocol)
 {
     // Use these defaults if client does not provide ALPN
@@ -69,14 +70,17 @@ CheckProtocol(const char *in, unsigned int inLen, const SBuf &matchedProtocol)
     while (remaining > 0) {
         unsigned int protoLen = *current;
         const char *clientProtocol = current+1;
-        if ((matchedProtocol.cmp(clientProtocol, protoLen) == 0 || matchedProtocol.cmp("any") == 0) && Supported(clientProtocol, protoLen)) {
-            return std::string_view(current, protoLen+1);
+        if ((matchedProtocol.cmp(clientProtocol, protoLen) == 0 || matchedProtocol.cmp("any") == 0)) {
+            const auto &result = Supported(clientProtocol, protoLen);
+            if (result != ClientHttpVersionSelector::UnsupportedProtocol)
+                return result;
         }
+        // the buffer boundaries must have been checked by tls_parse_ctos_alpn()
         current += (protoLen + 1);
         remaining -= (protoLen + 1);
     }
 
-    return std::string_view{};
+    return ClientHttpVersionSelector::UnsupportedProtocol;
 }
 
 void
@@ -85,14 +89,8 @@ ClientHttpVersionSelector::add(ConfigParser &parser)
     directives.emplace_back(std::make_shared<ClientHttpVersion>(parser));
 }
 
-std::string_view
-ClientHttpVersionSelector::check(ACLFilledChecklist &ch)
-{
-    return check(nullptr, 0, ch);
-}
-
-std::string_view
-ClientHttpVersionSelector::Check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist *ch)
+const SBuf &
+ClientHttpVersionSelector::Check(ACLFilledChecklist *ch, const char *alpn, unsigned int alpnLen)
 {
     if (!ch)
         return CheckProtocol(alpn, alpnLen, ClientHttpVersionSelector::AnyProtocol);
@@ -101,7 +99,7 @@ ClientHttpVersionSelector::Check(const char *alpn, unsigned int alpnLen, ACLFill
     return Config.clientHttpVersionSelector->check(alpn ,alpnLen, *ch);
 }
 
-std::string_view
+const SBuf &
 ClientHttpVersionSelector::check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist &ch)
 {
     auto matchedVersion = std::find_if(directives.begin(), directives.end(), [&](const ClientHttpVersion::Pointer& version) {

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -11,6 +11,7 @@
 #include "acl/FilledChecklist.h"
 #include "acl/Gadgets.h"
 #include "acl/Tree.h"
+#include "base/Raw.h"
 #include "ConfigOption.h"
 #include "ConfigParser.h"
 #include "configuration/Smooth.h"
@@ -67,32 +68,36 @@ Matched(const SBuf &candidateProtocol, const char *clientProto, unsigned int cli
 static std::optional<SBuf>
 CheckProtocol(const char *in, unsigned int inLen, const SBuf &matchedProtocol)
 {
+    std::optional<SBuf> resultProtocol = std::nullopt;
+
     if (!in) {
         assert(!inLen);
         // A client not providing ALPN usually intends to use http/1.1.
         const auto &clientDefault = ClientHttpVersionSelector::Http11Protocol;
         if (Matched(matchedProtocol, clientDefault.rawContent(), clientDefault.length()))
-            return clientDefault;
-        return std::nullopt;
+            resultProtocol = clientDefault;
+    } else {
+        assert(inLen);
+
+        auto current = in;
+        auto remaining = inLen;
+        while (remaining > 0) {
+            unsigned int protoLen = *current;
+            assert(remaining > protoLen);
+            auto clientProtocol = current+1;
+            debugs(11, 5, Raw("ALPN candidate", clientProtocol, protoLen));
+            if (Matched(matchedProtocol, clientProtocol, protoLen)) {
+                resultProtocol = Supported(clientProtocol, protoLen);
+                break;
+            }
+
+            // the buffer boundaries must have been checked by tls_parse_ctos_alpn()
+            current += (protoLen + 1);
+            remaining -= (protoLen + 1);
+        }
     }
-
-    assert(inLen);
-
-    auto current = in;
-    auto remaining = inLen;
-    while (remaining > 0) {
-        unsigned int protoLen = *current;
-        assert(remaining > protoLen);
-        auto clientProtocol = current+1;
-        if (Matched(matchedProtocol, clientProtocol, protoLen))
-            return Supported(clientProtocol, protoLen);
-
-        // the buffer boundaries must have been checked by tls_parse_ctos_alpn()
-        current += (protoLen + 1);
-        remaining -= (protoLen + 1);
-    }
-
-    return std::nullopt;
+    debugs(11, 2, "Selected HTTP version: " << (resultProtocol ? resultProtocol->c_str() : "none"));
+    return resultProtocol;
 }
 
 void

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -29,10 +29,11 @@
 #include <utility>
 
 static const std::array<std::pair<ClientHttpVersionSelector::Protocol, const char *>, 3> ProtoVersionMap = {{
-    {ClientHttpVersionSelector::http11, "http/1.1" },
-    {ClientHttpVersionSelector::h2, "h2"},
-    {ClientHttpVersionSelector::any, "any"}
-}};
+        {ClientHttpVersionSelector::http11, "http/1.1" },
+        {ClientHttpVersionSelector::h2, "h2"},
+        {ClientHttpVersionSelector::any, "any"}
+    }
+};
 
 const SBuf ClientHttpVersionSelector::Http11Protocol(ProtoVersionMap[ClientHttpVersionSelector::http11].second);
 const SBuf ClientHttpVersionSelector::Http2Protocol(ProtoVersionMap[ClientHttpVersionSelector::h2].second);
@@ -42,8 +43,8 @@ static std::optional<ClientHttpVersionSelector::Protocol>
 parseProtocol(const SBuf &protocol)
 {
     auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {
-            return protocol.cmp(p.second) == 0;
-            });
+        return protocol.cmp(p.second) == 0;
+    });
     if (it == ProtoVersionMap.end())
         return std::nullopt;
     return it->first;
@@ -193,7 +194,7 @@ Configuration::Component<ClientHttpVersionSelector*>::FinishSmoothReconfiguratio
     // if parsed at least one directive
     if (sr.fresh.clientHttpVersionSelector->aclList)
         Config.clientHttpVersionSelector = new ClientHttpVersionSelector(std::move(*sr.fresh.clientHttpVersionSelector));
- }
+}
 
 template <>
 void

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -16,12 +16,16 @@
 #include "ConfigOption.h"
 #include "ConfigParser.h"
 #include "configuration/Smooth.h"
+#include "fde.h"
 #include "HttpVersionSelector.h"
 #include "sbuf/Stream.h"
 #include "SquidConfig.h"
 
 #include <algorithm>
 #include <array>
+#if USE_OPENSSL
+#include "ssl/support.h"
+#endif
 #include <utility>
 
 static const std::array<std::pair<ClientHttpVersionSelector::Protocol, const char *>, 3> ProtoVersionMap = {{
@@ -145,6 +149,22 @@ ClientHttpVersionSelector::Check(ACLFilledChecklist *ch, const char *alpn, unsig
     }
 
     return CheckProtocol(alpn, alpnLen, proto);
+}
+
+bool
+ClientHttpVersionSelector::Verify(const Comm::ConnectionPointer &clientConnection, const SBuf clientProtocol)
+{
+    if (!Comm::IsConnOpen(clientConnection))
+        return true; // nothing to verify: the client connection is closed already
+#if USE_OPENSSL
+    if (auto session = fd_table[clientConnection->fd].ssl.get()) {
+        const auto proto = static_cast<const std::optional<SBuf> *>(SSL_get_ex_data(session, ssl_ex_index_ssl_alpn_selected));
+        Assure(proto);
+        Assure(*proto);
+        return proto->value() == clientProtocol;
+    }
+#endif
+    return clientProtocol == Http11Protocol;
 }
 
 template <>

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -204,10 +204,7 @@ Configuration::Component<ClientHttpVersionSelector*>::Print(std::ostream &os, Cl
                 return p.first == action.kind;
             });
             assert(it != ProtoVersionMap.end());
-            // TODO: get rid of this static SBuf
-            static SBuf result;
-            result = ToSBuf(it->second, " if ");
-            return result.c_str();
+            return it->second;
         });
         dump_SBufList(os, lines);
     }

--- a/src/clients/HttpVersionSelector.cc
+++ b/src/clients/HttpVersionSelector.cc
@@ -116,7 +116,7 @@ ClientHttpVersionSelector::parse(ConfigParser &parser)
 {
     const auto version = parser.token("client http version type");
 
-    auto proto = parseProtocol(version);
+    const auto proto = parseProtocol(version);
     if (!proto)
         throw TextException(ToSBuf("unsupported client http version: '", version, "'"), Here());
 
@@ -136,7 +136,7 @@ ClientHttpVersionSelector::Check(ACLFilledChecklist *ch, const char *alpn, unsig
         return CheckProtocol(alpn, alpnLen, ClientHttpVersionSelector::AnyProtocol);
 
     Assure(Config.clientHttpVersionSelector);
-    auto aclList =  Config.clientHttpVersionSelector->aclList.get();
+    const auto aclList =  Config.clientHttpVersionSelector->aclList.get();
     Assure(aclList);
 
     const auto &answer = ch->fastCheck(aclList);
@@ -221,7 +221,7 @@ Configuration::Component<ClientHttpVersionSelector*>::Print(std::ostream &os, Cl
 
     if (auto list = selector->aclList.get()) {
         const auto lines = ToTree(list).treeDump(directiveName, [](const Acl::Answer &action) {
-            auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {
+            const auto it = std::find_if(ProtoVersionMap.begin(), ProtoVersionMap.end(), [&](const auto &p) {
                 return p.first == action.kind;
             });
             assert(it != ProtoVersionMap.end());

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -10,15 +10,12 @@
 #include "configuration/forward.h"
 
 #include <memory>
-#include <optional>
 #include <string_view>
 
 class ClientHttpVersion
 {
 public:
     using Pointer = std::shared_ptr<ClientHttpVersion>;
-
-    enum Protocol { none, http11, h2, any };
 
     explicit ClientHttpVersion(ConfigParser &);
     ~ClientHttpVersion();
@@ -36,11 +33,22 @@ public:
 class ClientHttpVersionSelector
 {
 public:
-    void add(ConfigParser &);
-    std::optional<std::string_view> check(ACLFilledChecklist &ch);
-    std::optional<std::string_view> check(const char *, unsigned int, ACLFilledChecklist &);
+    inline static const SBuf AnyProtocol = SBuf("any");
 
-    bool supported(const char *proto, unsigned int protoLen) const;
+    void add(ConfigParser &);
+
+    /// Checks client_http_version directive when ALPN is available.
+    /// \param alpn the string containing client's offered ALPN protocols in format:
+    /// [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
+    /// \param alpnLen the length of alpn
+    static std::string_view Check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist *);
+
+    /// Checks client_http_version directive when ALPN is unavailable.
+    std::string_view check(ACLFilledChecklist &ch);
 
     std::vector<ClientHttpVersion::Pointer> directives;
+
+private:
+
+    std::string_view check(const char *in, unsigned int inLen, ACLFilledChecklist &);
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -29,7 +29,4 @@ public:
     static const std::optional<SBuf> Check(ACLFilledChecklist *, const char *alpn, unsigned int alpnLen);
 
     std::shared_ptr<ACLList> aclList;
-
-private:
-    const std::optional<SBuf> check(const char *in, unsigned int inLen, ACLFilledChecklist &);
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -10,6 +10,8 @@
 #include "configuration/forward.h"
 
 #include <memory>
+#include <optional>
+#include <string_view>
 
 class ClientHttpVersion
 {
@@ -28,14 +30,17 @@ public:
     void print(std::ostream &) const;
 
     ACLList *aclList = nullptr;
-    Protocol protocol = none;
+    SBuf protocol;
 };
 
 class ClientHttpVersionSelector
 {
 public:
     void add(ConfigParser &);
-    bool check(const SBufList &protocols, ACLFilledChecklist &);
+    std::optional<std::string_view> check(ACLFilledChecklist &ch);
+    std::optional<std::string_view> check(const char *, unsigned int, ACLFilledChecklist &);
+
+    bool supported(const char *proto, unsigned int protoLen) const;
 
     std::vector<ClientHttpVersion::Pointer> directives;
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -34,6 +34,7 @@ class ClientHttpVersionSelector
 {
 public:
     inline static const SBuf AnyProtocol = SBuf("any");
+    inline static const SBuf UnsupportedProtocol = SBuf();
 
     void add(ConfigParser &);
 
@@ -41,14 +42,11 @@ public:
     /// \param alpn the string containing client's offered ALPN protocols in format:
     /// [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
     /// \param alpnLen the length of alpn
-    static std::string_view Check(const char *alpn, unsigned int alpnLen, ACLFilledChecklist *);
-
-    /// Checks client_http_version directive when ALPN is unavailable.
-    std::string_view check(ACLFilledChecklist &ch);
+    static const SBuf &Check(ACLFilledChecklist *, const char *alpn, unsigned int alpnLen);
 
     std::vector<ClientHttpVersion::Pointer> directives;
 
 private:
 
-    std::string_view check(const char *in, unsigned int inLen, ACLFilledChecklist &);
+    const SBuf &check(const char *in, unsigned int inLen, ACLFilledChecklist &);
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 1996-2026 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "acl/forward.h"
+#include "configuration/forward.h"
+
+#include <memory>
+
+class ClientHttpVersion
+{
+public:
+	using Pointer = std::shared_ptr<ClientHttpVersion>;
+
+	enum Protocol { http11, h2, any };
+
+	explicit ClientHttpVersion(ConfigParser &);
+	~ClientHttpVersion();
+
+	// prohibit copy and move
+	ClientHttpVersion(const ClientHttpVersion&) = delete;
+	ClientHttpVersion& operator=(const ClientHttpVersion&) = delete;
+
+    void print(std::ostream &) const;
+
+    ACLList *aclList = nullptr;
+    Protocol protocol;
+};
+
+class ClientHttpVersionSelector
+{
+public:
+	void add(ConfigParser &);
+    bool check(ClientHttpVersion::Protocol, ACLFilledChecklist &);
+
+    std::vector<ClientHttpVersion::Pointer> directives;
+};

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -14,28 +14,28 @@
 class ClientHttpVersion
 {
 public:
-	using Pointer = std::shared_ptr<ClientHttpVersion>;
+    using Pointer = std::shared_ptr<ClientHttpVersion>;
 
-	enum Protocol { http11, h2, any };
+    enum Protocol { none, http11, h2, any };
 
-	explicit ClientHttpVersion(ConfigParser &);
-	~ClientHttpVersion();
+    explicit ClientHttpVersion(ConfigParser &);
+    ~ClientHttpVersion();
 
-	// prohibit copy and move
-	ClientHttpVersion(const ClientHttpVersion&) = delete;
-	ClientHttpVersion& operator=(const ClientHttpVersion&) = delete;
+    // prohibit copy and move
+    ClientHttpVersion(const ClientHttpVersion&) = delete;
+    ClientHttpVersion& operator=(const ClientHttpVersion&) = delete;
 
     void print(std::ostream &) const;
 
     ACLList *aclList = nullptr;
-    Protocol protocol;
+    Protocol protocol = none;
 };
 
 class ClientHttpVersionSelector
 {
 public:
-	void add(ConfigParser &);
-    bool check(ClientHttpVersion::Protocol, ACLFilledChecklist &);
+    void add(ConfigParser &);
+    bool check(const SBufList &protocols, ACLFilledChecklist &);
 
     std::vector<ClientHttpVersion::Pointer> directives;
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -10,43 +10,26 @@
 #include "configuration/forward.h"
 
 #include <memory>
-#include <string_view>
-
-class ClientHttpVersion
-{
-public:
-    using Pointer = std::shared_ptr<ClientHttpVersion>;
-
-    explicit ClientHttpVersion(ConfigParser &);
-    ~ClientHttpVersion();
-
-    // prohibit copy and move
-    ClientHttpVersion(const ClientHttpVersion&) = delete;
-    ClientHttpVersion& operator=(const ClientHttpVersion&) = delete;
-
-    void print(std::ostream &) const;
-
-    ACLList *aclList = nullptr;
-    SBuf protocol;
-};
 
 class ClientHttpVersionSelector
 {
 public:
-    inline static const SBuf AnyProtocol = SBuf("any");
-    inline static const SBuf Http11Protocol = SBuf("http/1.1");
+    static const SBuf Http11Protocol;
+    static const SBuf Http2Protocol;
+    static const SBuf AnyProtocol;
 
-    void add(ConfigParser &);
+    enum Protocol { http11, h2, any };
 
-    /// Checks client_http_version directive when ALPN is available.
-    /// \param alpn the string containing client's offered ALPN protocols in format:
+    void parse(ConfigParser &);
+
+    /// Applies client_http_version rule to select a suitable protocol.
+    /// \param alpn the string containing client's offered ALPN protocols (or nil) in format:
     /// [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
     /// \param alpnLen the length of alpn
     static const std::optional<SBuf> Check(ACLFilledChecklist *, const char *alpn, unsigned int alpnLen);
 
-    std::vector<ClientHttpVersion::Pointer> directives;
+    std::shared_ptr<ACLList> aclList;
 
 private:
-
     const std::optional<SBuf> check(const char *in, unsigned int inLen, ACLFilledChecklist &);
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -34,7 +34,7 @@ class ClientHttpVersionSelector
 {
 public:
     inline static const SBuf AnyProtocol = SBuf("any");
-    inline static const SBuf UnsupportedProtocol = SBuf();
+    inline static const SBuf Http11Protocol = SBuf("http/1.1");
 
     void add(ConfigParser &);
 
@@ -42,11 +42,11 @@ public:
     /// \param alpn the string containing client's offered ALPN protocols in format:
     /// [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
     /// \param alpnLen the length of alpn
-    static const SBuf &Check(ACLFilledChecklist *, const char *alpn, unsigned int alpnLen);
+    static const std::optional<SBuf> Check(ACLFilledChecklist *, const char *alpn, unsigned int alpnLen);
 
     std::vector<ClientHttpVersion::Pointer> directives;
 
 private:
 
-    const SBuf &check(const char *in, unsigned int inLen, ACLFilledChecklist &);
+    const std::optional<SBuf> check(const char *in, unsigned int inLen, ACLFilledChecklist &);
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -27,6 +27,8 @@ public:
     /// [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
     /// \param alpnLen the length of alpn
     static const std::optional<SBuf> Check(ACLFilledChecklist *, const char *alpn, unsigned int alpnLen);
+    /// whether the client connection expects the client protocol bytes
+    static bool Verify(const Comm::ConnectionPointer &clientConn, const SBuf clientProtocol);
 
     std::shared_ptr<ACLList> aclList;
 };

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -11,6 +11,7 @@
 
 #include "acl/forward.h"
 #include "configuration/forward.h"
+#include "sbuf/SBuf.h"
 
 #include <memory>
 

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -10,6 +10,7 @@
 #define SQUID_SRC_CLIENTS_HTTPVERSIONSELECTOR_H
 
 #include "acl/forward.h"
+#include "comm/forward.h"
 #include "configuration/forward.h"
 #include "sbuf/SBuf.h"
 

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -6,6 +6,9 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
+#ifndef SQUID_SRC_CLIENTS_HTTPVERSIONSELECTOR_H
+#define SQUID_SRC_CLIENTS_HTTPVERSIONSELECTOR_H
+
 #include "acl/forward.h"
 #include "configuration/forward.h"
 
@@ -32,3 +35,6 @@ public:
 
     std::shared_ptr<ACLList> aclList;
 };
+
+#endif /* SQUID_SRC_CLIENTS_HTTPVERSIONSELECTOR_H */
+

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -28,7 +28,7 @@ public:
 
     void parse(ConfigParser &);
 
-    /// Applies client_http_version rule to select a suitable protocol.
+    /// Applies client_http_version rules to select a suitable protocol.
     /// \param alpn the string containing client's offered ALPN protocols (or nil) in format:
     /// [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
     /// \param alpnLen the length of alpn

--- a/src/clients/HttpVersionSelector.h
+++ b/src/clients/HttpVersionSelector.h
@@ -14,6 +14,7 @@
 #include "sbuf/SBuf.h"
 
 #include <memory>
+#include <optional>
 
 class ClientHttpVersionSelector
 {

--- a/src/clients/Makefile.am
+++ b/src/clients/Makefile.am
@@ -12,6 +12,8 @@ noinst_LTLIBRARIES = libclients.la
 libclients_la_SOURCES = \
 	Client.cc \
 	Client.h \
+	HttpVersionSelector.cc \
+	HttpVersionSelector.h \
 	FtpClient.cc \
 	FtpClient.h \
 	FtpGateway.cc \

--- a/src/clients/Makefile.am
+++ b/src/clients/Makefile.am
@@ -12,8 +12,6 @@ noinst_LTLIBRARIES = libclients.la
 libclients_la_SOURCES = \
 	Client.cc \
 	Client.h \
-	HttpVersionSelector.cc \
-	HttpVersionSelector.h \
 	FtpClient.cc \
 	FtpClient.h \
 	FtpGateway.cc \
@@ -22,6 +20,8 @@ libclients_la_SOURCES = \
 	HttpTunneler.h \
 	HttpTunnelerAnswer.cc \
 	HttpTunnelerAnswer.h \
+	HttpVersionSelector.cc \
+	HttpVersionSelector.h \
 	WhoisGateway.cc \
 	WhoisGateway.h \
 	forward.h

--- a/src/clients/forward.h
+++ b/src/clients/forward.h
@@ -11,6 +11,7 @@
 
 #include "sbuf/forward.h"
 
+class ClientHttpVersionSelector;
 class FwdState;
 class HttpRequest;
 

--- a/src/configuration/Smooth.h
+++ b/src/configuration/Smooth.h
@@ -10,6 +10,7 @@
 #define SQUID_SRC_CONFIGURATION_SMOOTH_H
 
 #include "base/AsyncCallList.h"
+#include "clients/forward.h"
 #include "configuration/forward.h"
 #include "peering.h"
 
@@ -84,6 +85,7 @@ public:
     /// exposing every user to complete definitions of all underlying types.
     struct {
         FreshField<BeingConfiguredCachePeers> cachePeers;
+        FreshField<ClientHttpVersionSelector> clientHttpVersionSelector;
     } fresh;
 
 protected:

--- a/src/globals.h
+++ b/src/globals.h
@@ -99,6 +99,7 @@ extern int ssl_ex_index_ssl_errors;   /* -1 */
 extern int ssl_ex_index_ssl_cert_chain;  /* -1 */
 extern int ssl_ex_index_ssl_validation_counter;  /* -1 */
 extern int ssl_ex_index_ssl_alpn; /* -1 */
+extern int ssl_ex_index_ssl_alpn_selected; /* -1 */
 
 extern const char *external_acl_message;      /* NULL */
 extern int opt_send_signal; /* -1 */

--- a/src/globals.h
+++ b/src/globals.h
@@ -98,6 +98,7 @@ extern int ssl_ex_index_ssl_peeked_cert;      /* -1 */
 extern int ssl_ex_index_ssl_errors;   /* -1 */
 extern int ssl_ex_index_ssl_cert_chain;  /* -1 */
 extern int ssl_ex_index_ssl_validation_counter;  /* -1 */
+extern int ssl_ex_index_ssl_alpn; /* -1 */
 
 extern const char *external_acl_message;      /* NULL */
 extern int opt_send_signal; /* -1 */

--- a/src/security/KeyLog.cc
+++ b/src/security/KeyLog.cc
@@ -73,7 +73,7 @@ Security::KeyLog::dump(std::ostream &os) const
     dumpOptions(os);
     if (aclList) {
         // TODO: Use Acl::dump() after fixing the XXX in dump_acl_list().
-        for (const auto &acl: ToTree(aclList).treeDump("if", &Acl::AllowOrDeny))
+        for (const auto &acl: ToTree(aclList).treeDump("", &Acl::AllowOrDeny))
             os << ' ' << acl;
     }
 }

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -467,11 +467,15 @@ Security::ServerOptions::loadDhParams()
 
 #if USE_OPENSSL
 
-static const std::optional<SBuf>
+static std::optional<SBuf> *
 HttpVersionSelectorCheck(SSL *ssl,  const unsigned char *alpn, const unsigned int alpnLen)
 {
     auto checkList = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn));
-    return ClientHttpVersionSelector::Check(checkList, reinterpret_cast<const char *>(alpn), alpnLen);
+    const auto protoTemp = ClientHttpVersionSelector::Check(checkList, reinterpret_cast<const char *>(alpn), alpnLen);
+    const auto proto = new std::optional<SBuf>(protoTemp);
+    if (!SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn_selected, (void *)proto))
+        throw TextException("SSL_set_ex_data() error", Here());
+    return proto;
 }
 
 // TODO: move to where it belongs
@@ -482,12 +486,9 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
     assert(ssl);
 
     try {
-        const auto protoTemp = HttpVersionSelectorCheck(ssl, in, inlen);
-        const auto proto = new std::optional<SBuf>(protoTemp);
-        if (!SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn_selected, (void *)proto))
-            throw TextException("SSL_set_ex_data() error", Here());
+        const auto proto = HttpVersionSelectorCheck(ssl, in, inlen);
 
-        if (!protoTemp)
+        if (!proto->has_value())
             return SSL_TLSEXT_ERR_ALERT_FATAL;
 
         *out = reinterpret_cast<const unsigned char *>((*proto)->rawContent());
@@ -514,7 +515,7 @@ int client_hello_cb(SSL *ssl, int *al, void *) {
         // no ALPN, check the HTTP version selection rules here
         const auto proto = HttpVersionSelectorCheck(ssl, nullptr, 0);
 
-        if (!proto) {
+        if (!proto->has_value()) {
             // set the alert to "no_application_protocol" and fail
             *al = TLS1_AD_NO_APPLICATION_PROTOCOL;
             return SSL_CLIENT_HELLO_ERROR;

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -466,6 +466,14 @@ Security::ServerOptions::loadDhParams()
 }
 
 #if USE_OPENSSL
+
+static const SBuf &
+HttpVersionSelectorCheck(SSL *ssl,  const unsigned char *alpn, const unsigned int alpnLen)
+{
+    auto checkList = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn));
+    return ClientHttpVersionSelector::Check(checkList, reinterpret_cast<const char *>(alpn), alpnLen);
+}
+
 // TODO: move to where it belongs
 static int
 alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
@@ -474,18 +482,18 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
     assert(ssl);
 
     try {
-        auto checkList = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn));
-        const auto proto = ClientHttpVersionSelector::Check(reinterpret_cast<const char *>(in), inlen, checkList);
+        const auto &proto = HttpVersionSelectorCheck(ssl, in, inlen);
 
-        if (proto.empty())
+        SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn_selected, (void *)&proto);
+
+        if (proto.isEmpty())
             return SSL_TLSEXT_ERR_ALERT_FATAL;
 
-        const auto selected = reinterpret_cast<const unsigned char *>(proto.data());
-        *out = &selected[1];
-        *outlen = selected[0];
+        *out = reinterpret_cast<const unsigned char *>(proto.rawContent());
+        *outlen = proto.length();
         return SSL_TLSEXT_ERR_OK;
     } catch (...) {
-        debugs (83, 1, "cannot select a protocol: " << CurrentException);
+        debugs (83, DBG_IMPORTANT, "cannot select a protocol: " << CurrentException);
         return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 }
@@ -497,23 +505,24 @@ int client_hello_cb(SSL *ssl, int *al, void *) {
     try {
         const unsigned char *ext = nullptr;
         size_t extLen = 0;
+
         // Check if the ALPN extension is present
         if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_application_layer_protocol_negotiation, &ext, &extLen) == 1)
-            return SSL_CLIENT_HELLO_SUCCESS; // ALPN found, proceed normally
+            return SSL_CLIENT_HELLO_SUCCESS; // ALPN found, will handle them in alpn_select_cb()
 
-        if (auto ch = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn))) {
-            const auto proto = Config.clientHttpVersionSelector->check(*ch);
-            if (proto.empty()) {
-                // set the alert to "no_application_protocol" and fail
-                *al = TLS1_AD_NO_APPLICATION_PROTOCOL;
-                return SSL_CLIENT_HELLO_ERROR;
-            }
+        // no ALPN, check the HTTP version selection rules here
+        const auto &proto = HttpVersionSelectorCheck(ssl, nullptr, 0);
+
+        if (proto.isEmpty()) {
+            // set the alert to "no_application_protocol" and fail
+            *al = TLS1_AD_NO_APPLICATION_PROTOCOL;
+            return SSL_CLIENT_HELLO_ERROR;
         }
 
         // no ALPN, but HTTP version selection rules (if any) allow us to proceed
         return SSL_CLIENT_HELLO_SUCCESS;
     } catch (...) {
-        debugs (83, 2, "cannot handle client hello: " << CurrentException);
+        debugs (83, DBG_IMPORTANT, "cannot handle client hello: " << CurrentException);
         *al = SSL_AD_INTERNAL_ERROR;
         return SSL_CLIENT_HELLO_ERROR;
     }

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -11,6 +11,7 @@
 #include "base/IoManip.h"
 #include "base/Packable.h"
 #include "cache_cf.h"
+#include "clients/HttpVersionSelector.h"
 #include "error/SysErrorDetail.h"
 #include "fatal.h"
 #include "globals.h"
@@ -31,6 +32,8 @@
 #endif
 
 #include <limits>
+#include <optional>
+#include <string_view>
 
 Security::ServerOptions &
 Security::ServerOptions::operator =(const Security::ServerOptions &old) {
@@ -468,34 +471,26 @@ static int
 squid_alpn_select_callback(SSL *ssl, const unsigned char **out, unsigned char *outlen,
     const unsigned char *in, unsigned int inlen, void *)
 {
-    if (!ssl)
-        return SSL_TLSEXT_ERR_NOACK;
+    assert(ssl);
 
-    // 'in' contains the client's offered ALPN protocols in format:
-    // [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
-
-    auto protocolList = new SBufList();
-    const unsigned char *ptr = in;
-    auto remaining = inlen;
-    while (remaining > 0) {
-        unsigned char protoLen = *ptr;
-        protocolList->emplace_back(reinterpret_cast<const char*>(ptr + 1), protoLen);
-
-        // std::string protocol(reinterpret_cast<const char*>(&in[i + 1]), protoLen);
-        // debugs(83, 2, "Client offered ALPN: " << protocol);
-
-        ptr += (protoLen + 1);
-        remaining -= (protoLen + 1);
+    if (auto check = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn))) {
+        if (const auto proto = Config.clientHttpVersionSelector->check(reinterpret_cast<const char *>(in), inlen,  *check)) {
+            // one of the rules matched
+            if (!proto->empty()) {
+                const auto selected = reinterpret_cast<const unsigned char *>(proto->data());
+                *out = &selected[1];
+                *outlen = selected[0];
+                return SSL_TLSEXT_ERR_OK;
+            }
+            return SSL_TLSEXT_ERR_ALERT_FATAL;
+        } // else none of the rules matched
     }
 
-    if (!protocolList->empty())
-        SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn, protocolList);
-
-    // hardcode the server response to "http/1.1".
+    // default: hardcode server response to "http/1.1".
     static const unsigned char http11_alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
-    *out = &http11_alpn[1]; // Points directly to the string text "http/1.1"
-    *outlen = http11_alpn[0]; // the prefix (8)
-    return SSL_TLSEXT_ERR_OK; // Accept the handshake cleanly using HTTP/1.1
+    *out = &http11_alpn[1];
+    *outlen = http11_alpn[0];
+    return SSL_TLSEXT_ERR_OK;
 }
 #endif
 

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -467,7 +467,7 @@ Security::ServerOptions::loadDhParams()
 
 #if USE_OPENSSL
 
-static const SBuf &
+static const std::optional<SBuf>
 HttpVersionSelectorCheck(SSL *ssl,  const unsigned char *alpn, const unsigned int alpnLen)
 {
     auto checkList = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn));
@@ -482,15 +482,16 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
     assert(ssl);
 
     try {
-        const auto &proto = HttpVersionSelectorCheck(ssl, in, inlen);
+        const auto protoTemp = HttpVersionSelectorCheck(ssl, in, inlen);
+        const auto proto = new std::optional<SBuf>(protoTemp);
+        if (!SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn_selected, (void *)proto))
+            throw TextException("SSL_set_ex_data() error", Here());
 
-        SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn_selected, (void *)&proto);
-
-        if (proto.isEmpty())
+        if (proto)
             return SSL_TLSEXT_ERR_ALERT_FATAL;
 
-        *out = reinterpret_cast<const unsigned char *>(proto.rawContent());
-        *outlen = proto.length();
+        *out = reinterpret_cast<const unsigned char *>((*proto)->rawContent());
+        *outlen = (*proto)->length();
         return SSL_TLSEXT_ERR_OK;
     } catch (...) {
         debugs (83, DBG_IMPORTANT, "cannot select a protocol: " << CurrentException);
@@ -511,9 +512,9 @@ int client_hello_cb(SSL *ssl, int *al, void *) {
             return SSL_CLIENT_HELLO_SUCCESS; // ALPN found, will handle them in alpn_select_cb()
 
         // no ALPN, check the HTTP version selection rules here
-        const auto &proto = HttpVersionSelectorCheck(ssl, nullptr, 0);
+        const auto proto = HttpVersionSelectorCheck(ssl, nullptr, 0);
 
-        if (proto.isEmpty()) {
+        if (!proto) {
             // set the alert to "no_application_protocol" and fail
             *al = TLS1_AD_NO_APPLICATION_PROTOCOL;
             return SSL_CLIENT_HELLO_ERROR;

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -462,6 +462,43 @@ Security::ServerOptions::loadDhParams()
 #endif // USE_OPENSSL
 }
 
+// TODO: rename and move
+#if USE_OPENSSL
+static int
+squid_alpn_select_callback(SSL *ssl, const unsigned char **out, unsigned char *outlen,
+    const unsigned char *in, unsigned int inlen, void *)
+{
+    if (!ssl)
+        return SSL_TLSEXT_ERR_NOACK;
+
+    // 'in' contains the client's offered ALPN protocols in format:
+    // [len][string][len][string]... (e.g., \x02h2\x08http/1.1)
+
+    auto protocolList = new SBufList();
+    const unsigned char *ptr = in;
+    auto remaining = inlen;
+    while (remaining > 0) {
+        unsigned char protoLen = *ptr;
+        protocolList->emplace_back(reinterpret_cast<const char*>(ptr + 1), protoLen);
+
+        // std::string protocol(reinterpret_cast<const char*>(&in[i + 1]), protoLen);
+        // debugs(83, 2, "Client offered ALPN: " << protocol);
+
+        ptr += (protoLen + 1);
+        remaining -= (protoLen + 1);
+    }
+
+    if (!protocolList->empty())
+        SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn, protocolList);
+
+    // hardcode the server response to "http/1.1".
+    static const unsigned char http11_alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+    *out = &http11_alpn[1]; // Points directly to the string text "http/1.1"
+    *outlen = http11_alpn[0]; // the prefix (8)
+    return SSL_TLSEXT_ERR_OK; // Accept the handshake cleanly using HTTP/1.1
+}
+#endif
+
 bool
 Security::ServerOptions::updateContextConfig(Security::ContextPointer &ctx)
 {
@@ -500,6 +537,9 @@ Security::ServerOptions::updateContextConfig(Security::ContextPointer &ctx)
         SSL_CTX_set_ex_data(ctx.get(), ssl_ctx_ex_index_dont_verify_domain, (void *) -1);
 
     Security::SetSessionCacheCallbacks(ctx);
+
+    SSL_CTX_set_alpn_select_cb(ctx.get(), squid_alpn_select_callback, nullptr);
+
 #endif
     return true;
 }

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -487,7 +487,7 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
         if (!SSL_set_ex_data(ssl, ssl_ex_index_ssl_alpn_selected, (void *)proto))
             throw TextException("SSL_set_ex_data() error", Here());
 
-        if (proto)
+        if (!protoTemp)
             return SSL_TLSEXT_ERR_ALERT_FATAL;
 
         *out = reinterpret_cast<const unsigned char *>((*proto)->rawContent());

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -465,33 +465,60 @@ Security::ServerOptions::loadDhParams()
 #endif // USE_OPENSSL
 }
 
-// TODO: rename and move
 #if USE_OPENSSL
+// TODO: move to where it belongs
 static int
-squid_alpn_select_callback(SSL *ssl, const unsigned char **out, unsigned char *outlen,
+alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
     const unsigned char *in, unsigned int inlen, void *)
 {
     assert(ssl);
 
-    if (auto check = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn))) {
-        if (const auto proto = Config.clientHttpVersionSelector->check(reinterpret_cast<const char *>(in), inlen,  *check)) {
-            // one of the rules matched
-            if (!proto->empty()) {
-                const auto selected = reinterpret_cast<const unsigned char *>(proto->data());
-                *out = &selected[1];
-                *outlen = selected[0];
-                return SSL_TLSEXT_ERR_OK;
-            }
-            return SSL_TLSEXT_ERR_ALERT_FATAL;
-        } // else none of the rules matched
-    }
+    try {
+        auto checkList = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn));
+        const auto proto = ClientHttpVersionSelector::Check(reinterpret_cast<const char *>(in), inlen, checkList);
 
-    // default: hardcode server response to "http/1.1".
-    static const unsigned char http11_alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
-    *out = &http11_alpn[1];
-    *outlen = http11_alpn[0];
-    return SSL_TLSEXT_ERR_OK;
+        if (proto.empty())
+            return SSL_TLSEXT_ERR_ALERT_FATAL;
+
+        const auto selected = reinterpret_cast<const unsigned char *>(proto.data());
+        *out = &selected[1];
+        *outlen = selected[0];
+        return SSL_TLSEXT_ERR_OK;
+    } catch (...) {
+        debugs (83, 1, "cannot select a protocol: " << CurrentException);
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
 }
+
+int client_hello_cb(SSL *ssl, int *al, void *) {
+    assert(ssl);
+    assert(al);
+
+    try {
+        const unsigned char *ext = nullptr;
+        size_t extLen = 0;
+        // Check if the ALPN extension is present
+        if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_application_layer_protocol_negotiation, &ext, &extLen) == 1)
+            return SSL_CLIENT_HELLO_SUCCESS; // ALPN found, proceed normally
+
+        if (auto ch = static_cast<ACLFilledChecklist *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_alpn))) {
+            const auto proto = Config.clientHttpVersionSelector->check(*ch);
+            if (proto.empty()) {
+                // set the alert to "no_application_protocol" and fail
+                *al = TLS1_AD_NO_APPLICATION_PROTOCOL;
+                return SSL_CLIENT_HELLO_ERROR;
+            }
+        }
+
+        // no ALPN, but HTTP version selection rules (if any) allow us to proceed
+        return SSL_CLIENT_HELLO_SUCCESS;
+    } catch (...) {
+        debugs (83, 2, "cannot handle client hello: " << CurrentException);
+        *al = SSL_AD_INTERNAL_ERROR;
+        return SSL_CLIENT_HELLO_ERROR;
+    }
+}
+
 #endif
 
 bool
@@ -533,7 +560,8 @@ Security::ServerOptions::updateContextConfig(Security::ContextPointer &ctx)
 
     Security::SetSessionCacheCallbacks(ctx);
 
-    SSL_CTX_set_alpn_select_cb(ctx.get(), squid_alpn_select_callback, nullptr);
+    SSL_CTX_set_client_hello_cb(ctx.get(), client_hello_cb, nullptr);
+    SSL_CTX_set_alpn_select_cb(ctx.get(), alpn_select_cb, nullptr);
 
 #endif
     return true;

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -480,10 +480,9 @@ HttpVersionSelectorCheck(SSL *ssl,  const unsigned char *alpn, const unsigned in
 }
 
 static void
-HttpVersionSelectorErrorDetail(SSL *ssl, const char *detailString)
+HttpVersionSelectorErrorDetail(SSL *ssl, const ErrorDetail::Pointer &d)
 {
-    std::unique_ptr<ErrorDetail::Pointer> detail(new ErrorDetail::Pointer(
-                MakeNamedErrorDetail(detailString)));
+    std::unique_ptr<ErrorDetail::Pointer> detail(new ErrorDetail::Pointer(d));
     if (SSL_set_ex_data(ssl, ssl_ex_index_ssl_error_detail, detail.get()))
         detail.release();
     else
@@ -501,7 +500,8 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
         const auto proto = HttpVersionSelectorCheck(ssl, in, inlen);
 
         if (!proto->has_value()) {
-            HttpVersionSelectorErrorDetail(ssl, "SSL_TLSEXT_ERR_ALERT_FATAL(select)");
+            static const auto d = MakeNamedErrorDetail("SSL_TLSEXT_ERR_ALERT_FATAL(select)");
+            HttpVersionSelectorErrorDetail(ssl, d);
             return SSL_TLSEXT_ERR_ALERT_FATAL;
         }
 
@@ -510,7 +510,8 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
         return SSL_TLSEXT_ERR_OK;
     } catch (...) {
         debugs (83, DBG_IMPORTANT, "cannot select a protocol: " << CurrentException);
-        HttpVersionSelectorErrorDetail(ssl, "SSL_TLSEXT_ERR_ALERT_FATAL(error)");
+        static const auto d = MakeNamedErrorDetail("SSL_TLSEXT_ERR_ALERT_FATAL(error)");
+        HttpVersionSelectorErrorDetail(ssl, d);
         return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 }
@@ -534,7 +535,8 @@ client_hello_cb(SSL *ssl, int *al, void *) {
         if (!proto->has_value()) {
             // set the alert to "no_application_protocol" and fail
             *al = TLS1_AD_NO_APPLICATION_PROTOCOL;
-            HttpVersionSelectorErrorDetail(ssl, "TLS1_AD_NO_APPLICATION_PROTOCOL");
+            static const auto d = MakeNamedErrorDetail("TLS1_AD_NO_APPLICATION_PROTOCOL");
+            HttpVersionSelectorErrorDetail(ssl, d);
             return SSL_CLIENT_HELLO_ERROR;
         }
 
@@ -542,7 +544,8 @@ client_hello_cb(SSL *ssl, int *al, void *) {
         return SSL_CLIENT_HELLO_SUCCESS;
     } catch (...) {
         debugs (83, DBG_IMPORTANT, "cannot handle client hello: " << CurrentException);
-        HttpVersionSelectorErrorDetail(ssl, "SSL_AD_INTERNAL_ERROR");
+        static const auto d = MakeNamedErrorDetail("SSL_AD_INTERNAL_ERROR");
+        HttpVersionSelectorErrorDetail(ssl, d);
         *al = SSL_AD_INTERNAL_ERROR;
         return SSL_CLIENT_HELLO_ERROR;
     }

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -15,6 +15,7 @@
 #include "error/SysErrorDetail.h"
 #include "fatal.h"
 #include "globals.h"
+#include "sbuf/Stream.h"
 #include "security/KeyLogger.h"
 #include "security/ServerOptions.h"
 #include "security/Session.h"
@@ -478,6 +479,17 @@ HttpVersionSelectorCheck(SSL *ssl,  const unsigned char *alpn, const unsigned in
     return proto;
 }
 
+static void
+HttpVersionSelectorErrorDetail(SSL *ssl, const char *detailString)
+{
+    std::unique_ptr<ErrorDetail::Pointer> detail(new ErrorDetail::Pointer(
+                MakeNamedErrorDetail(detailString)));
+    if (SSL_set_ex_data(ssl, ssl_ex_index_ssl_error_detail, detail.get()))
+        detail.release();
+    else
+        debugs(83, 2, "failed to store error detail: " << *detail);
+}
+
 // TODO: move to where it belongs
 static int
 alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
@@ -488,14 +500,17 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
     try {
         const auto proto = HttpVersionSelectorCheck(ssl, in, inlen);
 
-        if (!proto->has_value())
+        if (!proto->has_value()) {
+            HttpVersionSelectorErrorDetail(ssl, "SSL_TLSEXT_ERR_ALERT_FATAL(select)");
             return SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
 
         *out = reinterpret_cast<const unsigned char *>((*proto)->rawContent());
         *outlen = (*proto)->length();
         return SSL_TLSEXT_ERR_OK;
     } catch (...) {
         debugs (83, DBG_IMPORTANT, "cannot select a protocol: " << CurrentException);
+        HttpVersionSelectorErrorDetail(ssl, "SSL_TLSEXT_ERR_ALERT_FATAL(error)");
         return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 }
@@ -518,6 +533,7 @@ int client_hello_cb(SSL *ssl, int *al, void *) {
         if (!proto->has_value()) {
             // set the alert to "no_application_protocol" and fail
             *al = TLS1_AD_NO_APPLICATION_PROTOCOL;
+            HttpVersionSelectorErrorDetail(ssl, "TLS1_AD_NO_APPLICATION_PROTOCOL");
             return SSL_CLIENT_HELLO_ERROR;
         }
 
@@ -525,6 +541,7 @@ int client_hello_cb(SSL *ssl, int *al, void *) {
         return SSL_CLIENT_HELLO_SUCCESS;
     } catch (...) {
         debugs (83, DBG_IMPORTANT, "cannot handle client hello: " << CurrentException);
+        HttpVersionSelectorErrorDetail(ssl, "SSL_AD_INTERNAL_ERROR");
         *al = SSL_AD_INTERNAL_ERROR;
         return SSL_CLIENT_HELLO_ERROR;
     }

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -493,7 +493,7 @@ HttpVersionSelectorErrorDetail(SSL *ssl, const char *detailString)
 // TODO: move to where it belongs
 static int
 alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
-    const unsigned char *in, unsigned int inlen, void *)
+               const unsigned char *in, unsigned int inlen, void *)
 {
     assert(ssl);
 

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -515,7 +515,8 @@ alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
     }
 }
 
-int client_hello_cb(SSL *ssl, int *al, void *) {
+static int
+client_hello_cb(SSL *ssl, int *al, void *) {
     assert(ssl);
     assert(al);
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -13,6 +13,7 @@
 #include "client_side.h"
 #include "client_side_reply.h"
 #include "client_side_request.h"
+#include "clients/HttpVersionSelector.h"
 #include "comm/Write.h"
 #include "HeaderMangling.h"
 #include "http/one/RequestParser.h"
@@ -53,6 +54,17 @@ Http::One::Server::start()
     AsyncCall::Pointer timeoutCall =  JobCallback(33, 5,
                                       TimeoutDialer, this, Http1::Server::requestTimeout);
     commSetConnTimeout(clientConnection, Config.Timeout.request_start_timeout, timeoutCall);
+
+    if (Config.clientHttpVersionSelector) {
+        auto ch = ACLFilledChecklist::Make(nullptr, nullptr);
+        fillChecklist(*ch);
+        if (!ClientHttpVersionSelector::Check(ch.release(), nullptr, 0)) {
+            debugs(33, 2, "Cannot select HTTP protocol version");
+            clientConnection->close();
+            return;
+        }
+    }
+
     readSomeData();
 }
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -91,8 +91,10 @@ Http::One::Server::parseOneRequest()
     // parser is incremental. Generate new parser state if we,
     // a) do not have one already
     // b) have completed the previous request parsing already
-    if (!parser_ || !parser_->needsMoreData())
+    if (!parser_ || !parser_->needsMoreData()) {
+        Assure(ClientHttpVersionSelector::Verify(clientConnection, ClientHttpVersionSelector::Http11Protocol));
         parser_ = new Http1::RequestParser(preservingClientData_);
+    }
 
     /* Process request */
     Http::Stream *context = parseHttpRequest(parser_);

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -61,7 +61,8 @@ Http::One::Server::start()
         fillChecklist(*ch);
         if (!ClientHttpVersionSelector::Check(ch.release(), nullptr, 0)) {
             debugs(33, 2, "Cannot select HTTP protocol version");
-            updateError(ERR_PROTOCOL_UNKNOWN, MakeNamedErrorDetail("CANNOT_SELECT_HTTP_VERSION"));
+            static const auto d = MakeNamedErrorDetail("CANNOT_SELECT_HTTP_VERSION");
+            updateError(ERR_PROTOCOL_UNKNOWN, d);
             clientConnection->close();
             return;
         }

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -15,6 +15,7 @@
 #include "client_side_request.h"
 #include "clients/HttpVersionSelector.h"
 #include "comm/Write.h"
+#include "error/Detail.h"
 #include "HeaderMangling.h"
 #include "http/one/RequestParser.h"
 #include "http/Stream.h"
@@ -60,6 +61,7 @@ Http::One::Server::start()
         fillChecklist(*ch);
         if (!ClientHttpVersionSelector::Check(ch.release(), nullptr, 0)) {
             debugs(33, 2, "Cannot select HTTP protocol version");
+            updateError(ERR_PROTOCOL_UNKNOWN, MakeNamedErrorDetail("CANNOT_SELECT_HTTP_VERSION"));
             clientConnection->close();
             return;
         }

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -767,14 +767,6 @@ ssl_free_ErrorDetail(void *, void *ptr, CRYPTO_EX_DATA *,
 }
 
 static void
-ssl_free_ProtocolList(void *, void *ptr, CRYPTO_EX_DATA *,
-int, long, void *)
-{
-    const auto protocolList = static_cast<SBufList*>(ptr);
-    delete protocolList;
-}
-
-static void
 ssl_free_SslErrors(void *, void *ptr, CRYPTO_EX_DATA *,
                    int, long, void *)
 {
@@ -896,7 +888,7 @@ Ssl::InitializeOnce()
     ssl_ex_index_ssl_cert_chain = SSL_get_ex_new_index(0, (void *) "ssl_cert_chain", nullptr, nullptr, &ssl_free_CertChain);
     ssl_ex_index_ssl_validation_counter = SSL_get_ex_new_index(0, (void *) "ssl_validation_counter", nullptr, nullptr, &ssl_free_int);
     ssl_ex_index_verify_callback_parameters = SSL_get_ex_new_index(0, (void *) "verify_callback_parameters", nullptr, nullptr, &ssl_free_VerifyCallbackParameters);
-    ssl_ex_index_ssl_alpn = SSL_get_ex_new_index(0, (void *) "ssl_alpn", nullptr, nullptr, &ssl_free_ProtocolList);
+    ssl_ex_index_ssl_alpn = SSL_get_ex_new_index(0, (void *) "ssl_alpn", nullptr, ssl_dupAclChecklist, &ssl_freeAclChecklist);
 }
 
 bool

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -767,6 +767,14 @@ ssl_free_ErrorDetail(void *, void *ptr, CRYPTO_EX_DATA *,
 }
 
 static void
+ssl_free_ProtocolList(void *, void *ptr, CRYPTO_EX_DATA *,
+int, long, void *)
+{
+    const auto protocolList = static_cast<SBufList*>(ptr);
+    delete protocolList;
+}
+
+static void
 ssl_free_SslErrors(void *, void *ptr, CRYPTO_EX_DATA *,
                    int, long, void *)
 {
@@ -888,6 +896,7 @@ Ssl::InitializeOnce()
     ssl_ex_index_ssl_cert_chain = SSL_get_ex_new_index(0, (void *) "ssl_cert_chain", nullptr, nullptr, &ssl_free_CertChain);
     ssl_ex_index_ssl_validation_counter = SSL_get_ex_new_index(0, (void *) "ssl_validation_counter", nullptr, nullptr, &ssl_free_int);
     ssl_ex_index_verify_callback_parameters = SSL_get_ex_new_index(0, (void *) "verify_callback_parameters", nullptr, nullptr, &ssl_free_VerifyCallbackParameters);
+    ssl_ex_index_ssl_alpn = SSL_get_ex_new_index(0, (void *) "ssl_alpn", nullptr, nullptr, &ssl_free_ProtocolList);
 }
 
 bool

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -889,6 +889,7 @@ Ssl::InitializeOnce()
     ssl_ex_index_ssl_validation_counter = SSL_get_ex_new_index(0, (void *) "ssl_validation_counter", nullptr, nullptr, &ssl_free_int);
     ssl_ex_index_verify_callback_parameters = SSL_get_ex_new_index(0, (void *) "verify_callback_parameters", nullptr, nullptr, &ssl_free_VerifyCallbackParameters);
     ssl_ex_index_ssl_alpn = SSL_get_ex_new_index(0, (void *) "ssl_alpn", nullptr, ssl_dupAclChecklist, &ssl_freeAclChecklist);
+    ssl_ex_index_ssl_alpn_selected = SSL_get_ex_new_index(0, (void *) "ssl_alpn_selected", nullptr, nullptr, nullptr);
 }
 
 bool

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -820,6 +820,30 @@ ssl_free_VerifyCallbackParameters(void *, void *ptr, CRYPTO_EX_DATA *,
     delete static_cast<Ssl::VerifyCallbackParameters*>(ptr);
 }
 
+/// "free" function for the ssl_ex_index_ssl_alpn_selected entry
+static void
+ssl_free_AlpnSelected(void *, void *ptr, CRYPTO_EX_DATA *,
+        int, long, void *)
+{
+    auto alpn = static_cast<std::optional<SBuf> *>(ptr);
+    delete alpn;
+}
+
+/// "dup" function for the ssl_ex_index_ssl_alpn_selected entry
+static int
+ssl_dup_AlpnSelected(CRYPTO_EX_DATA *, const CRYPTO_EX_DATA *, void **from_d,
+                    int , long, void *)
+{
+    if (*from_d == nullptr)
+        return 1;
+    auto alpnOld = static_cast<std::optional<SBuf> *>(*from_d);
+    auto alpnNew = new std::optional<SBuf>(*alpnOld);
+    if (!alpnNew)
+        return 0;
+    *from_d = alpnNew;
+    return 1;
+}
+
 void
 Ssl::Configure()
 {
@@ -889,7 +913,7 @@ Ssl::InitializeOnce()
     ssl_ex_index_ssl_validation_counter = SSL_get_ex_new_index(0, (void *) "ssl_validation_counter", nullptr, nullptr, &ssl_free_int);
     ssl_ex_index_verify_callback_parameters = SSL_get_ex_new_index(0, (void *) "verify_callback_parameters", nullptr, nullptr, &ssl_free_VerifyCallbackParameters);
     ssl_ex_index_ssl_alpn = SSL_get_ex_new_index(0, (void *) "ssl_alpn", nullptr, ssl_dupAclChecklist, &ssl_freeAclChecklist);
-    ssl_ex_index_ssl_alpn_selected = SSL_get_ex_new_index(0, (void *) "ssl_alpn_selected", nullptr, nullptr, nullptr);
+    ssl_ex_index_ssl_alpn_selected = SSL_get_ex_new_index(0, (void *) "ssl_alpn_selected", nullptr, ssl_dup_AlpnSelected, &ssl_free_AlpnSelected);
 }
 
 bool

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -823,7 +823,7 @@ ssl_free_VerifyCallbackParameters(void *, void *ptr, CRYPTO_EX_DATA *,
 /// "free" function for the ssl_ex_index_ssl_alpn_selected entry
 static void
 ssl_free_AlpnSelected(void *, void *ptr, CRYPTO_EX_DATA *,
-        int, long, void *)
+                      int, long, void *)
 {
     auto alpn = static_cast<std::optional<SBuf> *>(ptr);
     delete alpn;
@@ -832,7 +832,7 @@ ssl_free_AlpnSelected(void *, void *ptr, CRYPTO_EX_DATA *,
 /// "dup" function for the ssl_ex_index_ssl_alpn_selected entry
 static int
 ssl_dup_AlpnSelected(CRYPTO_EX_DATA *, const CRYPTO_EX_DATA *, void **from_d,
-                    int , long, void *)
+                     int, long, void *)
 {
     if (*from_d == nullptr)
         return 1;

--- a/src/tests/stub_cache_cf.cc
+++ b/src/tests/stub_cache_cf.cc
@@ -37,6 +37,7 @@ void dump_acl_list(StoreEntry*, ACLList*) STUB
 void Configuration::SwitchToGeneratedInput(const SBuf &) STUB
 void Configuration::SwitchToExternalInput(const char *, bool) STUB
 void Configuration::SwitchTo(const Location &) STUB
+void dump_SBufList(std::ostream &, const SBufList &) STUB
 
 #include "configuration/Preprocessor.h"
 void Configuration::PreprocessedDirective::print(std::ostream &) const STUB


### PR DESCRIPTION
This initial implementation does not cover SslBump cases.

Also print the 'if' keyword in directive dumps before the list of ACLs.