### PR TITLE
Remove extra whitespaces in configuration dumps

### DIFF
--- a/src/ClientDelayConfig.cc
+++ b/src/ClientDelayConfig.cc
@@ -25,7 +25,7 @@ void ClientDelayPool::dump(StoreEntry * entry, unsigned int poolNumberMinusOne) 
     LOCAL_ARRAY(char, nom, 32);
     snprintf(nom, 32, "client_delay_access %d", poolNumberMinusOne + 1);
     dump_acl_access(entry, nom, access);
-    storeAppendPrintf(entry, "client_delay_parameters %d %d %" PRId64 "\n", poolNumberMinusOne + 1, rate,highwatermark);
+    storeAppendPrintf(entry, "client_delay_parameters %d %d %" PRId64, poolNumberMinusOne + 1, rate, highwatermark);
     storeAppendPrintf(entry, "\n");
 }
 

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -79,8 +79,10 @@ Tree::treeDump(const SBuf &prefix, const ActionToStringConverter converter) cons
         }
 
         text.splice(text.end(), (*node)->dump());
-        if (node != lastNode)
-            text.push_back(SBuf("\n"));
+        if (node != lastNode) {
+            static const SBuf LF("\n");
+            text.push_back(LF);
+        }
     }
     return text;
 }

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -66,6 +66,7 @@ Tree::treeDump(const SBuf &prefix, const ActionToStringConverter converter) cons
     SBufList text;
     Actions::const_iterator action = actions.begin();
     typedef Nodes::const_iterator NCI;
+    const NCI lastNode = nodes.empty() ? nodes.end() : std::prev(nodes.end());
     for (NCI node = nodes.begin(); node != nodes.end(); ++node) {
 
         text.push_back(prefix);
@@ -78,7 +79,8 @@ Tree::treeDump(const SBuf &prefix, const ActionToStringConverter converter) cons
         }
 
         text.splice(text.end(), (*node)->dump());
-        text.push_back(SBuf("\n"));
+        if (node != lastNode)
+            text.push_back(SBuf("\n"));
     }
     return text;
 }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1157,7 +1157,7 @@ parse_SBufList(SBufList * list)
         list->push_back(SBuf(token));
 }
 
-// just dump a list, no directive name
+// just dump a list, no directive name (no terminating '\n')
 static void
 dump_SBufList(StoreEntry * entry, const SBufList &words)
 {
@@ -1173,7 +1173,6 @@ dump_SBufList(StoreEntry * entry, const SBufList &words)
             sawToken = true;
         }
     }
-    entry->append("\n",1);
 }
 
 // dump a SBufList type directive with name
@@ -1184,6 +1183,7 @@ dump_SBufList(StoreEntry * entry, const char *name, SBufList &list)
         entry->append(name, strlen(name));
         entry->append(" ", 1);
         dump_SBufList(entry, list);
+        entry->append("\n",1);
     }
 }
 
@@ -1225,8 +1225,10 @@ dump_acl_list(StoreEntry * entry, ACLList * head)
 void
 dump_acl_access(StoreEntry * entry, const char *name, acl_access * head)
 {
-    if (head)
+    if (head) {
         dump_SBufList(entry, ToTree(head).treeDump(name, &Acl::AllowOrDeny));
+        storeAppendPrintf(entry, "\n");
+    }
 }
 
 static void
@@ -1290,6 +1292,8 @@ dump_acl_address(StoreEntry * entry, const char *name, Acl::Address * head)
             storeAppendPrintf(entry, "%s autoselect", name);
 
         dump_acl_list(entry, l->aclList);
+
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -1326,6 +1330,8 @@ dump_acl_tos(StoreEntry * entry, const char *name, acl_tos * head)
             storeAppendPrintf(entry, "%s none", name);
 
         dump_acl_list(entry, l->aclList);
+
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -1380,6 +1386,8 @@ dump_acl_nfmark(StoreEntry * entry, const char *name, acl_nfmark * head)
         storeAppendPrintf(entry, "%s %s", name, ToSBuf(l->markConfig).c_str());
 
         dump_acl_list(entry, l->aclList);
+
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -1424,6 +1432,8 @@ dump_acl_b_size_t(StoreEntry * entry, const char *name, AclSizeLimit * head)
             storeAppendPrintf(entry, "%s none", name);
 
         dump_acl_list(entry, l->aclList);
+
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -1702,10 +1712,12 @@ free_AuthSchemes(acl_access **authSchemes)
 static void
 dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 {
-    if (authSchemes)
+    if (authSchemes) {
         dump_SBufList(entry, ToTree(authSchemes).treeDump(name, [](const Acl::Answer &action) {
         return Auth::TheConfig.schemeLists.at(action.kind).rawSchemes;
     }));
+        storeAppendPrintf(entry, "\n");
+    }
 }
 
 #endif /* USE_AUTH */
@@ -3757,8 +3769,7 @@ dump_access_log(StoreEntry * entry, const char *name, CustomLog * logs)
 
         if (log->aclList)
             dump_acl_list(entry, log->aclList);
-        else
-            storeAppendPrintf(entry, "\n");
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4029,8 +4040,7 @@ static void dump_sslproxy_cert_adapt(StoreEntry *entry, const char *name, sslpro
         storeAppendPrintf(entry, "%s{%s} ", Ssl::sslCertAdaptAlgoritm(ca->alg), ca->param);
         if (ca->aclList)
             dump_acl_list(entry, ca->aclList);
-        else
-            storeAppendPrintf(entry, "\n");
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4076,8 +4086,7 @@ static void dump_sslproxy_cert_sign(StoreEntry *entry, const char *name, sslprox
         storeAppendPrintf(entry, "%s ", Ssl::certSignAlgorithm(cs->alg));
         if (cs->aclList)
             dump_acl_list(entry, cs->aclList);
-        else
-            storeAppendPrintf(entry, "\n");
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4204,10 +4213,12 @@ static void parse_sslproxy_ssl_bump(acl_access **ssl_bump)
 
 static void dump_sslproxy_ssl_bump(StoreEntry *entry, const char *name, acl_access *ssl_bump)
 {
-    if (ssl_bump)
+    if (ssl_bump) {
         dump_SBufList(entry, ToTree(ssl_bump).treeDump(name, [](const Acl::Answer &action) {
         return Ssl::BumpModeStr.at(action.kind);
     }));
+        storeAppendPrintf(entry, "\n");
+    }
 }
 
 static void free_sslproxy_ssl_bump(acl_access **ssl_bump)
@@ -4226,8 +4237,7 @@ static void dump_HeaderWithAclList(StoreEntry * entry, const char *name, HeaderW
         storeAppendPrintf(entry, "%s %s %s", name, hwa->fieldName.c_str(), hwa->fieldValue.c_str());
         if (hwa->aclList)
             dump_acl_list(entry, hwa->aclList);
-        else
-            storeAppendPrintf(entry, "\n");
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4449,8 +4459,10 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
 
 static void dump_ftp_epsv(StoreEntry *entry, const char *name, acl_access *ftp_epsv)
 {
-    if (ftp_epsv)
+    if (ftp_epsv) {
         dump_SBufList(entry, ToTree(ftp_epsv).treeDump(name, Acl::AllowOrDeny));
+        storeAppendPrintf(entry, "\n");
+    }
 }
 
 static void free_ftp_epsv(acl_access **ftp_epsv)
@@ -4595,6 +4607,7 @@ dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *ac
             return onErrorTunnelMode.at(action.kind);
         });
         dump_SBufList(entry, lines);
+        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4628,6 +4641,7 @@ dump_http_upgrade_request_protocols(StoreEntry *entry, const char *rawName, Http
         const auto acld = ToTree(acls).treeDump("", &Acl::AllowOrDeny);
         line.insert(line.end(), acld.begin(), acld.end());
         dump_SBufList(entry, line);
+        storeAppendPrintf(entry, "\n");
     });
 }
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3770,6 +3770,7 @@ dump_access_log(StoreEntry * entry, const char *name, CustomLog * logs)
 
         if (log->aclList)
             dump_acl_list(entry, log->aclList);
+
         storeAppendPrintf(entry, "\n");
     }
 }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1163,6 +1163,7 @@ dump_SBufList(StoreEntry * entry, const SBufList &words)
 {
     bool sawToken = false;
     for (const auto &i : words) {
+        // avoid extra spaces before and after '\n'
         if (i.cmp("\n") == 0) {
             sawToken = false;
             entry->append("\n",1);
@@ -2654,17 +2655,17 @@ parse_TokenOrQuotedString(char **var)
 #define free_TokenOrQuotedString free_string
 
 static void
-dump_time_unit(StoreEntry * entry, const char *name, time_t var)
+dump_time_unit(std::ostream &os, time_t var)
 {
-    PackableStream os(*entry);
-    os << name << ' ' << var << " seconds";
+    os << ' ' << var << " seconds";
 }
 
 static void
 dump_time_t(StoreEntry * entry, const char *name, time_t var)
 {
-    dump_time_unit(entry, name, var);
     PackableStream os(*entry);
+    os << name;
+    dump_time_unit(os, var);
     os << "\n";
 }
 
@@ -3966,8 +3967,10 @@ static void parse_icap_service_failure_limit(Adaptation::Icap::Config *cfg)
 static void dump_icap_service_failure_limit(StoreEntry *entry, const char *name, const Adaptation::Icap::Config &cfg)
 {
     storeAppendPrintf(entry, "%s %d", name, cfg.service_failure_limit);
-    if (cfg.oldest_service_failure > 0) {
-        storeAppendPrintf(entry, " in %d seconds", (int)cfg.oldest_service_failure);
+    if (cfg.oldest_service_failure >= 0) {
+        PackableStream os(*entry);
+        os << " in";
+        dump_time_unit(os, static_cast<int>(cfg.oldest_service_failure));
     }
     storeAppendPrintf(entry, "\n");
 }
@@ -4553,13 +4556,14 @@ dump_UrlHelperTimeout(StoreEntry *entry, const char *name, SquidConfig::UrlHelpe
     const char  *onTimedOutActions[] = {"bypass", "fail", "retry", "use_configured_response"};
     assert(config.action >= 0 && config.action <= toutActUseConfiguredResponse);
 
-    dump_time_unit(entry, name, Config.Timeout.urlRewrite);
-    storeAppendPrintf(entry, " on_timeout=%s", onTimedOutActions[config.action]);
+    PackableStream os(*entry);
+    os << name;
+    dump_time_unit(os, static_cast<int>(Config.Timeout.urlRewrite));
+    os << " on_timeout=" << onTimedOutActions[config.action];
 
     if (config.response)
-        storeAppendPrintf(entry, " response=\"%s\"", config.response);
-
-    storeAppendPrintf(entry, "\n");
+        os << " response=\"" << config.response << '"';
+    os << "\n";
 }
 
 static void

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1715,8 +1715,8 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 {
     if (authSchemes) {
         dump_SBufList(entry, ToTree(authSchemes).treeDump(name, [](const Acl::Answer &action) {
-        return Auth::TheConfig.schemeLists.at(action.kind).rawSchemes;
-    }));
+            return Auth::TheConfig.schemeLists.at(action.kind).rawSchemes;
+        }));
         storeAppendPrintf(entry, "\n");
     }
 }
@@ -4219,8 +4219,8 @@ static void dump_sslproxy_ssl_bump(StoreEntry *entry, const char *name, acl_acce
 {
     if (ssl_bump) {
         dump_SBufList(entry, ToTree(ssl_bump).treeDump(name, [](const Acl::Answer &action) {
-        return Ssl::BumpModeStr.at(action.kind);
-    }));
+            return Ssl::BumpModeStr.at(action.kind);
+        }));
         storeAppendPrintf(entry, "\n");
     }
 }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1157,13 +1157,27 @@ parse_SBufList(SBufList * list)
         list->push_back(SBuf(token));
 }
 
+static bool
+IsDelimiter(const SBuf &token)
+{
+    return token.cmp("\n") == 0 || token.cmp(" ") == 0;
+}
+
 // just dump a list, no directive name
 static void
 dump_SBufList(StoreEntry * entry, const SBufList &words)
 {
-    for (const auto &i : words) {
-        entry->append(i.rawContent(), i.length());
-        entry->append(" ",1);
+    // assume that the list does not have leading delimiters
+    // exclude all trailing delimiters
+    const auto endToken = std::find_if(words.rbegin(), words.rend(), [] (const SBuf &token) {
+        return !IsDelimiter(token);
+    }).base();
+
+    for (auto i = words.begin(); i != endToken; ++i) {
+        // do not add space before and after existing delimiters
+        if (i != words.begin() && !IsDelimiter(*i) && !IsDelimiter(*std::prev(i)))
+            entry->append(" ",1);
+        entry->append(i->rawContent(), i->length());
     }
     entry->append("\n",1);
 }
@@ -1282,8 +1296,6 @@ dump_acl_address(StoreEntry * entry, const char *name, Acl::Address * head)
             storeAppendPrintf(entry, "%s autoselect", name);
 
         dump_acl_list(entry, l->aclList);
-
-        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -1320,8 +1332,6 @@ dump_acl_tos(StoreEntry * entry, const char *name, acl_tos * head)
             storeAppendPrintf(entry, "%s none", name);
 
         dump_acl_list(entry, l->aclList);
-
-        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -1376,8 +1386,6 @@ dump_acl_nfmark(StoreEntry * entry, const char *name, acl_nfmark * head)
         storeAppendPrintf(entry, "%s %s", name, ToSBuf(l->markConfig).c_str());
 
         dump_acl_list(entry, l->aclList);
-
-        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -1422,8 +1430,6 @@ dump_acl_b_size_t(StoreEntry * entry, const char *name, AclSizeLimit * head)
             storeAppendPrintf(entry, "%s none", name);
 
         dump_acl_list(entry, l->aclList);
-
-        storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -2642,10 +2648,18 @@ parse_TokenOrQuotedString(char **var)
 #define free_TokenOrQuotedString free_string
 
 static void
-dump_time_t(StoreEntry * entry, const char *name, time_t var)
+dump_time_unit(StoreEntry * entry, const char *name, time_t var)
 {
     PackableStream os(*entry);
-    os << name << ' ' << var << " seconds\n";
+    os << name << ' ' << var << " seconds";
+}
+
+static void
+dump_time_t(StoreEntry * entry, const char *name, time_t var)
+{
+    dump_time_unit(entry, name, var);
+    PackableStream os(*entry);
+    os << "\n";
 }
 
 void
@@ -3749,8 +3763,8 @@ dump_access_log(StoreEntry * entry, const char *name, CustomLog * logs)
 
         if (log->aclList)
             dump_acl_list(entry, log->aclList);
-
-        storeAppendPrintf(entry, "\n");
+        else
+            storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4021,7 +4035,8 @@ static void dump_sslproxy_cert_adapt(StoreEntry *entry, const char *name, sslpro
         storeAppendPrintf(entry, "%s{%s} ", Ssl::sslCertAdaptAlgoritm(ca->alg), ca->param);
         if (ca->aclList)
             dump_acl_list(entry, ca->aclList);
-        storeAppendPrintf(entry, "\n");
+        else
+            storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4067,7 +4082,8 @@ static void dump_sslproxy_cert_sign(StoreEntry *entry, const char *name, sslprox
         storeAppendPrintf(entry, "%s ", Ssl::certSignAlgorithm(cs->alg));
         if (cs->aclList)
             dump_acl_list(entry, cs->aclList);
-        storeAppendPrintf(entry, "\n");
+        else
+            storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4216,7 +4232,8 @@ static void dump_HeaderWithAclList(StoreEntry * entry, const char *name, HeaderW
         storeAppendPrintf(entry, "%s %s %s", name, hwa->fieldName.c_str(), hwa->fieldValue.c_str());
         if (hwa->aclList)
             dump_acl_list(entry, hwa->aclList);
-        storeAppendPrintf(entry, "\n");
+        else
+            storeAppendPrintf(entry, "\n");
     }
 }
 
@@ -4530,7 +4547,7 @@ dump_UrlHelperTimeout(StoreEntry *entry, const char *name, SquidConfig::UrlHelpe
     const char  *onTimedOutActions[] = {"bypass", "fail", "retry", "use_configured_response"};
     assert(config.action >= 0 && config.action <= toutActUseConfiguredResponse);
 
-    dump_time_t(entry, name, Config.Timeout.urlRewrite);
+    dump_time_unit(entry, name, Config.Timeout.urlRewrite);
     storeAppendPrintf(entry, " on_timeout=%s", onTimedOutActions[config.action]);
 
     if (config.response)

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2657,6 +2657,7 @@ parse_TokenOrQuotedString(char **var)
 static void
 dump_time_unit(std::ostream &os, time_t var)
 {
+    // canonical output in seconds
     os << ' ' << var << " seconds";
 }
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1157,27 +1157,21 @@ parse_SBufList(SBufList * list)
         list->push_back(SBuf(token));
 }
 
-static bool
-IsDelimiter(const SBuf &token)
-{
-    return token.cmp("\n") == 0 || token.cmp(" ") == 0;
-}
-
 // just dump a list, no directive name
 static void
 dump_SBufList(StoreEntry * entry, const SBufList &words)
 {
-    // assume that the list does not have leading delimiters
-    // exclude all trailing delimiters
-    const auto endToken = std::find_if(words.rbegin(), words.rend(), [] (const SBuf &token) {
-        return !IsDelimiter(token);
-    }).base();
-
-    for (auto i = words.begin(); i != endToken; ++i) {
-        // do not add space before and after existing delimiters
-        if (i != words.begin() && !IsDelimiter(*i) && !IsDelimiter(*std::prev(i)))
-            entry->append(" ",1);
-        entry->append(i->rawContent(), i->length());
+    bool sawToken = false;
+    for (const auto &i : words) {
+        if (i.cmp("\n") == 0) {
+            sawToken = false;
+            entry->append("\n",1);
+        } else {
+            if (sawToken)
+                entry->append(" ",1);
+            entry->append(i.rawContent(), i.length());
+            sawToken = true;
+        }
     }
     entry->append("\n",1);
 }

--- a/src/helper/ChildConfig.h
+++ b/src/helper/ChildConfig.h
@@ -113,7 +113,7 @@ public:
 
 /* Legacy parser interface */
 #define parse_HelperChildConfig(c)     (c)->parseConfig()
-#define dump_HelperChildConfig(e,n,c)  storeAppendPrintf((e), "\n%s %d startup=%d idle=%d concurrency=%d\n", (n), (c).n_max, (c).n_startup, (c).n_idle, (c).concurrency)
+#define dump_HelperChildConfig(e,n,c)  storeAppendPrintf((e), "%s %d startup=%d idle=%d concurrency=%d\n", (n), (c).n_max, (c).n_startup, (c).n_idle, (c).concurrency)
 #define free_HelperChildConfig(dummy)  // NO.
 
 #endif /* SQUID_SRC_HELPER_CHILDCONFIG_H */

--- a/src/security/KeyLog.cc
+++ b/src/security/KeyLog.cc
@@ -75,8 +75,7 @@ Security::KeyLog::dump(std::ostream &os) const
         // TODO: Use Acl::dump() after fixing the XXX in dump_acl_list().
         for (const auto &acl: ToTree(aclList).treeDump("if", &Acl::AllowOrDeny))
             os << ' ' << acl;
-    } else
-        os << '\n';
+    }
 }
 
 void
@@ -123,5 +122,6 @@ Configuration::Component<Security::KeyLog*>::Print(std::ostream &os, Security::K
     os << directiveName << ' ';
     assert(keyLog);
     keyLog->dump(os);
+    os << '\n';
 }
 

--- a/src/security/KeyLog.cc
+++ b/src/security/KeyLog.cc
@@ -75,7 +75,8 @@ Security::KeyLog::dump(std::ostream &os) const
         // TODO: Use Acl::dump() after fixing the XXX in dump_acl_list().
         for (const auto &acl: ToTree(aclList).treeDump("if", &Acl::AllowOrDeny))
             os << ' ' << acl;
-    }
+    } else
+        os << '\n';
 }
 
 void
@@ -122,6 +123,5 @@ Configuration::Component<Security::KeyLog*>::Print(std::ostream &os, Security::K
     os << directiveName << ' ';
     assert(keyLog);
     keyLog->dump(os);
-    os << '\n';
 }
 


### PR DESCRIPTION
Many directives' dump_* methods that used dump_SBufList()
produced extra space at line beginnings/endings and
an extra empty line. This happened because Tree::treeDump()
generated a list of tokens, including LF line separators, that
dump_SBufList() was unaware of when adding its own (space) separators.
Also Tree::treeDump() placed LF at the end of the list of tokens,
disregarding the need of some higher level callers to continue
adding tokens to the same line. To avoid this confusion, the final LF
addition was moved from low-level Tree::treeDump() and the two-argument
dump_SBufList() to their callers, that dump entire directives.

Also fixed 'url_rewrite_timeout' directive output, that
placed the 'on_timeout' argument separately on the next line.

Also fixed dump_HelperChildConfig() to not add an extra leading LF.
This affected several directives, such as url_rewrite_children, which
do not use dump_SBufList().

Also fixed client_delay_parameters directive to not add extra LF.