### PR TITLE
Improved ParseAclWithAction() to be able to parse conditional ACLs

### DIFF
--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -606,14 +606,9 @@ ConfigParser::skipOptional(const char *keyword)
 ACLList *
 ConfigParser::optionalAclList()
 {
-    if (!skipOptional("if"))
-        return nullptr; // OK: the directive has no ACLs
-
     ACLList *acls = nullptr;
-    const auto aclCount = aclParseAclList(*this, &acls, cfg_directive);
+    (void)aclParseAclList(*this, &acls, cfg_directive, true);
     assert(acls);
-    if (aclCount <= 0)
-        throw TextException("missing ACL name(s) after 'if' keyword", Here());
     return acls;
 }
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -194,6 +194,35 @@ aclParseAclList(ConfigParser &, ACLList **config, const char *label)
     return aclCount;
 }
 
+void
+ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl)
+{
+    assert(treePointer);
+    auto &access = *treePointer;
+    if (!access) {
+        const auto tree = new Acl::Tree;
+        tree->context(ToSBuf('(', desc, " rules)"), config_input_line);
+        access = new acl_access(tree);
+    }
+    assert(access);
+
+    Acl::AndNode *rule = new Acl::AndNode;
+    rule->context(ToSBuf('(', desc, " rule)"), config_input_line);
+    if (acl)
+        rule->add(acl);
+    else
+        rule->lineParse();
+    (*access)->add(rule, action);
+}
+
+void
+ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc)
+{
+    if (!parser.skipOptional("if"))
+        return; // the directive has no ACLs
+    ParseAclWithAction(treePointer, action, desc);
+}
+
 /*********************/
 /* Destroy functions */
 /*********************/

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -169,7 +169,7 @@ aclParseAccessLine(const char *directive, ConfigParser &parser, acl_access **con
 
 // aclParseAclList does not expect or set actions (cf. aclParseAccessLine)
 size_t
-aclParseAclList(ConfigParser &, ACLList **config, const char *label)
+aclParseAclList(ConfigParser &, ACLList **config, const char *label, const bool mandatoryIf)
 {
     // accommodate callers unable to convert their ACL list context to string
     if (!label)
@@ -177,7 +177,7 @@ aclParseAclList(ConfigParser &, ACLList **config, const char *label)
 
     Acl::AndNode *rule = new Acl::AndNode;
     rule->context(ToSBuf('(', cfg_directive, ' ', label, " line)"), config_input_line);
-    const auto aclCount = rule->lineParse();
+    const auto aclCount = rule->lineParse(mandatoryIf);
 
     // XXX: We have created only one node, and our callers do not support
     // actions, but we now have to create an action-supporting Acl::Tree because

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -194,35 +194,6 @@ aclParseAclList(ConfigParser &, ACLList **config, const char *label)
     return aclCount;
 }
 
-void
-ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl)
-{
-    assert(treePointer);
-    auto &access = *treePointer;
-    if (!access) {
-        const auto tree = new Acl::Tree;
-        tree->context(ToSBuf('(', desc, " rules)"), config_input_line);
-        access = new acl_access(tree);
-    }
-    assert(access);
-
-    Acl::AndNode *rule = new Acl::AndNode;
-    rule->context(ToSBuf('(', desc, " rule)"), config_input_line);
-    if (acl)
-        rule->add(acl);
-    else
-        rule->lineParse();
-    (*access)->add(rule, action);
-}
-
-void
-ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc)
-{
-    if (!parser.skipOptional("if"))
-        return; // the directive has no ACLs
-    ParseAclWithAction(treePointer, action, desc);
-}
-
 /*********************/
 /* Destroy functions */
 /*********************/

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -44,11 +44,12 @@ aclParseAclList(ConfigParser &parser, ACLList ** const tree, const Any any)
     return aclParseAclList(parser, tree, buf.str().c_str());
 }
 
-/// parses an [!]<acl>... line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+/// parses an optional [ [!]<acl>... ] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+/// \deprecated use ParseOptionalAclWithAction() instead
 void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
 
-/// parses an optional [if [!]<acl>...] line as ParseAclWithAction()
-void ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc);
+/// parses an optional [ if [!]<acl>...] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+void ParseOptionalAclWithAction(ConfigParser &, acl_access **treePointer, const Acl::Answer &action, const char *desc);
 
 /// Whether the given name names an Acl::Node object with true isProxyAuth() result.
 /// This is a safe variation of Acl::Node::FindByName(*name)->isProxyAuth().

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -26,7 +26,7 @@ void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 
-/// Parses a single line of the "allow" or "deny" action followed by acls" directive (e.g., http_access).
+/// Parses a single line of a "action followed by acls" directive (e.g., http_access).
 void aclParseAccessLine(const char *directive, ConfigParser &, acl_access **);
 
 /// Parses a single line of a "some context followed by acls" directive (e.g., note n v).
@@ -43,13 +43,6 @@ aclParseAclList(ConfigParser &parser, ACLList ** const tree, const Any any)
     buf << any;
     return aclParseAclList(parser, tree, buf.str().c_str());
 }
-
-/// parses an optional [ [!]<acl>... ] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
-/// \deprecated use ParseOptionalAclWithAction() instead
-void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
-
-/// parses an optional [ if [!]<acl>...] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
-void ParseOptionalAclWithAction(ConfigParser &, acl_access **treePointer, const Acl::Answer &action, const char *desc);
 
 /// Whether the given name names an Acl::Node object with true isProxyAuth() result.
 /// This is a safe variation of Acl::Node::FindByName(*name)->isProxyAuth().

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -32,7 +32,7 @@ void aclParseAccessLine(const char *directive, ConfigParser &, acl_access **);
 /// Parses a single line of a "some context followed by acls" directive (e.g., note n v).
 /// The label parameter identifies the context (for debugging).
 /// \returns the number of parsed ACL names
-size_t aclParseAclList(ConfigParser &, ACLList **, const char *label);
+size_t aclParseAclList(ConfigParser &, ACLList **, const char *label, bool mandatoryIf = false);
 
 /// Template to convert various context labels to strings. \ingroup ACLAPI
 template <class Any>

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -26,7 +26,7 @@ void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 
-/// Parses a single line of a "action followed by acls" directive (e.g., http_access).
+/// Parses a single line of the "allow" or "deny" action followed by acls" directive (e.g., http_access).
 void aclParseAccessLine(const char *directive, ConfigParser &, acl_access **);
 
 /// Parses a single line of a "some context followed by acls" directive (e.g., note n v).
@@ -43,6 +43,12 @@ aclParseAclList(ConfigParser &parser, ACLList ** const tree, const Any any)
     buf << any;
     return aclParseAclList(parser, tree, buf.str().c_str());
 }
+
+/// parses an [!]<acl>... line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
+
+/// parses an optional [if [!]<acl>...] line as ParseAclWithAction()
+void ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc);
 
 /// Whether the given name names an Acl::Node object with true isProxyAuth() result.
 /// This is a safe variation of Acl::Node::FindByName(*name)->isProxyAuth().

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -41,11 +41,21 @@ Acl::InnerNode::add(Acl::Node *node)
 
 // kids use this method to handle [multiple] parse() calls correctly
 size_t
-Acl::InnerNode::lineParse()
+Acl::InnerNode::lineParse(bool mandatoryIf)
 {
     // XXX: not precise, may change when looping or parsing multiple lines
     if (!cfgline)
         cfgline = xstrdup(config_input_line);
+
+    auto ifKeyword = false;
+    if (const auto nextToken = ConfigParser::PeekAtToken()) {
+        if (strcmp(nextToken, "if") == 0) {
+            ifKeyword = true;
+            (void)ConfigParser::NextToken();
+        } else if (mandatoryIf) {
+             throw TextException("missing 'if' keyword", Here());
+        }
+    }
 
     // expect a list of ACL names, each possibly preceded by '!' for negation
 
@@ -74,6 +84,8 @@ Acl::InnerNode::lineParse()
         ++count;
     }
 
+    if (!count && ifKeyword)
+        throw TextException("missing ACL name(s) after 'if' keyword", Here());
     return count;
 }
 

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -53,7 +53,7 @@ Acl::InnerNode::lineParse(bool mandatoryIf)
             ifKeyword = true;
             (void)ConfigParser::NextToken();
         } else if (mandatoryIf) {
-             throw TextException("missing 'if' keyword", Here());
+            throw TextException("missing 'if' keyword", Here());
         }
     }
 

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -35,7 +35,7 @@ public:
 
     /// parses a [ [!]acl1 [!]acl2... ] sequence, appending to nodes
     /// \returns the number of parsed ACL names
-    size_t lineParse();
+    size_t lineParse(bool mandatoryIf = false);
 
     /// appends the node to the collection and takes control over it
     void add(Acl::Node *node);

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1709,6 +1709,35 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 
 #endif /* USE_AUTH */
 
+void
+ParseAclWithAction(acl_access **config, const Acl::Answer &action, const char *desc, Acl::Node *acl)
+{
+    assert(config);
+    auto &access = *config;
+    if (!access) {
+        const auto tree = new Acl::Tree;
+        tree->context(ToSBuf('(', desc, " rules)"), config_input_line);
+        access = new acl_access(tree);
+    }
+    assert(access);
+
+    Acl::AndNode *rule = new Acl::AndNode;
+    rule->context(ToSBuf('(', desc, " rule)"), config_input_line);
+    if (acl)
+        rule->add(acl);
+    else
+        rule->lineParse();
+    (*access)->add(rule, action);
+}
+
+void
+ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc)
+{
+    if (!parser.skipOptional("if"))
+        return; // the directive has no ACLs
+    ParseAclWithAction(treePointer, action, desc);
+}
+
 static void
 parse_cachedir(Store::DiskConfig *swap)
 {

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1710,10 +1710,11 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 #endif /* USE_AUTH */
 
 void
-ParseAclWithAction(acl_access **config, const Acl::Answer &action, const char *desc, Acl::Node *acl)
+ParseAclWithAction(acl_access **config, const Acl::Answer &action, const char *desc, const bool mandatoryIf, Acl::Node *acl)
 {
     assert(config);
     auto &access = *config;
+
     if (!access) {
         const auto tree = new Acl::Tree;
         tree->context(ToSBuf('(', desc, " rules)"), config_input_line);
@@ -1726,16 +1727,8 @@ ParseAclWithAction(acl_access **config, const Acl::Answer &action, const char *d
     if (acl)
         rule->add(acl);
     else
-        rule->lineParse();
+        rule->lineParse(mandatoryIf);
     (*access)->add(rule, action);
-}
-
-void
-ParseOptionalAclWithAction(ConfigParser &parser, acl_access **treePointer, const Acl::Answer &action, const char *desc)
-{
-    if (!parser.skipOptional("if"))
-        return; // the directive has no ACLs
-    ParseAclWithAction(treePointer, action, desc);
 }
 
 static void
@@ -4431,7 +4424,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
             static const auto all = new SBuf("all");
             if (const auto a = Acl::Node::FindByName(*all))
-                ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
+                ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", false, a);
             else {
                 self_destruct();
                 return;

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -242,7 +242,6 @@ static void free_UrlHelperTimeout(SquidConfig::UrlHelperTimeout *);
 static void parse_on_unsupported_protocol(acl_access **access);
 static void dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *access);
 static void free_on_unsupported_protocol(acl_access **access);
-static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
 static void parse_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
 static void dump_http_upgrade_request_protocols(StoreEntry *entry, const char *name, HttpUpgradeProtocolAccess *protoGuards);
 static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
@@ -1709,27 +1708,6 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 }
 
 #endif /* USE_AUTH */
-
-static void
-ParseAclWithAction(acl_access **config, const Acl::Answer &action, const char *desc, Acl::Node *acl)
-{
-    assert(config);
-    auto &access = *config;
-    if (!access) {
-        const auto tree = new Acl::Tree;
-        tree->context(ToSBuf('(', desc, " rules)"), config_input_line);
-        access = new acl_access(tree);
-    }
-    assert(access);
-
-    Acl::AndNode *rule = new Acl::AndNode;
-    rule->context(ToSBuf('(', desc, " rule)"), config_input_line);
-    if (acl)
-        rule->add(acl);
-    else
-        rule->lineParse();
-    (*access)->add(rule, action);
-}
 
 static void
 parse_cachedir(Store::DiskConfig *swap)

--- a/src/cache_cf.h
+++ b/src/cache_cf.h
@@ -11,6 +11,7 @@
 #ifndef SQUID_SRC_CACHE_CF_H
 #define SQUID_SRC_CACHE_CF_H
 
+#include "acl/forward.h"
 #include "configuration/forward.h"
 #include "sbuf/forward.h"
 
@@ -29,6 +30,12 @@ void requirePathnameExists(const char *name, const char *path);
 void parse_time_t(time_t * var);
 /// Parse bytes number from a string
 void parseBytesOptionValue(size_t * bptr, const char *units, char const * value);
+
+/// parses an optional [ [!]<acl>... ] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+/// \deprecated use ParseOptionalAclWithAction() instead
+void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
+
+/// parses an optional [ if [!]<acl>...] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
 
 namespace Configuration {
 

--- a/src/cache_cf.h
+++ b/src/cache_cf.h
@@ -31,11 +31,9 @@ void parse_time_t(time_t * var);
 /// Parse bytes number from a string
 void parseBytesOptionValue(size_t * bptr, const char *units, char const * value);
 
-/// parses an optional [ [!]<acl>... ] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
-/// \deprecated use ParseOptionalAclWithAction() instead
-void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
-
-/// parses an optional [ if [!]<acl>...] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+/// parses an optional [ [if] [!]<acl>... ] line (e.g., ssl-bump) assigning the action to the Acl::Tree object
+/// \param mandatoryIf whether the "if" keyword must be placed before the list of ACLs
+void ParseAclWithAction(acl_access **treePointer, const Acl::Answer &action, const char *desc, bool mandatoryIf = false, Acl::Node *acl = nullptr);
 
 namespace Configuration {
 


### PR DESCRIPTION
ParseAclWithAction() parses ACLs for a directive and silently succeedes
if there are no ACLs specified. The function is used to parse directives
such as ssl_bump that do not document their ACLs as optional. An admin
who is unaware of this hidden peculiarity may be forced to write stub
ACLs in situations when the default behavior (allowed all) is just what
they need.  The `[ if ... ]` condition makes the configuration clear,
preventing these implicit assumptions.

The [ if ... ] condition is already analyzed in
ConfigParser::optionalAclList() API. Now we allow the 'if' keyword
in each ACL-driven directive. Depending on the directive, it can
be either optional or mandatory. Note that adding the optional
'if' keyword to an existing directive does not affect the directive
dumping: the output will be the same as without 'if'.

